### PR TITLE
Update component names to fix integration tests

### DIFF
--- a/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -114,7 +114,7 @@ public class GradleNativeInspectorTests {
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4j", "2.22.1");
             blackduckAssertions.checkComponentVersionExists("graphql-java", "18.2");
             blackduckAssertions.checkComponentVersionNotExists("SLF4J API Module", "2.0.4");
-            blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0");
+            blackduckAssertions.checkComponentVersionExists("google-guava", "v29.0");
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4J API", "2.22.1");
 
         }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -114,11 +114,7 @@ public class GradleNativeInspectorTests {
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4j", "2.22.1");
             blackduckAssertions.checkComponentVersionExists("graphql-java", "18.2");
             blackduckAssertions.checkComponentVersionNotExists("SLF4J API Module", "2.0.4");
-            try {
-                blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0"); // see it in the UI ??
-            } catch (Throwable t) {
-                dockerAssertions.logContains("definitely not");
-            }
+            blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0");
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4J API", "2.22.1");
 
         }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -114,7 +114,11 @@ public class GradleNativeInspectorTests {
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4j", "2.22.1");
             blackduckAssertions.checkComponentVersionExists("graphql-java", "18.2");
             blackduckAssertions.checkComponentVersionNotExists("SLF4J API Module", "2.0.4");
-            blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0");
+            try {
+                blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0"); // see it in the UI ??
+            } catch (Throwable t) {
+                dockerAssertions.logContains("definitely not");
+            }
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4J API", "2.22.1");
 
         }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -43,8 +43,8 @@ public class MavenShadedDependenciesTest {
             dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
 
-            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
-            blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
+//            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+            blackduckAssertions.hasComponents("JCTTools");
             blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
         }
     }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -40,11 +40,11 @@ public class MavenShadedDependenciesTest {
             commandBuilder.property(DetectProperties.DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES, String.valueOf(true));
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.logContains("Maven CLI: SUCCESS");
+            dockerAssertions.logContains("definitely not");
             dockerAssertions.atLeastOneBdioFile();
 
             try {
-                blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+                blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser"); // fails here, does not have this component
                 blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
                 blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
             } catch (Throwable t) {

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -40,16 +40,12 @@ public class MavenShadedDependenciesTest {
             commandBuilder.property(DetectProperties.DETECT_MAVEN_INCLUDE_SHADED_DEPENDENCIES, String.valueOf(true));
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
-            dockerAssertions.logContains("definitely not");
+            dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
 
-            try {
-                blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser"); // fails here, does not have this component
-                blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
-                blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
-            } catch (Throwable t) {
-                dockerAssertions.logContains("Logs definitely don't contain this");
-            }
+            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+            blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
+            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
         }
     }
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -43,9 +43,13 @@ public class MavenShadedDependenciesTest {
             dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
 
-            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
-            blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
-            blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
+            try {
+                blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+                blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
+                blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
+            } catch (Throwable t) {
+                dockerAssertions.logContains("Logs definitely don't contain this");
+            }
         }
     }
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/MavenShadedDependenciesTest.java
@@ -43,7 +43,7 @@ public class MavenShadedDependenciesTest {
             dockerAssertions.logContains("Maven CLI: SUCCESS");
             dockerAssertions.atLeastOneBdioFile();
 
-//            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
+            blackduckAssertions.hasComponents("ch.randelshofer:fastdoubleparser");
             blackduckAssertions.hasComponents("JCTTools");
             blackduckAssertions.hasComponents("Byte Buddy (with dependencies)");
         }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
