### PR TITLE
Add try-catch to fall back to sig-repo URL for air-gap creation for 9.10.z

### DIFF
--- a/src/main/resources/create-gradle-airgap-script.ftl
+++ b/src/main/resources/create-gradle-airgap-script.ftl
@@ -1,9 +1,14 @@
+String repoUrl = "https://repo.blackduck.com/bds-integration-public-cache/"
+
+try {
+    new URL(repoUrl).text
+} catch (Exception e) {
+    repoUrl = "https://sig-repo.synopsys.com/bds-integration-public-cache/"
+}
+
 repositories {
     maven {
-        url 'https://repo.blackduck.com/bds-integration-public-cache/'
-    }
-    maven {
-        url 'https://sig-repo.synopsys.com/bds-integration-public-cache/'
+        url repoUrl
     }
 }
 


### PR DESCRIPTION
Added an explicity try-catch block in the Gradle air gap script creation logic in Groovy to fall back to sig-repo if repo.blackduck.com is unreachable.