### PR TITLE
feat(Gradle): Add detect.gradle.root.only property. (IDETECT-4441)

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorDetectable.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorDetectable.java
@@ -100,7 +100,8 @@ public class GradleInspectorDetectable extends Detectable {
             gradleCommand,
             gradleInspectorOptions.getproxyInfo(),
             gradleInspector,
-            extractionEnvironment.getOutputDirectory()
+            extractionEnvironment.getOutputDirectory(),
+            gradleInspectorOptions.getGradleInspectorScriptOptions().isRootOnly()
         );
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
@@ -72,7 +72,6 @@ public class GradleInspectorExtractor {
                 Optional<GradleReport> rootReport = gradleReportParser.parseReport(reportFilesSorted.get(0));
                 if (!rootReport.isPresent()) {
                     logger.error("No root dependency report to process."); // TODO fail gradle inspector?
-                    // TODO error handling: log error or debug something went wrong or if index at 0 is index out of bounds etc. Fail scan if rootOnly is true but could not be processed. report files should be exactly one
                 } else {
                     List<CodeLocation> allCodeLocationsInRootReport = gradleReportTransformer.transformRootReport(rootReport.get());
                     codeLocations = allCodeLocationsInRootReport;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Comparator;
 
-import com.blackduck.integration.detectable.detectables.gradle.inspection.model.GradleReport;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -22,6 +21,7 @@ import com.blackduck.integration.detectable.detectable.executable.ExecutableFail
 import com.blackduck.integration.detectable.detectables.gradle.inspection.parse.GradleReportParser;
 import com.blackduck.integration.detectable.detectables.gradle.inspection.parse.GradleReportTransformer;
 import com.blackduck.integration.detectable.detectables.gradle.inspection.parse.GradleRootMetadataParser;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.model.GradleReport;
 import com.blackduck.integration.detectable.extraction.Extraction;
 import com.blackduck.integration.detectable.util.ToolVersionLogger;
 import com.blackduck.integration.rest.proxy.ProxyInfo;
@@ -67,12 +67,10 @@ public class GradleInspectorExtractor {
             reportFiles.toArray(files);
             List<File> reportFilesSorted = Arrays.asList(sortFilesByDepth(files));
 
-            if (rootOnly) {
-                logger.debug("Gradle Inspector root only option selected. Will process root project's dependencies only.");
+            if (rootOnly && reportFilesSorted.size()>0) {
+                logger.debug("Gradle Inspector root-only option selected. Only processing root project dependencies.");
                 Optional<GradleReport> rootReport = gradleReportParser.parseReport(reportFilesSorted.get(0));
-                if (!rootReport.isPresent()) {
-                    logger.error("No root dependency report to process."); // TODO fail gradle inspector?
-                } else {
+                if (rootReport.isPresent()) {
                     List<CodeLocation> allCodeLocationsInRootReport = gradleReportTransformer.transformRootReport(rootReport.get());
                     codeLocations = allCodeLocationsInRootReport;
                 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
@@ -68,10 +68,10 @@ public class GradleInspectorExtractor {
             List<File> reportFilesSorted = Arrays.asList(sortFilesByDepth(files));
 
             if (rootOnly) {
-                logger.debug("Gradle Inspector root only option selected. Will process root dependency graph only.");
+                logger.debug("Gradle Inspector root only option selected. Will process root project's dependencies only.");
                 Optional<GradleReport> rootReport = gradleReportParser.parseReport(reportFilesSorted.get(0));
                 if (!rootReport.isPresent()) {
-                    logger.error("No root dependency report to process.");
+                    logger.error("No root dependency report to process."); // TODO fail gradle inspector?
                     // TODO error handling: log error or debug something went wrong or if index at 0 is index out of bounds etc. Fail scan if rootOnly is true but could not be processed. report files should be exactly one
                 } else {
                     List<CodeLocation> allCodeLocationsInRootReport = gradleReportTransformer.transformRootReport(rootReport.get());

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/GradleInspectorExtractor.java
@@ -71,7 +71,7 @@ public class GradleInspectorExtractor {
                 logger.debug("Gradle Inspector root-only option selected. Only processing root project dependencies.");
                 Optional<GradleReport> rootReport = gradleReportParser.parseReport(reportFilesSorted.get(0));
                 if (rootReport.isPresent()) {
-                    List<CodeLocation> allCodeLocationsInRootReport = gradleReportTransformer.transformRootReport(rootReport.get());
+                    List<CodeLocation> allCodeLocationsInRootReport = gradleReportTransformer.transformRootReportOnly(rootReport.get());
                     codeLocations = allCodeLocationsInRootReport;
                 }
             } else {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptCreator.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptCreator.java
@@ -51,6 +51,7 @@ public class GradleInspectorScriptCreator {
         gradleScriptData.put("excludedConfigurationNames", toCommaSeparatedString(scriptOptions.getExcludedConfigurationNames()));
         gradleScriptData.put("includedConfigurationNames", toCommaSeparatedString(scriptOptions.getIncludedConfigurationNames()));
         gradleScriptData.put("customRepositoryUrl", scriptOptions.getGradleInspectorRepositoryUrl());
+        gradleScriptData.put("rootOnlyOption", Boolean.toString(scriptOptions.isRootOnlyOptionSelected()));
 
         try {
             populateGradleScriptWithData(targetFile, gradleScriptData);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptCreator.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptCreator.java
@@ -51,7 +51,7 @@ public class GradleInspectorScriptCreator {
         gradleScriptData.put("excludedConfigurationNames", toCommaSeparatedString(scriptOptions.getExcludedConfigurationNames()));
         gradleScriptData.put("includedConfigurationNames", toCommaSeparatedString(scriptOptions.getIncludedConfigurationNames()));
         gradleScriptData.put("customRepositoryUrl", scriptOptions.getGradleInspectorRepositoryUrl());
-        gradleScriptData.put("rootOnlyOption", Boolean.toString(scriptOptions.isRootOnlyOptionSelected()));
+        gradleScriptData.put("rootOnlyOption", Boolean.toString(scriptOptions.isRootOnly()));
 
         try {
             populateGradleScriptWithData(targetFile, gradleScriptData);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptOptions.java
@@ -10,7 +10,7 @@ public class GradleInspectorScriptOptions {
     private final List<String> excludedConfigurationNames;
     private final List<String> includedConfigurationNames;
     private final String gradleInspectorRepositoryUrl;
-    private final boolean rootOnlyOption;
+    private final boolean rootOnly;
 
     public GradleInspectorScriptOptions(
         List<String> excludedProjectNames,
@@ -20,7 +20,7 @@ public class GradleInspectorScriptOptions {
         List<String> excludedConfigurationNames,
         List<String> includedConfigurationNames,
         String gradleInspectorRepositoryUrl,
-        boolean rootOnlyOption
+        boolean rootOnly
     ) {
         this.excludedProjectNames = excludedProjectNames;
         this.includedProjectNames = includedProjectNames;
@@ -29,7 +29,7 @@ public class GradleInspectorScriptOptions {
         this.excludedConfigurationNames = excludedConfigurationNames;
         this.includedConfigurationNames = includedConfigurationNames;
         this.gradleInspectorRepositoryUrl = gradleInspectorRepositoryUrl;
-        this.rootOnlyOption = rootOnlyOption;
+        this.rootOnly = rootOnly;
     }
 
     public String getGradleInspectorRepositoryUrl() {
@@ -60,7 +60,7 @@ public class GradleInspectorScriptOptions {
         return includedProjectPaths;
     }
 
-    public boolean isRootOnlyOptionSelected() {
-        return rootOnlyOption;
+    public boolean isRootOnly() {
+        return rootOnly;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/inspector/GradleInspectorScriptOptions.java
@@ -10,6 +10,7 @@ public class GradleInspectorScriptOptions {
     private final List<String> excludedConfigurationNames;
     private final List<String> includedConfigurationNames;
     private final String gradleInspectorRepositoryUrl;
+    private final boolean rootOnlyOption;
 
     public GradleInspectorScriptOptions(
         List<String> excludedProjectNames,
@@ -18,7 +19,8 @@ public class GradleInspectorScriptOptions {
         List<String> includedProjectPaths,
         List<String> excludedConfigurationNames,
         List<String> includedConfigurationNames,
-        String gradleInspectorRepositoryUrl
+        String gradleInspectorRepositoryUrl,
+        boolean rootOnlyOption
     ) {
         this.excludedProjectNames = excludedProjectNames;
         this.includedProjectNames = includedProjectNames;
@@ -27,6 +29,7 @@ public class GradleInspectorScriptOptions {
         this.excludedConfigurationNames = excludedConfigurationNames;
         this.includedConfigurationNames = includedConfigurationNames;
         this.gradleInspectorRepositoryUrl = gradleInspectorRepositoryUrl;
+        this.rootOnlyOption = rootOnlyOption;
     }
 
     public String getGradleInspectorRepositoryUrl() {
@@ -55,5 +58,9 @@ public class GradleInspectorScriptOptions {
 
     public List<String> getIncludedProjectPaths() {
         return includedProjectPaths;
+    }
+
+    public boolean isRootOnlyOptionSelected() {
+        return rootOnlyOption;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/model/GradleGav.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/model/GradleGav.java
@@ -29,4 +29,9 @@ public class GradleGav implements GradleGavId {
     public LazyId toDependencyId() {
         return LazyId.fromString(String.format("%s:%s:%s", getGroup(), getName(), getVersion()));
     }
+
+    @Override
+    public String toString() {
+        return getGroup() + ":" + getName() + ":" + getVersion();
+    }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/model/GradleTreeNode.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/model/GradleTreeNode.java
@@ -39,8 +39,8 @@ public class GradleTreeNode extends Stringable {
     private final GradleGav gav;
     private final String projectName;
 
-    public static GradleTreeNode newProject(int level) {
-        return new GradleTreeNode(NodeType.PROJECT, level, null, "");
+    public static GradleTreeNode newProject(int level, String subProjectName) {
+        return new GradleTreeNode(NodeType.PROJECT, level, null, subProjectName);
     }
 
     public static GradleTreeNode newGav(int level, String group, String name, String version) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -119,7 +119,7 @@ public class GradleReportLineParser {
             }
         }
 
-        projectName = metadata.getOrDefault(PROJECT_NAME_PREFIX, "orphanProject"); // TOME project name relevant for rich version stuff potentially...
+        projectName = metadata.getOrDefault(PROJECT_NAME_PREFIX, "orphanProject");
         rootProjectName = metadata.getOrDefault(ROOT_PROJECT_NAME_PREFIX, "");
         projectParent = metadata.getOrDefault(PROJECT_PARENT_PREFIX, "null");
 
@@ -179,7 +179,7 @@ public class GradleReportLineParser {
        return false;
     }
 
-    private boolean checkRichVersionUse(String dependencyLine) { // should rename to isUsingRichVersion
+    private boolean checkRichVersionUse(String dependencyLine) {
         return dependencyLine.contains(STRICTLY) || dependencyLine.contains(REJECT) || dependencyLine.contains(REQUIRE) || dependencyLine.contains(PREFER);
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -1,7 +1,6 @@
 package com.blackduck.integration.detectable.detectables.gradle.inspection.parse;
 
 import java.util.Map;
-import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Arrays;
@@ -56,7 +55,8 @@ public class GradleReportLineParser {
         if (!line.contains(COMPONENT_PREFIX)) {
             return GradleTreeNode.newUnknown(level);
         } else if (StringUtils.containsAny(line, PROJECT_INDICATORS)) {
-            return GradleTreeNode.newProject(level);
+            String subProjectName = extractSubProjectName(line);
+            return GradleTreeNode.newProject(level, subProjectName);
         } else {
             List<String> gav = parseGav(line, metadata);
             if (gav.size() != 3) {
@@ -71,6 +71,16 @@ public class GradleReportLineParser {
                 String version = gav.get(2);
                 return GradleTreeNode.newGav(level, group, name, version);
             }
+        }
+    }
+
+    private String extractSubProjectName(String line) {
+        // A subProject dependency line looks exactly like: "+--- project :subProjectName"
+        if (line.contains(":")) {
+            String[] parts = line.split(":");
+            return parts[1].trim();
+        } else {
+            return "";
         }
     }
 
@@ -109,7 +119,7 @@ public class GradleReportLineParser {
             }
         }
 
-        projectName = metadata.getOrDefault(PROJECT_NAME_PREFIX, "orphanProject");
+        projectName = metadata.getOrDefault(PROJECT_NAME_PREFIX, "orphanProject"); // TOME project name relevant for rich version stuff potentially...
         rootProjectName = metadata.getOrDefault(ROOT_PROJECT_NAME_PREFIX, "");
         projectParent = metadata.getOrDefault(PROJECT_PARENT_PREFIX, "null");
 
@@ -169,7 +179,7 @@ public class GradleReportLineParser {
        return false;
     }
 
-    private boolean checkRichVersionUse(String dependencyLine) {
+    private boolean checkRichVersionUse(String dependencyLine) { // should rename to isUsingRichVersion
         return dependencyLine.contains(STRICTLY) || dependencyLine.contains(REJECT) || dependencyLine.contains(REQUIRE) || dependencyLine.contains(PREFER);
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportParser.java
@@ -97,8 +97,8 @@ public class GradleReportParser {
     private void parseConfigurationLines(List<String> configurationLines, GradleReport gradleReport) {
         if (configurationLines.size() > 1 && isConfigurationHeader(configurationLines)) {
             String header = configurationLines.get(0);
-            List<String> dependencyTree = configurationLines.stream().skip(1).collect(Collectors.toList());
-            GradleConfiguration configuration = gradleReportConfigurationParser.parse(header, dependencyTree, metadata);
+            List<String> dependencyLines = configurationLines.stream().skip(1).collect(Collectors.toList());
+            GradleConfiguration configuration = gradleReportConfigurationParser.parse(header, dependencyLines, metadata);
             gradleReport.getConfigurations().add(configuration);
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportTransformer.java
@@ -1,7 +1,7 @@
 package com.blackduck.integration.detectable.detectables.gradle.inspection.parse;
 
 import java.io.File;
-import java.util.Optional;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -24,9 +24,118 @@ import com.blackduck.integration.detectable.detectables.gradle.inspection.model.
 public class GradleReportTransformer {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final EnumListFilter<GradleConfigurationType> configurationTypeFilter;
+    private final List<CodeLocation> allCodeLocationsWithinRoot = new ArrayList<>();
 
     public GradleReportTransformer(EnumListFilter<GradleConfigurationType> configurationTypeFilter) {
         this.configurationTypeFilter = configurationTypeFilter;
+    }
+
+    public List<CodeLocation> transformRootReport(GradleReport gradleReport) {
+        DependencyGraph rootGraph = new BasicDependencyGraph();
+        for (GradleConfiguration configuration : gradleReport.getConfigurations()) {
+            if (configuration.isResolved() || configurationTypeFilter.shouldInclude(GradleConfigurationType.UNRESOLVED)) {
+                logger.debug("Adding configuration to the graph: {}", configuration.getName());
+                addConfigurationToGraph_rootFlow(rootGraph, configuration, gradleReport);
+            } else {
+                logger.trace("Excluding unresolved configuration from the graph: {}", configuration.getName());
+            }
+        }
+
+        ExternalId projectId = ExternalId.FACTORY.createMavenExternalId(gradleReport.getProjectGroup(), gradleReport.getProjectName(), gradleReport.getProjectVersionName());
+        if (StringUtils.isNotBlank(gradleReport.getProjectSourcePath())) {
+            CodeLocation rootCodeLocation = new CodeLocation(rootGraph, projectId, new File(gradleReport.getProjectSourcePath())); /// path for when the only report is root we have: /Users/shanty/blackduck/github-folder/detect
+            allCodeLocationsWithinRoot.add(rootCodeLocation);
+        } else {
+            CodeLocation rootCodeLocation = new CodeLocation(rootGraph, projectId);
+            allCodeLocationsWithinRoot.add(rootCodeLocation);
+        }
+
+        return allCodeLocationsWithinRoot;
+    }
+
+
+    private void addConfigurationToGraph_rootFlow(DependencyGraph rootGraph, GradleConfiguration configuration, GradleReport rootReport) {
+        DependencyHistory history = new DependencyHistory();
+
+        TreeNodeSkipper treeNodeSkipper = new TreeNodeSkipper();
+        for (GradleTreeNode currentNode : configuration.getChildren()) {
+            if (treeNodeSkipper.shouldSkip(currentNode)) {
+                logger.debug("~~~Skipping node: " + currentNode.getGav());
+                continue;
+            }
+
+            if (currentNode.getNodeType() == GradleTreeNode.NodeType.GAV) {
+                history.clearDependenciesDeeperThan(currentNode.getLevel());
+                Optional<GradleGav> currentNodeGav = currentNode.getGav();
+                if (currentNodeGav.isPresent()) {
+                    addGavToGraph(currentNodeGav.get(), history, rootGraph);
+                }
+                else {
+                    // We know this is a GradleTreeNode.NodeType.GAV
+                    // So if its missing data, something is probably wrong.
+                    logger.debug("Missing expected GAV from known NodeType. {}", currentNode);
+                }
+            }
+            else if (currentNode.getNodeType() == GradleTreeNode.NodeType.PROJECT) {
+                // Let this method skip over the subProject section as usual
+                treeNodeSkipper.skipUntilLineLevel(currentNode.getLevel());
+                // Process subProject section separately
+                processSubprojectAndCreateCodeLocation(currentNode, configuration.getChildren(), rootReport);
+            } else {
+                treeNodeSkipper.skipUntilLineLevel(currentNode.getLevel());
+            }
+        }
+    }
+    private void processSubprojectAndCreateCodeLocation(GradleTreeNode subProjectNode, List<GradleTreeNode> allTreeNodesInCurrentConfiguration, GradleReport rootReport) {
+        logger.debug("Processing subProject node:" + subProjectNode.getProjectName());
+        String subProjectName = subProjectNode.getProjectName().get();
+        int subProjectSectionStartIndex = allTreeNodesInCurrentConfiguration.indexOf(subProjectNode);
+        int subProjectNodeLevel = subProjectNode.getLevel();
+
+        DependencyGraph subProjectGraph = new BasicDependencyGraph();
+        DependencyHistory history = new DependencyHistory();
+        TreeNodeSkipper treeNodeSkipper = new TreeNodeSkipper();
+
+
+        for (int i = subProjectSectionStartIndex+1; i < allTreeNodesInCurrentConfiguration.size(); i++) {
+            GradleTreeNode currentNode = allTreeNodesInCurrentConfiguration.get(i);
+            int currentNodeLevelRelativeToSubProject = currentNode.getLevel() - 1;
+            if (currentNodeLevelRelativeToSubProject != -1) { // (aka subProjectNodeLevel -1)
+                if (currentNode.getNodeType() == GradleTreeNode.NodeType.GAV) {
+                    logger.debug("Adding dependency " + currentNode.getGav() + " for subProject " + subProjectName);
+                    history.clearDependenciesDeeperThan(currentNodeLevelRelativeToSubProject);
+                    Optional<GradleGav> currentNodeGav = currentNode.getGav();
+                    if (currentNodeGav.isPresent()) {
+                        addGavToGraph(currentNodeGav.get(), history, subProjectGraph);
+                    }
+                    else {
+                        // We know this is a GradleTreeNode.NodeType.GAV
+                        // So if its missing data, something is probably wrong.
+                        logger.debug("Missing expected GAV from known NodeType. {}", currentNode);
+                    }
+                } else {
+                    // current node is either unknown or a nested subproject, todo later
+                    logger.debug("Encountered unknown or nested project node while processing subProject");
+                }
+            } else {
+                // the current node is back at 0 so we are done processing subProject section
+                break;
+            }
+        }
+
+        // have we encountered this subProject before?
+        // if not, create new code location
+        CodeLocation newCodeLocation = createCodeLocationForSubProject(rootReport, subProjectGraph, subProjectName);
+        allCodeLocationsWithinRoot.add(newCodeLocation);
+    }
+
+    private CodeLocation createCodeLocationForSubProject(GradleReport rootReport, DependencyGraph subProjectGraph, String subProjectName) {
+        ExternalId projectId = ExternalId.FACTORY.createMavenExternalId(rootReport.getProjectGroup(), subProjectName, rootReport.getProjectVersionName());
+        if (StringUtils.isNotBlank(rootReport.getProjectSourcePath())) {
+            return new CodeLocation(subProjectGraph, projectId, new File(rootReport.getProjectSourcePath() + "/" + subProjectName)); /// path for when the only report is root we have: /Users/shanty/blackduck/github-folder/detect
+        } else {
+            return new CodeLocation(subProjectGraph, projectId);
+        }
     }
 
     public CodeLocation transform(GradleReport gradleReport) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorDetectableTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorDetectableTest.java
@@ -101,7 +101,8 @@ public class GradleInspectorDetectableTest extends DetectableFunctionalTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                ""
+                "",
+                false
             ),
             ProxyInfo.NO_PROXY_INFO, EnumListFilter.excludeNone()
         );

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTest.java
@@ -129,7 +129,5 @@ public class GradleInspectorRootOnlyTest extends DetectableFunctionalTest {
         // Empty subProjectB has no dependencies
         Set<Dependency> subProjectBDirectDependencies = subProjectB.getDependencyGraph().getDirectDependencies();
         Assertions.assertEquals(0, subProjectBDirectDependencies.size());
-
-        // TODO SubprojectC is a nested dep within subprojectA, still processed independently
     }
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTest.java
@@ -48,11 +48,11 @@ public class GradleInspectorRootOnlyTest extends DetectableFunctionalTest {
                 "--info"
         );
 
-        List<String> lines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/rootProjectMetadata.txt");
-        addOutputFile(Paths.get("rootProjectMetadata.txt"), lines);
+        List<String> rootProjectMetadataLines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/rootProjectMetadata.txt");
+        addOutputFile(Paths.get("rootProjectMetadata.txt"), rootProjectMetadataLines);
 
-        List<String> newLines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt");
-        addOutputFile(Paths.get("root_dependencyGraph.txt"), newLines);
+        List<String> dependenciesCommandOutputLines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt");
+        addOutputFile(Paths.get("root_dependencyGraph.txt"), dependenciesCommandOutputLines);
     }
 
     @NotNull

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTests.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorRootOnlyTests.java
@@ -1,0 +1,125 @@
+package com.blackduck.integration.detectable.detectables.gradle.functional;
+
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
+import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
+import com.blackduck.integration.detectable.Detectable;
+import com.blackduck.integration.detectable.DetectableEnvironment;
+import com.blackduck.integration.detectable.ExecutableTarget;
+import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
+import com.blackduck.integration.detectable.detectable.util.EnumListFilter;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.GradleInspectorOptions;
+import com.blackduck.integration.detectable.detectables.gradle.inspection.inspector.GradleInspectorScriptOptions;
+import com.blackduck.integration.detectable.extraction.Extraction;
+import com.blackduck.integration.detectable.functional.DetectableFunctionalTest;
+import com.blackduck.integration.detectable.util.ExtractionUtil;
+import com.blackduck.integration.detectable.util.FunctionalTestFiles;
+import com.blackduck.integration.detectable.util.graph.NameVersionGraphAssert;
+import com.blackduck.integration.executable.ExecutableOutput;
+import com.blackduck.integration.rest.proxy.ProxyInfo;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class GradleInspectorRootOnlyTests extends DetectableFunctionalTest {
+    protected GradleInspectorRootOnlyTests() throws IOException {
+        super("my-root-only-test-attempt");
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        addFile(Paths.get("build.gradle"), "no content");
+
+        ExecutableOutput gradleDependenciesOutput = createStandardOutput("no content");
+
+        addExecutableOutput(
+                gradleDependenciesOutput,
+                new File("gradle").getCanonicalPath(),
+                "gatherDependencies",
+                "--init-script=gradle-inspector",
+                "-DGRADLEEXTRACTIONDIR=" + getOutputDirectory().toFile().getCanonicalPath(),
+                "--info"
+        );
+
+        List<String> lines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/rootProjectMetadata.txt");
+        addOutputFile(Paths.get("rootProjectMetadata.txt"), lines);
+
+        List<String> newLines = FunctionalTestFiles.asListOfStrings("/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt");
+        addOutputFile(Paths.get("root_dependencyGraph.txt"), newLines);
+    }
+
+    @NotNull
+    @Override
+    public Detectable create(@NotNull DetectableEnvironment detectableEnvironment) {
+        GradleInspectorOptions gradleInspectorOptions = new GradleInspectorOptions("",
+                new GradleInspectorScriptOptions(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        "",
+                        true
+                ),
+                ProxyInfo.NO_PROXY_INFO, EnumListFilter.excludeNone()
+        );
+        return detectableFactory.createGradleDetectable(
+                detectableEnvironment,
+                gradleInspectorOptions,
+                () -> new File("gradle-inspector"),
+                (environment) -> ExecutableTarget.forFile(new File("gradle"))
+        );
+    }
+
+    @Override
+    public void assertExtraction(@NotNull Extraction extraction) {
+        Assertions.assertEquals(3, extraction.getCodeLocations().size());
+
+        CodeLocation root = ExtractionUtil.assertAndGetCodeLocationNamed("simple", extraction);
+        CodeLocation subProjectA = ExtractionUtil.assertAndGetCodeLocationNamed("subProjectA", extraction);
+        CodeLocation subProjectB = ExtractionUtil.assertAndGetCodeLocationNamed("subProjectB", extraction);
+        // nested subProjectC with dependencies.....--->
+
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        // Root dependencies
+        ExternalId logback_classic = externalIdFactory.createMavenExternalId("ch.qos.logback", "logback-classic", "1.2.13");
+        ExternalId logback_core = externalIdFactory.createMavenExternalId("ch.qos.logback", "logback-core", "1.2.13");
+        ExternalId commons_text = externalIdFactory.createMavenExternalId("org.apache.commons", "commons-text", "1.10.0");
+        // SubProjectA dependencies
+        ExternalId blackduck_common = externalIdFactory.createMavenExternalId("com.blackduck.integration", "blackduck-common", "67.0.2");
+        ExternalId blackduck_common_api = externalIdFactory.createMavenExternalId("com.blackduck.integration", "blackduck-common-api", "2023.4.2.7");
+
+
+
+        NameVersionGraphAssert rootGraphAssert = new NameVersionGraphAssert(Forge.MAVEN, root.getDependencyGraph());
+        NameVersionGraphAssert subProjectAGraphAssert = new NameVersionGraphAssert(Forge.MAVEN, subProjectA.getDependencyGraph());
+
+
+        // Root has 2 direct and 1 transitive
+        Set<Dependency> rootProjectDirectDependencies = root.getDependencyGraph().getDirectDependencies();
+        Assertions.assertEquals(2, rootProjectDirectDependencies.size());
+        rootGraphAssert.hasRootDependency(logback_classic);
+        rootGraphAssert.hasRootDependency(commons_text);
+        rootGraphAssert.hasParentChildRelationship(logback_classic, logback_core);
+
+        // SubProjectA has 1 direct and 1 transitive
+        Set<Dependency> subProjectADirectDependencies = subProjectA.getDependencyGraph().getDirectDependencies();
+        Assertions.assertEquals(1, subProjectADirectDependencies.size());
+        subProjectAGraphAssert.hasRootDependency(blackduck_common);
+        subProjectAGraphAssert.hasParentChildRelationship(blackduck_common, blackduck_common_api);
+
+        // Empty subProjectB has no dependencies
+        Set<Dependency> subProjectBDirectDependencies = subProjectB.getDependencyGraph().getDirectDependencies();
+        Assertions.assertEquals(0, subProjectBDirectDependencies.size());
+
+        // TODO SubprojectC is a nested dep within subprojectA, still processed independently
+    }
+}

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorScriptCreatorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleInspectorScriptCreatorTest.java
@@ -38,7 +38,8 @@ public class GradleInspectorScriptCreatorTest {
             Collections.emptyList(),
             excludedConfigurationNames,
             includedConfigurationNames,
-            gradleInspectorRepositoryUrl
+            gradleInspectorRepositoryUrl,
+            false
         );
 
         Configuration configuration = createFreemarkerConfiguration();

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleReplacementDetectableTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/functional/GradleReplacementDetectableTest.java
@@ -85,7 +85,8 @@ public class GradleReplacementDetectableTest extends DetectableFunctionalTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                ""
+                "",
+                false
             ),
             ProxyInfo.NO_PROXY_INFO, EnumListFilter.excludeNone()
         );

--- a/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/rootProjectMetadata.txt
+++ b/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/rootProjectMetadata.txt
@@ -1,0 +1,7 @@
+DETECT META DATA START
+rootProjectDirectory:/path/to/multimodule/project/simple
+rootProjectPath::
+rootProjectGroup:com.blackduck.integration
+rootProjectName:simple
+rootProjectVersion:1.1.1
+DETECT META DATA END

--- a/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
+++ b/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
@@ -15,6 +15,15 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- project :subProjectB
 \--- org.apache.commons:commons-text:1.10.0
 
+runtimeClasspath - Runtime classpath of source set 'test'.
++--- com.google.guava:guava:32.1.2-jre
+|    \--- com.google.guava:failureaccess:1.0.1
++--- project :subProjectA
+|    +--- com.google.guava:guava:32.1.2-jre (*)
+|    +--- project :subProjectC
+|    \--- com.paypal.digraph:digraph-parser:1.0
+|         \--- org.antlr:antlr4-runtime:4.2 -> 4.7.2
+
 (c) - dependency constraint
 (*) - dependencies omitted (listed previously)
 

--- a/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
+++ b/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
@@ -5,11 +5,13 @@ Root project 'simple'
 
 compileClasspath - Compile classpath for source set 'main'.
 +--- ch.qos.logback:logback-classic:1.2.13
-|    /--- ch.qos.logback:logback-core:1.2.13
+|    \--- ch.qos.logback:logback-core:1.2.13
 +--- project :subProjectA
-|    \--- com.blackduck.integration:blackduck-common:67.0.2
-|         +--- com.blackduck.integration:blackduck-common-api:2023.4.2.7
-|         |    \--- com.blackduck.integration:integration-rest:11.0.1
+|    +--- com.blackduck.integration:blackduck-common:67.0.2
+|    |    \--- com.blackduck.integration:blackduck-common-api:2023.4.2.7
+|    +--- project :subProjectC
+|    |    \--- org.antlr:antlr4-runtime:4.2 -> 4.7.2
+|    \--- com.paypal.digraph:digraph-parser:1.0
 +--- project :subProjectB
 \--- org.apache.commons:commons-text:1.10.0
 

--- a/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
+++ b/detectable/src/test/resources/detectables/functional/gradle/root-only-tests/root_project__simple__depth0_dependencyGraph.txt
@@ -1,0 +1,33 @@
+
+------------------------------------------------------------
+Root project 'simple'
+------------------------------------------------------------
+
+compileClasspath - Compile classpath for source set 'main'.
++--- ch.qos.logback:logback-classic:1.2.13
+|    /--- ch.qos.logback:logback-core:1.2.13
++--- project :subProjectA
+|    \--- com.blackduck.integration:blackduck-common:67.0.2
+|         +--- com.blackduck.integration:blackduck-common-api:2023.4.2.7
+|         |    \--- com.blackduck.integration:integration-rest:11.0.1
++--- project :subProjectB
+\--- org.apache.commons:commons-text:1.10.0
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+DETECT META DATA START
+rootProjectDirectory:/path/to/multimodule/project/simple
+rootProjectGroup:com.blackduck.integration
+rootProjectPath::
+rootProjectName:simple
+rootProjectVersion:1.1.1
+projectDirectory:/path/to/multimodule/project/simple
+projectGroup:com.blackduck.integration
+projectName:simple
+projectVersion:1.1.1
+projectPath::
+projectParent:null
+DETECT META DATA END

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -13,7 +13,7 @@
 ### New features
 
 * npm lockfile and shrinkwrap detectors now ignore packages flagged as extraneous in the package-lock.json and npm-shrinkwrap.json files.
-* (IDETECT-4441) New Gradle Native Inspector option to only process the root dependencies of a Gradle project. See [detect.gradle.root.only](properties/detectors/gradle.md) for more details.
+* (IDETECT-4441) New Gradle Native Inspector option to only process the root dependencies of a Gradle project. See [detect.gradle.root.only](properties/detectors/gradle.md#gradle-root-only-advanced) for more details.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -13,7 +13,7 @@
 ### New features
 
 * npm lockfile and shrinkwrap detectors now ignore packages flagged as extraneous in the package-lock.json and npm-shrinkwrap.json files.
-* (IDETECT-4441) New GradleNative Inspector option to process root tree only. TODO
+* (IDETECT-4441) New Gradle Native Inspector option to process a Gradle projects root dependencies only. See <link to new property detail page> for more details. 
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -13,7 +13,7 @@
 ### New features
 
 * npm lockfile and shrinkwrap detectors now ignore packages flagged as extraneous in the package-lock.json and npm-shrinkwrap.json files.
-* (IDETECT-4441) New Gradle Native Inspector option to process a Gradle projects root dependencies only. See <link to new property detail page> for more details. 
+* (IDETECT-4441) New Gradle Native Inspector option to only process the root dependencies of a Gradle project. See [detect.gradle.root.only](properties/detectors/gradle.md) for more details.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -13,6 +13,7 @@
 ### New features
 
 * npm lockfile and shrinkwrap detectors now ignore packages flagged as extraneous in the package-lock.json and npm-shrinkwrap.json files.
+* (IDETECT-4441) New GradleNative Inspector option to process root tree only. TODO
 
 ### Changed features
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -916,6 +916,17 @@ public class DetectProperties {
             .setGroups(DetectGroup.GRADLE, DetectGroup.GLOBAL)
             .build();
 
+    public static final BooleanProperty DETECT_GRADLE_ROOT_ONLY =
+            BooleanProperty.newBuilder("detect.gradle.root.only", false)
+                    .setInfo("TODO", DetectPropertyFromVersion.VERSION_7_0_0)
+                    .setHelp(
+                            "TODO",
+                            "TODO"
+                    )
+                    .setGroups(DetectGroup.GRADLE, DetectGroup.SOURCE_SCAN)
+                    .setCategory(DetectCategory.Advanced)
+                    .build();
+
     public static final NullablePathProperty DETECT_HEX_REBAR3_PATH =
         NullablePathProperty.newBuilder("detect.hex.rebar3.path")
             .setInfo("Rebar3 Executable", DetectPropertyFromVersion.VERSION_3_0_0)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -918,10 +918,10 @@ public class DetectProperties {
 
     public static final BooleanProperty DETECT_GRADLE_ROOT_ONLY =
             BooleanProperty.newBuilder("detect.gradle.root.only", false)
-                    .setInfo("TODO", DetectPropertyFromVersion.VERSION_10_1_0)
+                    .setInfo("Gradle Root Only Enabled", DetectPropertyFromVersion.VERSION_10_1_0)
                     .setHelp(
-                            "TODO",
-                            "TODO"
+                            "If set to true, Gradle Native Inspector will evaluate only the root project's dependencies.",
+                            "This property trumps other inclusion/exclusion rules and therefore should not be combined with detect.gradle.excluded.projects, detect.gradle.excluded.project.paths, detect.gradle.included.projects or detect.gradle.included.project.paths."
                     )
                     .setGroups(DetectGroup.GRADLE, DetectGroup.SOURCE_SCAN)
                     .setCategory(DetectCategory.Advanced)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -920,8 +920,8 @@ public class DetectProperties {
             BooleanProperty.newBuilder("detect.gradle.root.only", false)
                     .setInfo("Gradle Root Only Enabled", DetectPropertyFromVersion.VERSION_10_1_0)
                     .setHelp(
-                            "If set to true, Gradle Native Inspector will evaluate only the root project's dependencies.",
-                            "This property trumps other inclusion/exclusion rules and therefore should not be combined with detect.gradle.excluded.projects, detect.gradle.excluded.project.paths, detect.gradle.included.projects or detect.gradle.included.project.paths."
+                            "If set to true, Gradle Native Inspector will only evaluate root project dependencies.",
+                            "This property overrides other inclusion/exclusion rules and therefore should not be combined with detect.gradle.excluded.projects, detect.gradle.excluded.project.paths, detect.gradle.included.projects, or detect.gradle.included.project.paths."
                     )
                     .setGroups(DetectGroup.GRADLE, DetectGroup.SOURCE_SCAN)
                     .setCategory(DetectCategory.Advanced)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -918,7 +918,7 @@ public class DetectProperties {
 
     public static final BooleanProperty DETECT_GRADLE_ROOT_ONLY =
             BooleanProperty.newBuilder("detect.gradle.root.only", false)
-                    .setInfo("TODO", DetectPropertyFromVersion.VERSION_7_0_0)
+                    .setInfo("TODO", DetectPropertyFromVersion.VERSION_10_1_0)
                     .setHelp(
                             "TODO",
                             "TODO"

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -50,7 +50,8 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_9_6_0("9.6.0"),
     VERSION_9_7_0("9.7.0"),
     VERSION_9_8_0("9.8.0"),
-    VERSION_10_0_0("10.0.0");
+    VERSION_10_0_0("10.0.0"),
+    VERSION_10_1_0("10.1.0");
 
     private final String version;
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -146,6 +146,7 @@ public class DetectableOptionFactory {
         List<String> includedProjectPaths = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_INCLUDED_PROJECT_PATHS);
         List<String> excludedConfigurationNames = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_EXCLUDED_CONFIGURATIONS);
         List<String> includedConfigurationNames = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_INCLUDED_CONFIGURATIONS);
+        boolean rootOnlyOption = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_ROOT_ONLY);
         String customRepository = ArtifactoryConstants.GRADLE_INSPECTOR_MAVEN_REPO;
 
         Set<GradleConfigurationType> excludedConfigurationTypes = detectConfiguration.getValue(DetectProperties.DETECT_GRADLE_CONFIGURATION_TYPES_EXCLUDED).representedValueSet();
@@ -158,7 +159,8 @@ public class DetectableOptionFactory {
             includedProjectPaths,
             excludedConfigurationNames,
             includedConfigurationNames,
-            customRepository
+            customRepository,
+            rootOnlyOption
         );
         String gradleBuildCommand = detectConfiguration.getNullableValue(DetectProperties.DETECT_GRADLE_BUILD_COMMAND);
         return new GradleInspectorOptions(gradleBuildCommand, scriptOptions, proxyInfo, dependencyTypeFilter);

--- a/src/main/resources/init-script-gradle.ftl
+++ b/src/main/resources/init-script-gradle.ftl
@@ -94,7 +94,7 @@ gradle.allprojects {
             }
         }
         // this forces the dependencies task to be run which will write the content to the modified output file
-        project.gatherDependencies.finalizedBy(project.tasks.getByName('dependencies')) // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-task/finalized-by.html meaning dependencies task should run following a gatherDependencies task which should only be done if proj is of interest/included at all
+        project.gatherDependencies.finalizedBy(project.tasks.getByName('dependencies'))
         project.gatherDependencies
     }
 }

--- a/src/test/resources/battery/gradle-root-only/GRADLE-0/rootProjectMetadata.txt
+++ b/src/test/resources/battery/gradle-root-only/GRADLE-0/rootProjectMetadata.txt
@@ -1,7 +1,0 @@
-DETECT META DATA START
-rootProjectDirectory:/blah/myTest
-rootProjectPath::
-rootProjectGroup:com.blackduck.integration
-rootProjectName:myTest
-rootProjectVersion:1.0
-DETECT META DATA END

--- a/src/test/resources/battery/gradle-root-only/GRADLE-0/rootProjectMetadata.txt
+++ b/src/test/resources/battery/gradle-root-only/GRADLE-0/rootProjectMetadata.txt
@@ -1,0 +1,7 @@
+DETECT META DATA START
+rootProjectDirectory:/blah/myTest
+rootProjectPath::
+rootProjectGroup:com.blackduck.integration
+rootProjectName:myTest
+rootProjectVersion:1.0
+DETECT META DATA END


### PR DESCRIPTION
Below is a brief summary, for details please see the spike and/or design document linked in jira IDETECT-4441 . 

A new property, **detect.gradle.root.only**, will set the Gradle Native Inspector to create a BDIO from the output of running `gradle dependencies` on the root project of a multimodule Gradle project.  


**Script changes:** 
- New boolean input 'rootOnlyOption', value passed in from property detect.gradle.root.only
- When set, this property trumps any project inclusion/exclusion and only the root project's dependency tree will be processed (detect.gradle.excluded.projects, detect.gradle.excluded.project.paths, detect.gradle.included.projects, detect.gradle.included.project.paths are not combinable with this property)

**Parser changes:** 
- Adding subProject name to project type GradleTreeNode  (no effect on existing gradle inspector flow as this used to be empty string always and never used)

**Transformer changes:** 
- Existing flow calls on transform() and addConfigurationToGraph())
New flow (which is only trigerred if root only is set to true) calls on the following sequence instead: 
- transformRootOnly()
- addConfigurationToRootAndSubProjectGraphs()
- processSubprojectAndCreateCodeLocation()