### PR TITLE
Update Opam Tree approach to use JSON parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.1.0-SIGQA9-SNAPSHOT'
+version = '10.2.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildDetectable.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildDetectable.java
@@ -58,7 +58,7 @@ public class OpamBuildDetectable extends Detectable {
     @Override
     public Extraction extract(ExtractionEnvironment extractionEnvironment) throws ExecutableRunnerException {
         List<File> opamFiles = fileFinder.findFiles(environment.getDirectory(),OPAM_FILE);
-        return opamBuildExtractor.extract(opamFiles, opamExe);
+        return opamBuildExtractor.extract(opamFiles, opamExe, extractionEnvironment.getOutputDirectory());
     }
 
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamJsonFileModule.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamJsonFileModule.java
@@ -1,0 +1,21 @@
+package com.blackduck.integration.detectable.detectables.opam.buildexe.parse;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class OpamJsonFileModule {
+
+    @SerializedName("opam-version")
+    public String opamVersion;
+
+    @SerializedName("command-line")
+    public List<String> commandLineArgs;
+
+    @SerializedName("switch")
+    public String switchName;
+
+    @SerializedName("tree")
+    public List<OpamTreeProjectModule> opamProjects;
+
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeDependencyModule.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeDependencyModule.java
@@ -1,0 +1,23 @@
+package com.blackduck.integration.detectable.detectables.opam.buildexe.parse;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class OpamTreeDependencyModule {
+
+    @SerializedName("name")
+    public String name;
+
+    @SerializedName("version")
+    public String version;
+
+    @SerializedName("satisfies")
+    public String satifies;
+
+    @SerializedName("is_duplicate")
+    public boolean isDuplicate;
+
+    @SerializedName("dependencies")
+    public List<OpamTreeDependencyModule> dependencies;
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
@@ -66,8 +66,7 @@ public class OpamTreeParser {
             if(!opamTreeProjectModule.dependencies.isEmpty()) {
                 collectCodeLocations(opamTreeProjectModule.dependencies, null);
             }
-
-        };
+        }
     }
 
     private void collectCodeLocations(List<OpamTreeDependencyModule> dependencyModules, Dependency parentDependency) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
@@ -14,7 +14,6 @@ import com.google.gson.stream.JsonReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
@@ -37,17 +36,19 @@ public class OpamTreeParser {
     }
 
     public List<OpamParsedResult> parseJsonTreeFile(File outputFile) throws IOException {
+        //Check if there is any issue with the file
         if(outputFile == null || !outputFile.exists() || !outputFile.isFile()) {
             logger.warn("The opamTreeOutput.json file does not exist, the file was deleted, or an issue occurred while running the opam tree command.");
             return codeLocations;
         }
 
+        //initialize json reader object
         try (JsonReader jsonReader = new JsonReader(new FileReader(outputFile))) {
+            //convert the whole JSON file into OpamJsonFileModule PoJo
             OpamJsonFileModule opamTreeModule = gson.fromJson(jsonReader, OpamJsonFileModule.class);
+            //After getting PoJo, we will loop over the projects which are found in the tree
             for(OpamTreeProjectModule opamTreeProjectModule: opamTreeModule.opamProjects) {
-                if(opamTreeProjectModule != null) {
-                    processTreeJsonObject(opamTreeProjectModule);
-                }
+                processTreeJsonObject(opamTreeProjectModule);
             }
         } catch (IOException e) {
             throw new IOException("There was an error while parsing the JSON file.",e);
@@ -58,18 +59,21 @@ public class OpamTreeParser {
 
     public void processTreeJsonObject(OpamTreeProjectModule opamTreeProjectModule){
         if(opamTreeProjectModule != null) {
+            //this PoJo is OpamTreeProjectModule where it will have name, version and dependencies of one project
             String projectName = opamTreeProjectModule.name;
             String projectVersion = opamTreeProjectModule.version;
 
+            //initialze the project
             initializeProject(projectName, projectVersion);
 
             if(!opamTreeProjectModule.dependencies.isEmpty()) {
-                collectCodeLocations(opamTreeProjectModule.dependencies, null);
+                collectCodeLocations(opamTreeProjectModule.dependencies, null); //passing as null to distinguish between direct and transitive
             }
         }
     }
 
     private void collectCodeLocations(List<OpamTreeDependencyModule> dependencyModules, Dependency parentDependency) {
+        // recursively loop over the dependencies for each project
         for(OpamTreeDependencyModule dependencyModule: dependencyModules) {
             if(dependencyModule != null) {
                 String packageName = dependencyModule.name;
@@ -77,12 +81,14 @@ public class OpamTreeParser {
 
                 Dependency dependency = createDependencyExternalId(packageName, packageVersion);
 
+                //direct dependency
                 if(parentDependency == null) {
                     currentGraph.addDirectDependency(dependency);
-                } else {
+                } else { //transitive dependency
                     currentGraph.addChildWithParent(dependency, parentDependency);
                 }
 
+                //recursively call this method again if there are any transitives found with current dependency as parent
                 if(!dependencyModule.dependencies.isEmpty()) {
                     collectCodeLocations(dependencyModule.dependencies, dependency);
                 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
@@ -9,141 +9,100 @@ import com.blackduck.integration.bdio.model.Forge;
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
-import com.blackduck.integration.detectable.detectable.util.DetectableStringUtils;
-import org.apache.commons.lang3.StringUtils;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Stack;
 import java.io.File;
 
 public class OpamTreeParser {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private int level = 0;
-    private String currentProject;
-    private static final String DIRECT_DEPENDENCY_INDICATOR = "|--"; // direct dependencies usually start with this prefix
-    private static final String[] DEPENDENCY_INDICATOR = new String[] { "|", "|--", "'--" }; // indicates that line contains a dependency
-    private static final String PACKAGE_PREFIX = "-- ";
-    private final List<OpamParsedResult> codeLocations = new ArrayList<>();
+    private List<OpamParsedResult> codeLocations = new ArrayList<>();
     private DependencyGraph currentGraph;
-    private Stack<Dependency> dependencyStack;
     private final File sourceDirectory;
     private final ExternalIdFactory externalIdFactory;
+    private final Gson gson;
 
-    public OpamTreeParser(File sourceDirectory, ExternalIdFactory externalIdFactory) {
+    public OpamTreeParser(Gson gson, File sourceDirectory, ExternalIdFactory externalIdFactory) {
+        this.gson = gson;
         this.sourceDirectory = sourceDirectory;
         this.externalIdFactory = externalIdFactory;
     }
 
-    public List<OpamParsedResult> parseTree(List<String> tree) {
-        currentProject = null;
-        currentGraph = new BasicDependencyGraph();
-        dependencyStack = new Stack<>();
+    public List<OpamParsedResult> parseJsonTreeFile(File outputFile) throws IOException {
+        if(outputFile == null || !outputFile.exists() || !outputFile.isFile()) {
+            logger.warn("Opam Tree output json does not exist, there seems to be an issue while running opam tree command.");
+            return codeLocations;
+        }
 
-
-        for(String line: tree) {
-            if(line.isEmpty() || line.startsWith("*") || line.startsWith("=")) {
-                continue;
+        try (JsonReader jsonReader = new JsonReader(new FileReader(outputFile))) {
+            OpamJsonFileModule opamTreeModule = gson.fromJson(jsonReader, OpamJsonFileModule.class);
+            for(OpamTreeProjectModule opamTreeProjectModule: opamTreeModule.opamProjects) {
+                if(opamTreeProjectModule != null) {
+                    processTreeJsonObject(opamTreeProjectModule);
+                }
             }
-
-            // if line starts with none of dependency indicator and starts with alphanumeric it may suggest the start of a new project
-            if(!StringUtils.startsWithAny(line, DEPENDENCY_INDICATOR) && !line.startsWith(" ")) {
-                initializeProject(line);
-                continue;
-            }
-
-            int previousLevel = level;
-            level = parseLevel(line);
-
-            Dependency dependency = parseDependencyLine(line);
-
-            if(dependency != null && currentProject != null) {
-                addDependencyToGraph(dependency, previousLevel);
-            }
-
+        } catch (IOException e) {
+            throw new IOException("There was an error while parsing the JSON file.",e);
         }
 
         return codeLocations;
     }
 
-    private Dependency parseDependencyLine(String line) {
-        String dependencyLine = StringUtils.trimToEmpty(line);
+    public void processTreeJsonObject(OpamTreeProjectModule opamTreeProjectModule){
+        if(opamTreeProjectModule != null) {
+            String projectName = opamTreeProjectModule.name;
+            String projectVersion = opamTreeProjectModule.version;
 
-        //Usually the dependency line will start like this "|-- package.v.e.r [*] (conditional)", so we get the substring after the
-        // package prefix and split it on basis of white space, after that we split on first occurrence of "."
-        dependencyLine = dependencyLine.substring(dependencyLine.indexOf(PACKAGE_PREFIX) + PACKAGE_PREFIX.length());
+            initializeProject(projectName, projectVersion);
 
-        String[] dependencyLineParts = dependencyLine.split(" +");
-        String dependencyString = dependencyLineParts[0];
+            if(!opamTreeProjectModule.dependencies.isEmpty()) {
+                collectCodeLocations(opamTreeProjectModule.dependencies, null);
+            }
 
-        String[] dependencyStringParts = dependencyString.split("\\.", 2);
-        if(dependencyStringParts.length == 2) {
-            return createDependencyExternalId(dependencyStringParts[0], dependencyStringParts[1]);
-        }
-
-        return null;
+        };
     }
 
-    private void addDependencyToGraph(Dependency dependency, int previousLevel) {
-        if(level == 0) { // add direct dependency to graph
-            currentGraph.addDirectDependency(dependency);
-            dependencyStack.clear(); //clear dependency stack for new transitives
-            dependencyStack.push(dependency);
-        } else {
-            if(level == previousLevel) { // indicates a sibling of previous dependency
-                dependencyStack.pop(); // pop the previous dependency and add current to head
-                currentGraph.addChildWithParent(dependency, dependencyStack.peek());
-                dependencyStack.push(dependency);
-            } else if(level > previousLevel) { // a child of dependency at head
-                currentGraph.addChildWithParent(dependency, dependencyStack.peek());
-                dependencyStack.push(dependency);
-            } else { // a child of dependency encountered earlier in the tree
-                while(previousLevel != level) {
-                    dependencyStack.pop();
-                    previousLevel--;
+    private void collectCodeLocations(List<OpamTreeDependencyModule> dependencyModules, Dependency parentDependency) {
+        for(OpamTreeDependencyModule dependencyModule: dependencyModules) {
+            if(dependencyModule != null) {
+                String packageName = dependencyModule.name;
+                String packageVersion = dependencyModule.version;
+
+                Dependency dependency = createDependencyExternalId(packageName, packageVersion);
+
+                if(parentDependency == null) {
+                    currentGraph.addDirectDependency(dependency);
+                } else {
+                    currentGraph.addChildWithParent(dependency, parentDependency);
                 }
-                currentGraph.addChildWithParent(dependency, dependencyStack.peek());
-                dependencyStack.push(dependency);
+
+                if(!dependencyModule.dependencies.isEmpty()) {
+                    collectCodeLocations(dependencyModule.dependencies, dependency);
+                }
             }
         }
     }
 
-    private int parseLevel(String line) {
-        if(line.startsWith(DIRECT_DEPENDENCY_INDICATOR)) {
-            return 0; // if direct return zero
+    private void initializeProject(String projectName, String projectVersion) {
+        Dependency projectDependency = createDependencyExternalId(projectName, projectVersion); // create a dependency for the project
+        currentGraph = new BasicDependencyGraph();
+        String codeLocationPath = sourceDirectory.getPath();
+        if(!codeLocationPath.endsWith(projectDependency.getName())) { // get the source code for the project using specific opam file
+            codeLocationPath = "/" + projectDependency.getName();
         }
-
-        String modifiedLine = DetectableStringUtils.removeEvery(line, DEPENDENCY_INDICATOR); // this will remove every thing after the start of the dependency
-
-        if(!modifiedLine.startsWith("|") && modifiedLine.startsWith(" ")) {
-            modifiedLine = "|" + modifiedLine;
-        }
-
-        modifiedLine = modifiedLine.replace("     ", "    |"); // replace with "|", if there are extra number of spaces in the middle
-        return StringUtils.countMatches(modifiedLine, "|"); // the number of "|" will be the level of the transitive dependency
+        CodeLocation codeLocation = new CodeLocation(currentGraph, projectDependency.getExternalId(), new File(codeLocationPath));
+        codeLocations.add(new OpamParsedResult(projectName, projectName, codeLocation)); // create a new opam parsed result for the project being initialized
     }
 
-    private void initializeProject(String line) {
-        String[] projectParts = line.split("\\.", 2);
 
-        // Usually the project syntax looks like: reason.3.8.2, so we split on the first occurrence of "."
-        if(projectParts.length == 2) {
-            Dependency projectDependency = createDependencyExternalId(projectParts[0], projectParts[1]); // create a dependency for the project
-            currentGraph = new BasicDependencyGraph();
-            currentProject = projectParts[0];
-            String codeLocationPath = sourceDirectory.getPath();
-            if(!codeLocationPath.endsWith(projectDependency.getName())) { // get the source code for the project using specific opam file
-                codeLocationPath = "/" + projectDependency.getName();
-            }
-            CodeLocation codeLocation = new CodeLocation(currentGraph, projectDependency.getExternalId(), new File(codeLocationPath));
-            codeLocations.add(new OpamParsedResult(projectParts[0], projectParts[1], codeLocation)); // create a new opam parsed result for the project being initialized
-        } else {
-            logger.debug(String.format("%s does not look like a dependency we can parse", line));
-        }
-    }
 
     private Dependency createDependencyExternalId(String name, String version) {
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.OPAM, name, version);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeParser.java
@@ -38,7 +38,7 @@ public class OpamTreeParser {
 
     public List<OpamParsedResult> parseJsonTreeFile(File outputFile) throws IOException {
         if(outputFile == null || !outputFile.exists() || !outputFile.isFile()) {
-            logger.warn("Opam Tree output json does not exist, there seems to be an issue while running opam tree command.");
+            logger.warn("The opamTreeOutput.json file does not exist, the file was deleted, or an issue occurred while running the opam tree command.");
             return codeLocations;
         }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeProjectModule.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/parse/OpamTreeProjectModule.java
@@ -1,0 +1,16 @@
+package com.blackduck.integration.detectable.detectables.opam.buildexe.parse;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class OpamTreeProjectModule {
+    @SerializedName("name")
+    public String name;
+
+    @SerializedName("version")
+    public String version;
+
+    @SerializedName("dependencies")
+    public List<OpamTreeDependencyModule> dependencies;
+}

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
@@ -64,7 +64,7 @@ public class OpamLockFileParser {
             String version = matcher.group(2);
             if(version.contains("=")) {
                 version = version.replace("= ",""); // remove = from version
-                version = version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")); // remove " from version
+                version = version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")); // get version between ""
             }
             parsedLockedOpamDependencies.put(packageName, version);
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
@@ -64,7 +64,7 @@ public class OpamLockFileParser {
             String version = matcher.group(2);
             if(version.contains("=")) {
                 version = version.replace("= ",""); // remove = from version
-                version = version.replace("\"",""); // remove " from version
+                version = version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")); // remove " from version
             }
             parsedLockedOpamDependencies.put(packageName, version);
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -25,10 +25,6 @@ public class OpamFileParser {
     private boolean inVersionSection = false;
     private boolean inDependsSection = false;
 
-    public OpamFileParser() {
-        // We do not need any variables to be initialized so keeping it default
-    }
-
     //have a separate parseData and parse method to use for parsing opam show command, as it gives output in file format
     public OpamParsedResult parse(File opamFile) {
         List<String> parsedOpamDependencies = new ArrayList<>();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -23,8 +23,10 @@ public class OpamFileParser {
     private static final String DEPENDS = "depends";
     private static final String NAME = "name";
     private boolean inVersionSection = false;
+    private boolean inDependsSection = false;
 
     public OpamFileParser() {
+        // We do not need any variables to be initialized so keeping it default
     }
 
     //have a separate parseData and parse method to use for parsing opam show command, as it gives output in file format
@@ -63,7 +65,6 @@ public class OpamFileParser {
         Map<String, String> output = new HashMap<>();
         Set<String> dependsSection = new HashSet<>();
         Pattern pattern = Pattern.compile("\"([^\"]+)\"");
-        boolean inDependsSection = false;
 
 
         for (String line : lines) {
@@ -81,18 +82,7 @@ public class OpamFileParser {
                 output.put(NAME, line.split(":")[1]);
             }
 
-            // parse depends section
-            // sometimes, depends contains dependencies in one line, so we have to parse them differently
-            // than normal opam files. Eg: depends: ["ocaml" "dune"], otherwise all the dependencies are present in different lines
-            if (line.startsWith("depends:")) {
-                inDependsSection = true;
-                if(line.contains("]")) {
-                    handleSameLineDependencies(line, dependsSection, pattern);
-                    inDependsSection = false;
-                }
-            } else if (inDependsSection && line.startsWith("]")) {
-                inDependsSection = false;
-            }
+            checkDependsSection(line, dependsSection, pattern);
 
             if (inDependsSection) {
                 addDependencyToList(line, dependsSection, pattern); // add dependency to list
@@ -105,6 +95,21 @@ public class OpamFileParser {
         }
 
         return output;
+    }
+
+    private void checkDependsSection(String line, Set<String> dependsSection, Pattern pattern) {
+        // parse depends section
+        // sometimes, depends contains dependencies in one line, so we have to parse them differently
+        // than normal opam files. Eg: depends: ["ocaml" "dune"], otherwise all the dependencies are present in different lines
+        if (line.startsWith("depends:")) {
+            inDependsSection = true;
+            if(line.contains("]")) {
+                handleSameLineDependencies(line, dependsSection, pattern);
+                inDependsSection = false;
+            }
+        } else if (inDependsSection && line.startsWith("]")) {
+            inDependsSection = false;
+        }
     }
 
     //parse the opam depends line as Eg: depends: ["ocaml" "dune"]

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
@@ -36,7 +36,7 @@ public class OpamGraphTransformer {
     private final ExternalIdFactory externalIdFactory;
     private final DetectableExecutableRunner executableRunner;
     Map<Dependency, Set<Dependency>> visitedDependenciesGraph = new HashMap<>();
-    private static final String ORPHAN_PARENT_NAME = "Transitive_Dependencies";
+    private static final String ORPHAN_PARENT_NAME = "Additional_Components";
     private static final String ORPHAN_PARENT_VERSION = "none";
 
     public OpamGraphTransformer(File sourceDirectory, ExternalIdFactory externalIdFactory, DetectableExecutableRunner executableRunner) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
@@ -123,7 +123,7 @@ public class OpamGraphTransformer {
 
             Map<String, String> parsedOutput = parser.parseData(output); // parse opam show output
 
-            String version = parsedOutput.get(VERSION).trim().replaceAll("\"","");
+            String version = parsedOutput.get(VERSION).trim().replace("\"","");
 
             Dependency createdDependency = createExternalId(dependency, version); // create dependency with name and version
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/transform/OpamGraphTransformer.java
@@ -36,6 +36,9 @@ public class OpamGraphTransformer {
     private final ExternalIdFactory externalIdFactory;
     private final DetectableExecutableRunner executableRunner;
     Map<Dependency, Set<Dependency>> visitedDependenciesGraph = new HashMap<>();
+    private static final String ORPHAN_PARENT_NAME = "Transitive_Dependencies";
+    private static final String ORPHAN_PARENT_VERSION = "none";
+
     public OpamGraphTransformer(File sourceDirectory, ExternalIdFactory externalIdFactory, DetectableExecutableRunner executableRunner) {
         this.sourceDirectory = sourceDirectory;
         this.externalIdFactory = externalIdFactory;
@@ -92,12 +95,21 @@ public class OpamGraphTransformer {
         List<String> directDependencies = opamParsedResult.getParsedDirectDependencies();
         Map<String, String> opamLockDependencies = opamParsedResult.getLockFileDependencies();
 
+        Dependency orphanParentDependency = createExternalId(ORPHAN_PARENT_NAME, ORPHAN_PARENT_VERSION);
+
         //match direct dependencies found in opam files with all the resolved packages from lock files to generate graph
         for(String dependency: opamLockDependencies.keySet()) {
             if(directDependencies.contains(dependency)) {
                 String packageVersion = opamLockDependencies.get(dependency);
                 Dependency directDependency = createExternalId(dependency, packageVersion); //convert to OPAM dependency
                 dependencyGraph.addDirectDependency(directDependency); //add Dependency to root
+            } else {
+                if(!dependencyGraph.hasDependency(orphanParentDependency)) {
+                    dependencyGraph.addChildrenToRoot(orphanParentDependency);
+                }
+                String packageVersion = opamLockDependencies.get(dependency);
+                Dependency transitiveDependency = createExternalId(dependency, packageVersion);
+                dependencyGraph.addChildWithParent(transitiveDependency, orphanParentDependency);
             }
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/factory/DetectableFactory.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/factory/DetectableFactory.java
@@ -1133,7 +1133,7 @@ public class DetectableFactory {
     }
 
     private OpamTreeParser opamTreeParser(File sourceDirectory) {
-        return new OpamTreeParser(sourceDirectory, externalIdFactory);
+        return new OpamTreeParser(gson, sourceDirectory, externalIdFactory);
     }
 
     private OpamBuildExtractor opamBuildExtractor(File sourceDirectory) {

--- a/documentation/src/main/markdown/packagemgrs/opam.md
+++ b/documentation/src/main/markdown/packagemgrs/opam.md
@@ -21,7 +21,7 @@ exe to be present on your $PATH. You can also override the location for `opam` e
 The OPAM Build Detector will work in the following way on your project:
 
 1. [detect_product_short] OPAM Build Detector will run `opam --version` to get the version of opam on your machine.
-2. If the version of opam is greater than or equal to 2.2.0, then [detect_product_short] will run the command `opam tree . --with-test --with-doc --with-dev --recursive --json=JSON_FILE_OUTPUT_PATH` if the version of opam is equal to, or greater than 
+2. [detect_product_short] will run the command `opam tree . --with-test --with-doc --with-dev --recursive --json=JSON_FILE_OUTPUT_PATH` if the version of opam is equal to, or greater than 
 2.2.0 to generate an opamTreeOutput.json file of resolved packages installed in the current project [switch](https://opam.ocaml.org/doc/Manual.html#Switches).
 The opamTreeOutput.json file will be stored in {user home directory}/blackduck/{run directory}/extractions and parsed by [detect_product_short] to generate the output of the scan.
 <note type="note">You must have all prerequisites for the project set up on your machine (e.g., the opam switch where your packages for the project are installed), before running [detect_product_short].</note>

--- a/documentation/src/main/markdown/packagemgrs/opam.md
+++ b/documentation/src/main/markdown/packagemgrs/opam.md
@@ -21,8 +21,9 @@ exe to be present on your $PATH. You can also override the location for `opam` e
 The OPAM Build Detector will work in the following way on your project:
 
 1. [detect_product_short] OPAM Build Detector will run `opam --version` to get the version of opam on your machine.
-2. If the version of opam is greater than or equal to 2.2.0, then [detect_product_short] would run `opam tree . --with-test --with-doc --with-dev --recursive`
-to get the list of resolved packages installed in the current [switch](https://ocaml.org/docs/opam-switch-introduction#opam-switch-introduction) for the project.
+2. If the version of opam is greater than or equal to 2.2.0, then [detect_product_short] would run `opam tree . --with-test --with-doc --with-dev --recursive --json=JSON_FILE_OUTPUT_PATH`
+to get a json file of resolved packages installed in the current [switch](https://ocaml.org/docs/opam-switch-introduction#opam-switch-introduction) for the project. 
+The JSON file will be present in '{user home directory}/blackduck/{run directory}/extractions'. [detect_product_short] will parse the JSON file to generate the output of the scan.
 <note type="note">You must have all prerequisites for the project set up on your machine (e.g., the opam switch where your packages for the project are installed), before running [detect_product_short].</note>
 3. If the version constraint for 2.2.0 is not satisfied, or the tree commands fails for an unknown reason, [detect_product_short] will parse all dependencies found in the `<pkgname>.opam` files.
    For each of the parsed dependencies, [detect_product_short]  will run `opam show <pkgname>` recursively to find all transitive dependencies of the project.
@@ -31,6 +32,9 @@ to get the list of resolved packages installed in the current [switch](https://o
 
 ## OPAM Lock Detector
 
-The OPAM Lock Detector does not find transitives for the project and is considered a LOW accuracy Detector. OPAM Lock Detector will run if HIGH accuracy Detectors cannot, and the project contains `<pkgname>.opam.locked` and `<pkgname>.opam` files in the top level directory.
+The OPAM Lock Detector is considered a LOW accuracy Detector. OPAM Lock Detector will run if HIGH accuracy Detectors cannot, and the project contains `<pkgname>.opam.locked` and `<pkgname>.opam` files in the top level directory.
 
-OPAM Lock Detector will parse both `<pkgname>.opam.` and `<pkgname>.opam.locked` files to gather the list of direct project dependencies.
+OPAM Lock Detector will parse both `<pkgname>.opam` and `<pkgname>.opam.locked` files to gather the list of dependencies.
+
+OPAM Lock Detector will declare a dependency as direct by checking if the dependency is present in both  `<pkgname>.opam` and `<pkgname>.opam.locked` file. Else the dependency will be deemed as transitive. 
+From this information, [detect_product_short] cannot conclude the position of the transitive dependency in the graph, so [detect_product_short] will place the dependency under a placeholder "component" named *Transitive_Dependencies*.

--- a/documentation/src/main/markdown/packagemgrs/opam.md
+++ b/documentation/src/main/markdown/packagemgrs/opam.md
@@ -37,4 +37,4 @@ The OPAM Lock Detector is considered a LOW accuracy Detector. OPAM Lock Detector
 OPAM Lock Detector will parse both `<pkgname>.opam` and `<pkgname>.opam.locked` files to gather the list of dependencies.
 
 OPAM Lock Detector will declare a dependency as direct if the dependency is present in both `<pkgname>.opam` and `<pkgname>.opam.locked` file. Otherwise, the dependency will be deemed as transitive.
-Based on the information available, [detect_product_short] cannot determine the position of the transitive dependency in the graph, and will note the dependency under a placeholder "component" named *Additional_Components*.
+Based on the information available, [detect_product_short] cannot determine the position of the transitive dependency in the graph, and will note the dependency under a placeholder "parent component" named *Additional_Components*.

--- a/documentation/src/main/markdown/packagemgrs/opam.md
+++ b/documentation/src/main/markdown/packagemgrs/opam.md
@@ -21,9 +21,9 @@ exe to be present on your $PATH. You can also override the location for `opam` e
 The OPAM Build Detector will work in the following way on your project:
 
 1. [detect_product_short] OPAM Build Detector will run `opam --version` to get the version of opam on your machine.
-2. If the version of opam is greater than or equal to 2.2.0, then [detect_product_short] would run `opam tree . --with-test --with-doc --with-dev --recursive --json=JSON_FILE_OUTPUT_PATH`
-to get a json file of resolved packages installed in the current [switch](https://ocaml.org/docs/opam-switch-introduction#opam-switch-introduction) for the project. 
-The JSON file will be present in '{user home directory}/blackduck/{run directory}/extractions'. [detect_product_short] will parse the JSON file to generate the output of the scan.
+2. If the version of opam is greater than or equal to 2.2.0, then [detect_product_short] will run the command `opam tree . --with-test --with-doc --with-dev --recursive --json=JSON_FILE_OUTPUT_PATH` if the version of opam is equal to, or greater than 
+2.2.0 to generate an opamTreeOutput.json file of resolved packages installed in the current project [switch](https://opam.ocaml.org/doc/Manual.html#Switches).
+The opamTreeOutput.json file will be stored in {user home directory}/blackduck/{run directory}/extractions and parsed by [detect_product_short] to generate the output of the scan.
 <note type="note">You must have all prerequisites for the project set up on your machine (e.g., the opam switch where your packages for the project are installed), before running [detect_product_short].</note>
 3. If the version constraint for 2.2.0 is not satisfied, or the tree commands fails for an unknown reason, [detect_product_short] will parse all dependencies found in the `<pkgname>.opam` files.
    For each of the parsed dependencies, [detect_product_short]  will run `opam show <pkgname>` recursively to find all transitive dependencies of the project.
@@ -36,5 +36,5 @@ The OPAM Lock Detector is considered a LOW accuracy Detector. OPAM Lock Detector
 
 OPAM Lock Detector will parse both `<pkgname>.opam` and `<pkgname>.opam.locked` files to gather the list of dependencies.
 
-OPAM Lock Detector will declare a dependency as direct by checking if the dependency is present in both  `<pkgname>.opam` and `<pkgname>.opam.locked` file. Else the dependency will be deemed as transitive. 
-From this information, [detect_product_short] cannot conclude the position of the transitive dependency in the graph, so [detect_product_short] will place the dependency under a placeholder "component" named *Transitive_Dependencies*.
+OPAM Lock Detector will declare a dependency as direct if the dependency is present in both `<pkgname>.opam` and `<pkgname>.opam.locked` file. Otherwise, the dependency will be deemed as transitive.
+Based on the information available, [detect_product_short] cannot determine the position of the transitive dependency in the graph, and will note the dependency under a placeholder "component" named *Additional_Components*.


### PR DESCRIPTION
This PR is a fix for ticket IDETECT-4575 where the output of the tree was different in other environments using the CLI parser causing a corrupted BDIO to be generated. The fix is to generate and use the --json option provided by OPAM to create and parse the json file to get all the dependencies. An example json file is attached to the ticket.

Also, there are some sonarcloud fixes from the earlier commits.

For Opam Lock Detector, there was an error while parsing version so rectified that and also instead of omitting transitive dependencies from Lock File, we will create a new unmatched transitive parent component and then add transitives as child of that component. (Similar to what we do in our Maven CLI Detector.)