### PR TITLE
Update statusCode in status.json to reflect failure reason during detector cascade

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutputManager.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/report/output/FormattedOutputManager.java
@@ -154,7 +154,7 @@ public class FormattedOutputManager {
             detectorToolResult.getDetectorReports().forEach(report -> {
                 report.getExtractedDetectors().forEach(extracted -> {
                     extracted.getAttemptedDetectables().stream()
-                        .map(attempted -> convertAttempted(report.getDirectory(), extracted.getRule().getDetectorType(), attempted, "ATTEMPTED", DetectorStatusCode.ATTEMPTED))
+                        .map(attempted -> convertAttempted(report.getDirectory(), extracted.getRule().getDetectorType(), attempted, "ATTEMPTED", attempted.getStatusCode()))
                         .forEach(outputs::add);
 
                     outputs.add(convertExtracted(report.getDirectory(), extracted.getRule().getDetectorType(), extracted.getExtractedDetectable(), "SUCCESS"));


### PR DESCRIPTION
# Description

This update ensures that the statusCode in the status.json file reflects the failure reason when all HIGH accuracy detectors fail but the LOW accuracy detector passes. Currently, the statusCode remains as "ATTEMPTED," which is inconsistent with cases where all detectors fail. The change aligns statusCode with the failure reason for consistency.