### PR TITLE
Deprecate detect.project.codelocation.unmap property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.1.0-SIGQA2-SNAPSHOT'
+version = '10.1.0-SIGQA2-andrian.IDETECT-3873'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.1.0-SIGQA2-andrian.IDETECT-3873'
+version = '10.1.0-SIGQA3-andrian.IDETECT-3873'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.1.0-SIGQA3-andrian.IDETECT-3873'
+version = '10.1.0-SIGQA4-andrian.IDETECT-3873'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -9,6 +9,7 @@
 ### Changed features
 
 * npm version 1 package-lock.json and npm-shrinkwrap.json file parsing has been restored.
+* The `detect.project.codelocation.unmap` property has been deprecated.
 
 ### Resolved issues
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1404,14 +1404,6 @@ public class DetectProperties {
             .setCategory(DetectCategory.Advanced)
             .build();
 
-    public static final BooleanProperty DETECT_PROJECT_CODELOCATION_UNMAP =
-        BooleanProperty.newBuilder("detect.project.codelocation.unmap", false)
-            .setInfo("Unmap All Other Scans for Project", DetectPropertyFromVersion.VERSION_4_0_0)
-            .setHelp("If set to true, unmaps all other scans mapped to the project version produced by the current run of Detect.")
-            .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
-            .setCategory(DetectCategory.Advanced)
-            .build();
-
     public static final NullableStringProperty DETECT_PROJECT_DESCRIPTION =
         NullableStringProperty.newBuilder("detect.project.description")
             .setInfo("Project Description", DetectPropertyFromVersion.VERSION_4_0_0)
@@ -1854,6 +1846,18 @@ public class DetectProperties {
     //#endregion Active Properties
 
     //#region Deprecated Properties
+
+    public static final BooleanProperty DETECT_PROJECT_CODELOCATION_UNMAP =
+        BooleanProperty.newBuilder("detect.project.codelocation.unmap", false)
+            .setInfo("Unmap All Other Scans for Project", DetectPropertyFromVersion.VERSION_4_0_0)
+            .setHelp("If set to true, unmaps all other scans mapped to the project version produced by the current run of Detect.")
+            .setGroups(DetectGroup.PROJECT, DetectGroup.PROJECT_SETTING)
+            .setCategory(DetectCategory.Advanced)
+            .setDeprecated(
+                "This property has been deprecated.",
+                DetectMajorVersion.ELEVEN
+            )
+            .build();
 
     // Can't take in the DetectProperty<?> due to an illegal forward reference :(
     private static String createTypeFilterHelpText(String exclusionTypePlural) {

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/DetectMajorVersion.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/DetectMajorVersion.java
@@ -13,6 +13,7 @@ public class DetectMajorVersion extends ProductMajorVersion {
     public static final DetectMajorVersion EIGHT = new DetectMajorVersion(8);
     public static final DetectMajorVersion NINE = new DetectMajorVersion(9);
     public static final DetectMajorVersion TEN = new DetectMajorVersion(10);
+    public static final DetectMajorVersion ELEVEN = new DetectMajorVersion(11);
 
     public DetectMajorVersion(Integer intValue) {
         super(intValue);


### PR DESCRIPTION
# Description

Deprecate detect.project.codelocation.unmap property.

With this change, when the property is used, the following is displayed in the log:

```
2024-11-07 16:08:02 MST INFO  [main] --- DEPRECATIONS:
2024-11-07 16:08:02 MST INFO  [main] ---        detect.project.codelocation.unmap
2024-11-07 16:08:02 MST INFO  [main] ---                This property has been deprecated. This property will be removed in 11.0.0.
```
