### PR TITLE
Update signJar Gradle task to use the new Windows jar signing client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,7 @@ task signJar() {
     finalizedBy 'verifyJar'
     doLast {
         exec {
-            commandLine 'jarsigner', '-tsa', 'http://rfc3161timestamp.globalsign.com/advanced', '-storetype', 'pkcs12', '-storepass', "${jarSigningKeystorePassword}", '-keystore', "${jarSigningKeystorePath}", "${createArtifactName()}", "${jarSigningCertificateAlias}"
+            commandLine 'signing-client', '--username', "${System.getenv('SIGNING_USER')}", '--password', "env:SIGNING_TOKEN", '--server', "${System.getenv('SIGNING_SERVER')}", '--port', '8000', '--signer', 'jarsigner', '--output', "${createArtifactName()}", "${createArtifactName()}"
         }
     }
 }


### PR DESCRIPTION
#### Description
The new windows jar signing client enables signing jars using a Black Duck certificate and this server is centrally managed by release engineering. The code signing process is controlled by the "signJar" Gradle task.

This task needs to be updated to use the new signing client only for Detect versions 10.1.0 and above.

For all previous Detect versions, the Gradle task should continue using the existing code signing workfow that signs the jar with Synopsys certs.


#### JIRA
IDETECT-4518