### PR TITLE
DRAFT: Ability to override artifactory address for downloading dependent tools

### DIFF
--- a/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
+++ b/src/main/java/com/synopsys/integration/detect/workflow/ArtifactoryConstants.java
@@ -1,7 +1,7 @@
 package com.synopsys.integration.detect.workflow;
 
 public class ArtifactoryConstants {
-    public static final String ARTIFACTORY_URL = "https://sig-repo.synopsys.com/";
+    public static final String ARTIFACTORY_URL = Objects.requireNonNullElse(System.getenv("ARTIFACTORY_URL"), "https://sig-repo.synopsys.com/");
     public static final String VERSION_PLACEHOLDER = "<VERSION>";
 
     public static final String GRADLE_INSPECTOR_MAVEN_REPO = ARTIFACTORY_URL + "bds-integration-public-cache/";


### PR DESCRIPTION
# Description

This change allows us to override the default Artifactory location to a mirror/proxy address through the `ARTIFACTORY_URL` environment variable. If the variable is not set, then sig-repo will be used as the default address.

# Issues

IDETECT-3902