### PR TITLE
Patch updated for two transitives to resolve purported vulnerabilities.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ dependencies {
         implementation('org.apache.james:apache-mime4j-core:0.8.10') {
             because 'previous version has a vulnerability'
         }
-        implementation('org.bouncycastle:bcutil-jdk18on:1.78') {
+        implementation('org.bouncycastle:bcutil-jdk18on:1.78.0') {
             because 'previous version has a vulnerability'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,12 @@ dependencies {
         implementation('ch.qos.logback:logback-core:1.2.13') {
             because 'previous version has a vulnerability'
         }
+        implementation('org.apache.james:apache-mime4j-core:0.8.10') {
+            because 'previous version has a vulnerability'
+        }
+        implementation('org.bouncycastle:bcutil-jdk18on:1.78') {
+            because 'previous version has a vulnerability'
+        }
     }
 
     // spring-boot-starter-test *can* provide these, but we choose to be more explicit about the dependencies we ACTUALLY use


### PR DESCRIPTION
# Description

Remediate the following transitives due to previous version reported to have vulnerabilities:
org.bouncycastle_bcprov-jdk18on  1.76 -> 1.78
org.apache.james_apache-mime4j-core 0.8.9 -> 0.8.10

# Github Issues
IDETECT-4560
