### PR TITLE
Fix failing test due to component name change in Black Duck

### DIFF
--- a/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/GradleNativeInspectorTests.java
@@ -114,7 +114,7 @@ public class GradleNativeInspectorTests {
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4j", "2.22.1");
             blackduckAssertions.checkComponentVersionExists("graphql-java", "18.2");
             blackduckAssertions.checkComponentVersionNotExists("SLF4J API Module", "2.0.4");
-            blackduckAssertions.checkComponentVersionExists("google-guava", "v29.0");
+            blackduckAssertions.checkComponentVersionExists("googleguava", "v29.0");
             blackduckAssertions.checkComponentVersionNotExists("Apache Log4J API", "2.22.1");
 
         }


### PR DESCRIPTION
# Description

The component name in Black Duck changed so this assertion started to fail.
There might be a better way to design this and similar tests in the future and I welcome suggestions; however, at this point we want to unblock builds ASAP.
