### PR TITLE
Fix for clang regressions due to sonar fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA4-dmamidibd-patch-revert-tounblockartifactorychecks'
+version = '10.2.0-SIGQA5-dmamidibd-patch-revert-tounblockartifactorychecks'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA7-dmamidibd-patch-revert-tounblockartifactorychecks-SNAPSHOT'
+version = '10.2.0-SIGQA2'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA6-dmamidibd-patch-revert-tounblockartifactorychecks'
+version = '10.2.0-SIGQA7-dmamidibd-patch-revert-tounblockartifactorychecks-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA2'
+version = '10.2.0-SIGQA3-dmamidibd-patch-revert-tounblockartifactorychecks'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA3-dmamidibd-patch-revert-tounblockartifactorychecks'
+version = '10.2.0-SIGQA4-dmamidibd-patch-revert-tounblockartifactorychecks'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA5-dmamidibd-patch-revert-tounblockartifactorychecks'
+version = '10.2.0-SIGQA6-dmamidibd-patch-revert-tounblockartifactorychecks'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
@@ -35,10 +35,10 @@ public class DependencyListFileParser {
         String depsListString = depsMkTextParts[1];
         logger.trace(String.format("dependencies: %s", depsListString));
 
-        depsListString = depsListString.replaceAll("\n", " ");
+        depsListString = depsListString.replace("\n", " ");
         logger.trace(String.format("dependencies, newlines removed: %s", depsListString));
 
-        depsListString = depsListString.replaceAll("\\\\", " "); //TODO: This does not work on Windows paths.
+        depsListString = depsListString.replace("\\", " "); //TODO: This does not work on Windows paths.
         logger.trace(String.format("dependencies, backslashes removed: %s", depsListString));
 
         String[] deps = depsListString.split("\\s+");

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
@@ -38,7 +38,7 @@ public class DependencyListFileParser {
         depsListString = depsListString.replaceAll("\n", " ");
         logger.trace(String.format("dependencies, newlines removed: %s", depsListString));
 
-        depsListString = depsListString.replace("\\\\", " "); //TODO: This does not work on Windows paths.
+        depsListString = depsListString.replaceAll("\\\\", " "); //TODO: This does not work on Windows paths.
         logger.trace(String.format("dependencies, backslashes removed: %s", depsListString));
 
         String[] deps = depsListString.split("\\s+");

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/clang/dependencyfile/DependencyListFileParser.java
@@ -35,7 +35,7 @@ public class DependencyListFileParser {
         String depsListString = depsMkTextParts[1];
         logger.trace(String.format("dependencies: %s", depsListString));
 
-        depsListString = depsListString.replace("\n", " ");
+        depsListString = depsListString.replaceAll("\n", " ");
         logger.trace(String.format("dependencies, newlines removed: %s", depsListString));
 
         depsListString = depsListString.replace("\\\\", " "); //TODO: This does not work on Windows paths.


### PR DESCRIPTION
This PR addresses fix for two functional regressions caused by recent sonar fixes. The two tests failing are below blocking dev, comprehensive and release-qa pipelines (Noticed this as I was blocked to perform validation of AWS migration and artifactory migration to AWS yesterday)

DependencyListFileParserTest.testNonCanonical 
DependencyListFileParserTest.testSimple

replaceAll was changed to replace as suggested by Sonar in an PR yesterday, but in Java 
Two backslashes: This represents a single backslash in a Java string literal and 
Four backslashes: This represents a single backslash in a regular expression within a Java string literal.

So when replaceAll was changed to replace which takes first parameter as not a regular expression, we should just use two backslashes which is equivalent to replaceAll with four backslashes 

With this change, functional tests do pass now and all pipelines pass.




