### PR TITLE
Fix IDETECT-4576: Wrong project name parsing

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/OpamLockFileExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/OpamLockFileExtractor.java
@@ -3,7 +3,6 @@ package com.blackduck.integration.detectable.detectables.opam.lockfile;
 import com.blackduck.integration.detectable.detectables.opam.lockfile.parse.OpamLockFileParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamFileParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamParsedResult;
-import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.common.util.Bds;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.opam.transform.OpamGraphTransformer;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
@@ -66,7 +66,7 @@ public class OpamLockFileParser {
                 version = version.replace("= ",""); // remove = from version
                 version = version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")); // get version between ""
                 if(version.contains("+")) {
-                    version = version.split("\\+")[0];
+                    version = version.split("\\+")[0]; // Edge case where version is like this: {"0.7.0+dune"}
                 }
             }
             parsedLockedOpamDependencies.put(packageName, version);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/lockfile/parse/OpamLockFileParser.java
@@ -65,6 +65,9 @@ public class OpamLockFileParser {
             if(version.contains("=")) {
                 version = version.replace("= ",""); // remove = from version
                 version = version.substring(version.indexOf("\"") + 1, version.lastIndexOf("\"")); // get version between ""
+                if(version.contains("+")) {
+                    version = version.split("\\+")[0];
+                }
             }
             parsedLockedOpamDependencies.put(packageName, version);
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -72,22 +72,12 @@ public class OpamFileParser {
 
             if (line.startsWith("version:")) {
                 //parse version
-                String version = line.split(":")[1];
-                Matcher matcher = pattern.matcher(version);
-                if (matcher.find()) {
-                    version = matcher.group(1);
-                }
-                output.put(VERSION, version);
+                addProjectNameAndVersion(line, output, pattern, VERSION);
             }
 
             if (line.startsWith("name:")) {
-                // parse package name
-                String name = line.split(":")[1];
-                Matcher matcher = pattern.matcher(name);
-                if (matcher.find()) {
-                    name = matcher.group(1);
-                }
-                output.put(NAME, name);
+                // parse project name
+                addProjectNameAndVersion(line, output, pattern, NAME);
             }
 
             checkDependsSection(line, dependsSection, pattern);
@@ -103,6 +93,22 @@ public class OpamFileParser {
         }
 
         return output;
+    }
+
+    private void addProjectNameAndVersion(String line, Map<String, String> output, Pattern pattern, String parsingValue) {
+        String value = line.split(":")[1];
+        Matcher matcher = pattern.matcher(value);
+        if (matcher.find()) {
+            value = matcher.group(1);
+        }
+
+        if(parsingValue.equals(NAME)) {
+            output.put(NAME, value);
+        } else {
+            output.put(VERSION, value);
+        }
+
+
     }
 
     private void checkDependsSection(String line, Set<String> dependsSection, Pattern pattern) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -136,7 +136,7 @@ public class OpamFileParser {
         Matcher matcher = pattern.matcher(line);
         if (matcher.find()) {
             String packageName = matcher.group(1);
-            if(!packageName.equals("cc")) {
+            if(!packageName.equals("cc") && !packageName.equals("arm64") && !packageName.equals("win32") && !packageName.equals("x86_64")) {
                 dependsSection.add(packageName);
             }
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -70,12 +70,24 @@ public class OpamFileParser {
                 continue;
             }
 
-            if (line.startsWith("version:")) { // parse version
-                output.put(VERSION, line.split(":")[1]);
+            if (line.startsWith("version:")) {
+                //parse version
+                String version = line.split(":")[1];
+                Matcher matcher = pattern.matcher(version);
+                if (matcher.find()) {
+                    version = matcher.group(1);
+                }
+                output.put(VERSION, version);
             }
 
-            if (line.startsWith("name:")) { // parse package name
-                output.put(NAME, line.split(":")[1]);
+            if (line.startsWith("name:")) {
+                // parse package name
+                String name = line.split(":")[1];
+                Matcher matcher = pattern.matcher(name);
+                if (matcher.find()) {
+                    name = matcher.group(1);
+                }
+                output.put(NAME, name);
             }
 
             checkDependsSection(line, dependsSection, pattern);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/parse/OpamFileParser.java
@@ -101,14 +101,7 @@ public class OpamFileParser {
         if (matcher.find()) {
             value = matcher.group(1);
         }
-
-        if(parsingValue.equals(NAME)) {
-            output.put(NAME, value);
-        } else {
-            output.put(VERSION, value);
-        }
-
-
+        output.put(parsingValue, value);
     }
 
     private void checkDependsSection(String line, Set<String> dependsSection, Pattern pattern) {


### PR DESCRIPTION
This PR fixes an issue IDETECT-4576 where the name of the project name was getting wrongly parsed with double quotes `"project-name"` causing BD to fail on rescan cause it can't allow projects with same name.