@@ -108,6 +108,10 @@ public class BlackDuckAssertions {
 
     public void hasComponents(Set<String> componentNames) throws IntegrationException {
         List<ProjectVersionComponentVersionView> bomComponents = getBomComponents();
+        for (ProjectVersionComponentVersionView bomCompo : bomComponents) {
+            System.out.println("About to print out components in BOM: ");
+            System.out.println(bomCompo.getComponentName());
+        }
         componentNames.forEach(componentName -> {
             Optional<ProjectVersionComponentVersionView> blackDuckCommonComponent = bomComponents.stream()
                 .filter(ProjectVersionComponentView -> componentName.equals(ProjectVersionComponentView.getComponentName()))

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
@@ -19,8 +19,6 @@ import com.blackduck.integration.blackduck.service.model.ProjectVersionWrapper;
 import com.blackduck.integration.common.util.Bds;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.util.NameVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class BlackDuckAssertions {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ProjectService projectService;
     private final BlackDuckApiClient blackDuckApiClient;
     private final ProjectBomService projectBomService;
@@ -63,8 +60,6 @@ public class BlackDuckAssertions {
         List<ProjectVersionComponentVersionView> bomComponents = projectBomService.getComponentsForProjectVersion(optionalProjectVersionWrapper.get().getProjectVersionView());
         assertEquals(0, bomComponents.size());
 
-        logger.info("testing info logger");
-        logger.debug("testing debug logger");
         return optionalProjectVersionWrapper.get();
     }
 

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/BlackDuckAssertions.java
@@ -19,6 +19,8 @@ import com.blackduck.integration.blackduck.service.model.ProjectVersionWrapper;
 import com.blackduck.integration.common.util.Bds;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.util.NameVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class BlackDuckAssertions {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ProjectService projectService;
     private final BlackDuckApiClient blackDuckApiClient;
     private final ProjectBomService projectBomService;
@@ -60,6 +63,8 @@ public class BlackDuckAssertions {
         List<ProjectVersionComponentVersionView> bomComponents = projectBomService.getComponentsForProjectVersion(optionalProjectVersionWrapper.get().getProjectVersionView());
         assertEquals(0, bomComponents.size());
 
+        logger.info("testing info logger");
+        logger.debug("testing debug logger");
         return optionalProjectVersionWrapper.get();
     }
 
@@ -108,10 +113,6 @@ public class BlackDuckAssertions {
 
     public void hasComponents(Set<String> componentNames) throws IntegrationException {
         List<ProjectVersionComponentVersionView> bomComponents = getBomComponents();
-        for (ProjectVersionComponentVersionView bomCompo : bomComponents) {
-            System.out.println("About to print out components in BOM: ");
-            System.out.println(bomCompo.getComponentName());
-        }
         componentNames.forEach(componentName -> {
             Optional<ProjectVersionComponentVersionView> blackDuckCommonComponent = bomComponents.stream()
                 .filter(ProjectVersionComponentView -> componentName.equals(ProjectVersionComponentView.getComponentName()))


### PR DESCRIPTION
There are two test failures in the Detect comprehensive pipeline, this MR updates them to get the tests passing once again: 

**1) GradleNativeInspectorTests.gradleRishVersions()**
The test fails on assertion `blackduckAssertions.checkComponentVersionExists("googleguava","v29.0");`
- The example project comes from {snps internal artifactory}/artifactory/detect-generic-qa-local/gradle-rich-versions-project.zip, which has not been modified since April. 
- Looking at the BOM in the UI and the BDIO, there is a component with ID com.google.guava:guava:29.0-jre:
![Screenshot 2024-11-19 at 08 02 12](https://github.com/user-attachments/assets/f8d78ed7-9915-4213-a2c2-ebfbc7d820d4)
- The component name corresponding to the above from the Hub response during the integration test is **"google-guava", but "googleguava" is not found.** 
- Reverts the following change we made recently: https://github.com/blackducksoftware/detect/pull/1192 


**2) MavenShadedDependenciesTest.mavenShadedDependencyTest()**
The test fails on this assertion: blackduckAssertions.hasComponents("Java Concurrency Tools Core Library");
- In maven central, the ID for "Java Concurrency Tools Library" appears to be org.jctools? See [here](https://mvnrepository.com/artifact/org.jctools/jctools-core)
- In the Detect logs, we see: 
`Manage dependency: <org.jctools:jctools-core:jar:4.0.5:compile-shadedBy:8ce31936-2fbd-79be-8002-84533515c815> -> <org.jctools:jctools-core:jar:4.0.5:compile-shadedBy:8ce31936-2fbd-79be-8002-84533515c815>`
- Scanning the test project, and checking in the UI, the following is what we have corresponding to org.jctools:jctools-core:4.0.5:
![Screenshot 2024-11-19 at 08 01 21](https://github.com/user-attachments/assets/c6d3c8bb-f31b-4b88-8c89-81f5d6daa9dc)
- So we have JCTTools corresponding to org.jctools-core:4.0.5 but no "Java Concurrency Tools Core Library"


The first test began failing Nov 9, and the second test Nov 6. Based on the explanations above, I believe this is due to a KB update. Unclear on how I can 100% confirm that, but I feel confident the updates maintains the test integrity 