### PR TITLE
Add step to skip tracing `extraneous` packages

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -169,6 +169,7 @@ public class NpmDependencyConverter {
                 // These packages are not part of the dependency tree and are unnecessary for graph construction.
                 // It's recommended to run `npm prune` to remove them: https://docs.npmjs.com/cli/v7/commands/npm-prune
                 if (parentPackage == null && packageLock.packages.get(packageName) != null && packageLock.packages.get(packageName).extraneous) {
+                    packagesToRemove.add(packageName);
                     continue;
                 }
                 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -161,6 +161,16 @@ public class NpmDependencyConverter {
                 // The parent will be the portion of the package name up to and not including the final *.
                 PackageLockPackage parentPackage = 
                         packageLock.packages.get(packageName.substring(0, packageName.lastIndexOf("*")));
+
+                // `parentPackage` should never be null, in case it's extraneous packages, we'll just skip it.
+                // `Extraneous` packages are those present in the node_modules folder that are not listed as any package's dependency list.
+                // At this point, the `parentPackage` might is not present in the packages object, so we can't link it to the child.
+                // Resulting in the `parentPackage` == null.
+                // These packages are not part of the dependency tree and are not needed for the graph construction.
+                // Can suggest running npm prune to remove them. https://docs.npmjs.com/cli/v7/commands/npm-prune
+                if (parentPackage == null && packageLock.packages.get(packageName) != null && packageLock.packages.get(packageName).extraneous) {
+                    continue;
+                }
                 
                 if (parentPackage.packages == null) {
                     parentPackage.packages = new HashMap<String, PackageLockPackage>();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -162,12 +162,12 @@ public class NpmDependencyConverter {
                 PackageLockPackage parentPackage = 
                         packageLock.packages.get(packageName.substring(0, packageName.lastIndexOf("*")));
 
-                // `parentPackage` should never be null, in case it's extraneous packages, we'll just skip it.
-                // `Extraneous` packages are those present in the node_modules folder that are not listed as any package's dependency list.
-                // At this point, the `parentPackage` might is not present in the packages object, so we can't link it to the child.
-                // Resulting in the `parentPackage` == null.
-                // These packages are not part of the dependency tree and are not needed for the graph construction.
-                // Can suggest running npm prune to remove them. https://docs.npmjs.com/cli/v7/commands/npm-prune
+                // `parentPackage` can be null if the package is marked as `extraneous`, so we'll skip it.
+                // `Extraneous` packages are those present in the node_modules folder but not listed as dependencies in any package's dependency list.
+                // In this case, the `parentPackage` may not be present in the packages object, so we can't link it to the child, 
+                // resulting in `parentPackage == null`.
+                // These packages are not part of the dependency tree and are unnecessary for graph construction.
+                // It's recommended to run `npm prune` to remove them: https://docs.npmjs.com/cli/v7/commands/npm-prune
                 if (parentPackage == null && packageLock.packages.get(packageName) != null && packageLock.packages.get(packageName).extraneous) {
                     continue;
                 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
@@ -35,4 +35,6 @@ public class PackageLockPackage {
     public Boolean dev;
 
     public Boolean peer;
+
+    public Boolean extraneous;
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
@@ -44,6 +44,18 @@ public class NpmDependencyConverterTest {
         String lockFileText = FunctionalTestFiles.asString("/npm/packages-linkage-test/package-lock-wildcards-and-relative.json");
         validatePackageLinkage(lockFileText);
     }
+
+    @Test
+    public void testLinkPackagesDependenciesExtraneousDependencies() {
+        String lockFileText = FunctionalTestFiles.asString("/npm/packages-linkage-test/package-lock-extraneous.json");
+        lockFileText = packager.removePathInfoFromPackageName(lockFileText);
+        PackageLock packageLock = gson.fromJson(lockFileText, PackageLock.class);
+        converter.linkPackagesDependencies(packageLock);
+        
+        PackageLockPackage extraneousPackage = packageLock.packages.get("extraneouspackage");
+        
+        Assertions.assertNull(extraneousPackage);;
+    }
     
     @Test
     public void testAllDependenciesAddedToDependencies() {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
@@ -52,9 +52,11 @@ public class NpmDependencyConverterTest {
         PackageLock packageLock = gson.fromJson(lockFileText, PackageLock.class);
         converter.linkPackagesDependencies(packageLock);
         
-        PackageLockPackage extraneousPackage = packageLock.packages.get("extraneouspackage");
         
-        Assertions.assertNull(extraneousPackage);;
+        Assertions.assertNull(packageLock.packages.get("testpackage"));;
+        Assertions.assertNull(packageLock.packages.get("extraneouspackage"));;
+        Assertions.assertNull(packageLock.packages.get("testpackage*extraneouspackage"));
+        Assertions.assertNull(packageLock.packages.get("node_modules/testpackage/node_modules/extraneouspackage"));
     }
     
     @Test

--- a/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-extraneous.json
+++ b/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-extraneous.json
@@ -1,0 +1,14 @@
+{
+    "name": "npmworkspace",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+      "node_modules/testpackage/node_modules/extraneouspackage": {
+        "name": "extraneouspackage",
+        "version": "1.0.0",
+        "license": "ISC",
+        "extraneous": true
+      }
+    }
+  }


### PR DESCRIPTION
# Description
Issue:
```
NPM Package Lock: ATTEMPTED
NullPointerException: Cannot read field `packages` because `parentPackages` is null
```

This PR introduces a step to skip tracing extraneous packages during dependency graph construction.


In `package-lock.json`, have a`packageName` as follows:

```
"node_modules/parentpackage/node_modules/child": {
   "extraneous": true,
   .....
}
```
However,`parentpackage` does not exist in the packages object.

`Extraneous` packages are those that reside in the `node_modules` folder but are not listed as dependencies in any package's dependency list. 
As a result, their `parentPackage` may not exist in the packages object, preventing linkage to the child package and causing `parentPackage == null`.

(E.g. `extraneous` package in `package-lock.json` [link](https://github.com/marcelocarmona/tailwindcss/blob/bac5ecf0040aa9a788d1b22d706506146ee831ff/package-lock.stable.json#L81))

By skipping these extraneous packages, we avoid unnecessary processing of non-essential packages, ensuring a more accurate and efficient dependency graph.

Additionally, users are encouraged to clean up their environment by running npm prune to remove such packages. For more details, refer to the [npm prune documentation](https://docs.npmjs.com/cli/v7/commands/npm-prune).

**adding test `testLinkPackagesDependenciesExtraneousDependencies`**
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/7c621f26-e374-4f8c-a381-78785ca17759">


# Github Issues

IDETECT-4548