### PR TITLE
Return a Unique Exit Code for Out of Memory Incidents  

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detect.configuration.enumeration;
 
 public enum ExitCodeType {
+    FAILURE_OUT_OF_MEMORY(-1, "Detect encountered an Out of Memory error. Please review memory settings and system resources."),
     SUCCESS(0, "Detect exited successfully."),
     FAILURE_BLACKDUCK_CONNECTIVITY(1, "Detect was unable to connect to Black Duck. Check your configuration and connection."),
     FAILURE_TIMEOUT(2, "Detect was unable to wait for actions to be completed on Black Duck. Check your Black Duck server or increase your timeout."),

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -59,9 +59,9 @@ public enum ExitCodeType {
         } else if (second.isSuccess()) {
             return first;
         } else {
-            if (first.priority < second.priority) {
+            if (first.getPriority() < second.getPriority()) {
                 return first;
-            } else if (second.priority < first.priority) {
+            } else if (second.getPriority() < first.getPriority()) {
                 return second;
             } else {
                 return (first.getExitCode() < second.getExitCode()) ? first : second;
@@ -80,4 +80,6 @@ public enum ExitCodeType {
     public String getDescription() {
         return description;
     }
+
+    public double getPriority() { return priority; }
 }

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -59,13 +59,7 @@ public enum ExitCodeType {
         } else if (second.isSuccess()) {
             return first;
         } else {
-            if (first.getPriority() < second.getPriority()) {
-                return first;
-            } else if (second.getPriority() < first.getPriority()) {
-                return second;
-            } else {
-                return (first.getExitCode() < second.getExitCode()) ? first : second;
-            }
+            return (first.getPriority() < second.getPriority()) ? first : second;
         }
     }
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -1,7 +1,6 @@
 package com.blackduck.integration.detect.configuration.enumeration;
 
 public enum ExitCodeType {
-    FAILURE_OUT_OF_MEMORY(-1, "Detect encountered an Out of Memory error. Please review memory settings and system resources."),
     SUCCESS(0, "Detect exited successfully."),
     FAILURE_BLACKDUCK_CONNECTIVITY(1, "Detect was unable to connect to Black Duck. Check your configuration and connection."),
     FAILURE_TIMEOUT(2, "Detect was unable to wait for actions to be completed on Black Duck. Check your Black Duck server or increase your timeout."),
@@ -26,6 +25,7 @@ public enum ExitCodeType {
     ),
 
     FAILURE_ACCURACY_NOT_MET(15, "Detect was unable to meet the required accuracy."),
+    FAILURE_OUT_OF_MEMORY(16, "Detect encountered an Out of Memory error. Please review memory settings and system resources."),
 
     FAILURE_IMAGE_NOT_AVAILABLE(20, "Image scan attempted but no return data available."),
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -25,7 +25,7 @@ public enum ExitCodeType {
     ),
 
     FAILURE_ACCURACY_NOT_MET(15, "Detect was unable to meet the required accuracy."),
-    FAILURE_OUT_OF_MEMORY(16, "Detect encountered an Out of Memory error. Please review memory settings and system resources."),
+    FAILURE_OUT_OF_MEMORY(16, "Detect encountered an Out of Memory error. Please review memory settings and system resources.", 0.5),
 
     FAILURE_IMAGE_NOT_AVAILABLE(20, "Image scan attempted but no return data available."),
 
@@ -36,14 +36,22 @@ public enum ExitCodeType {
 
     private final int exitCode;
     private final String description;
+    private final double priority;
 
     ExitCodeType(int exitCode, String description) {
+        this(exitCode, description, (double) exitCode);
+    }
+
+    ExitCodeType(int exitCode, String description, double priority) {
         this.exitCode = exitCode;
         this.description = description;
+        this.priority = priority;
     }
 
     /**
-     * A failure always beats a success and a failure with a lower exit code beats a failure with a higher exit code.
+     * A failure always beats a success. Among failures:
+     * - The one with a lower priority wins.
+     * - If priorities are equal, the one with a lower exit code wins.
      */
     public static ExitCodeType getWinningExitCodeType(ExitCodeType first, ExitCodeType second) {
         if (first.isSuccess()) {
@@ -51,10 +59,12 @@ public enum ExitCodeType {
         } else if (second.isSuccess()) {
             return first;
         } else {
-            if (first.getExitCode() < second.getExitCode()) {
+            if (first.priority < second.priority) {
                 return first;
-            } else {
+            } else if (second.priority < first.priority) {
                 return second;
+            } else {
+                return (first.getExitCode() < second.getExitCode()) ? first : second;
             }
         }
     }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
@@ -6,6 +6,8 @@ import java.util.List;
 import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
 import com.blackduck.integration.detect.workflow.event.Event;
 import com.blackduck.integration.detect.workflow.event.EventSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExitCodeManager {
     private final List<ExitCodeRequest> exitCodeRequests = new ArrayList<>();
@@ -33,12 +35,6 @@ public class ExitCodeManager {
         for (ExitCodeRequest exitCodeRequest : exitCodeRequests) {
             winningExitCodeType = ExitCodeType.getWinningExitCodeType(winningExitCodeType, exitCodeRequest.getExitCodeType());
         }
-
-        if (!winningExitCodeType.isSuccess() &&
-            exitCodeRequests.stream().anyMatch(request -> request.getExitCodeType() == ExitCodeType.FAILURE_OUT_OF_MEMORY)) {
-            return ExitCodeType.FAILURE_OUT_OF_MEMORY;
-        }
-
         return winningExitCodeType;
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
@@ -6,8 +6,6 @@ import java.util.List;
 import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
 import com.blackduck.integration.detect.workflow.event.Event;
 import com.blackduck.integration.detect.workflow.event.EventSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ExitCodeManager {
     private final List<ExitCodeRequest> exitCodeRequests = new ArrayList<>();

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/shutdown/ExitCodeManager.java
@@ -33,6 +33,12 @@ public class ExitCodeManager {
         for (ExitCodeRequest exitCodeRequest : exitCodeRequests) {
             winningExitCodeType = ExitCodeType.getWinningExitCodeType(winningExitCodeType, exitCodeRequest.getExitCodeType());
         }
+
+        if (!winningExitCodeType.isSuccess() &&
+            exitCodeRequests.stream().anyMatch(request -> request.getExitCodeType() == ExitCodeType.FAILURE_OUT_OF_MEMORY)) {
+            return ExitCodeType.FAILURE_OUT_OF_MEMORY;
+        }
+
         return winningExitCodeType;
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
@@ -7,8 +7,13 @@ import com.blackduck.integration.detect.tool.detector.report.DetectorDirectoryRe
 import com.blackduck.integration.detect.workflow.status.DetectIssue;
 import com.blackduck.integration.detect.workflow.status.DetectIssueType;
 import com.blackduck.integration.detect.workflow.status.StatusEventPublisher;
+import com.blackduck.integration.detector.base.DetectorStatusCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DetectorIssuePublisher {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     public void publishIssues(StatusEventPublisher statusEventPublisher, List<DetectorDirectoryReport> reports) {
         //TODO (detectors): just verify we don't want to publish 'attempted' when successfully extracted, right now publishing all attempted in not-extracted.
         String spacer = "\t";
@@ -23,6 +28,17 @@ public class DetectorIssuePublisher {
             });
 
         }
+    }
+    public boolean hasOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
+        logger.info("Checking for Out of Memory (OOM) Error.");
+
+        return reports.stream()
+            .flatMap(report -> report.getNotExtractedDetectors().stream())
+            .flatMap(notExtracted -> notExtracted.getAttemptedDetectables().stream())
+            .anyMatch(attemptedDetectableReport -> {
+                logger.debug("Attempted Detectable Status Code: {}", attemptedDetectableReport.getStatusCode());
+                return attemptedDetectableReport.getStatusCode() == DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY;
+            });
     }
 
 }

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
@@ -30,13 +30,10 @@ public class DetectorIssuePublisher {
         }
     }
     public boolean hasOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
-        logger.info("Checking for Out of Memory (OOM) Error.");
-
         return reports.stream()
             .flatMap(report -> report.getNotExtractedDetectors().stream())
             .flatMap(notExtracted -> notExtracted.getAttemptedDetectables().stream())
             .anyMatch(attemptedDetectableReport -> {
-                logger.debug("Attempted Detectable Status Code: {}", attemptedDetectableReport.getStatusCode());
                 return attemptedDetectableReport.getStatusCode() == DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY;
             });
     }

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorIssuePublisher.java
@@ -12,8 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DetectorIssuePublisher {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
     public void publishIssues(StatusEventPublisher statusEventPublisher, List<DetectorDirectoryReport> reports) {
         //TODO (detectors): just verify we don't want to publish 'attempted' when successfully extracted, right now publishing all attempted in not-extracted.
         String spacer = "\t";
@@ -29,6 +27,7 @@ public class DetectorIssuePublisher {
 
         }
     }
+
     public boolean hasOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
         return reports.stream()
             .flatMap(report -> report.getNotExtractedDetectors().stream())
@@ -37,5 +36,4 @@ public class DetectorIssuePublisher {
                 return attemptedDetectableReport.getStatusCode() == DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY;
             });
     }
-
 }

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
@@ -108,18 +108,20 @@ public class DetectorTool {
         List<DetectorDirectoryReport> reports = new DetectorReporter().generateReport(evaluation);
         DetectorToolResult toolResult = publishAllResults(reports, directory, projectDetector, requiredDetectors, requiredAccuracyTypes);
 
-        boolean outOfMemoryIssueFound = detectorIssuePublisher.hasOutOfMemoryIssue(reports);
-
-        if (outOfMemoryIssueFound) {
-            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY");
-            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
-        }
+        checkAndHandleOutOfMemoryIssue(reports);
 
         //Completed.
         logger.debug("Finished running detectors.");
         detectorEventPublisher.publishDetectorsComplete(toolResult);
 
         return toolResult;
+    }
+
+    private void checkAndHandleOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
+        if (detectorIssuePublisher.hasOutOfMemoryIssue(reports)) {
+            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY");
+            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
+        }
     }
 
     private DetectorToolResult publishAllResults(

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
@@ -111,7 +111,7 @@ public class DetectorTool {
         boolean outOfMemoryIssueFound = detectorIssuePublisher.hasOutOfMemoryIssue(reports);
 
         if (outOfMemoryIssueFound) {
-            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY.");
+            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY");
             exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
         }
 

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
@@ -108,6 +108,13 @@ public class DetectorTool {
         List<DetectorDirectoryReport> reports = new DetectorReporter().generateReport(evaluation);
         DetectorToolResult toolResult = publishAllResults(reports, directory, projectDetector, requiredDetectors, requiredAccuracyTypes);
 
+        boolean outOfMemoryIssueFound = detectorIssuePublisher.hasOutOfMemoryIssue(reports);
+
+        if (outOfMemoryIssueFound) {
+            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY.");
+            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
+        }
+
         //Completed.
         logger.debug("Finished running detectors.");
         detectorEventPublisher.publishDetectorsComplete(toolResult);

--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorTool.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import com.blackduck.integration.detector.base.DetectorStatusCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +120,7 @@ public class DetectorTool {
 
     private void checkAndHandleOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
         if (detectorIssuePublisher.hasOutOfMemoryIssue(reports)) {
-            logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY");
+            logger.error("Detected an issue. " + DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY.getDescription());
             exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
         }
     }

--- a/src/test/java/com/blackduck/integration/detect/configuration/ExitCodeTypeTest.java
+++ b/src/test/java/com/blackduck/integration/detect/configuration/ExitCodeTypeTest.java
@@ -1,0 +1,28 @@
+package com.blackduck.integration.detect.configuration;
+
+import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
+import org.junit.jupiter.api.Test;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExitCodeTypeTest {
+
+    @Test
+    void testUniquePriorities() {
+        Set<Double> priorities = new HashSet<>();
+        for (ExitCodeType exitCode : ExitCodeType.values()) {
+            assertTrue(priorities.add(exitCode.getPriority()),
+                "Duplicate priority found: " + exitCode.getPriority());
+        }
+    }
+
+    @Test
+    void testUniqueExitCodes() {
+        Set<Integer> exitCodes = new HashSet<>();
+        for (ExitCodeType exitCode : ExitCodeType.values()) {
+            assertTrue(exitCodes.add(exitCode.getExitCode()),
+                "Duplicate exit code found: " + exitCode.getExitCode());
+        }
+    }
+}


### PR DESCRIPTION
#### Ticket
IDETECT-3872

#### Summary  
This pull request implements a solution for handling "Out of Memory" (OOM) incidents in sub-processes by introducing a unique exit code. The changes ensure that OOM-related failures are appropriately identified and prioritized in the application's exit code logic.  

#### Key Changes  
1. **Detection of OOM Incidents**  
   - A new method, `hasOutOfMemoryIssue`, was added to the `DetectIssuePublisher` class.  
   - This method inspects `DetectorDirectoryReport` objects to identify if any sub-process has crashed due to an OOM incident (mapped to `DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY`).  
     
     ```java
     public boolean hasOutOfMemoryIssue(List<DetectorDirectoryReport> reports) {
         logger.info("Checking for Out of Memory (OOM) Error.");
         return reports.stream()
             .flatMap(report -> report.getNotExtractedDetectors().stream())
             .flatMap(notExtracted -> notExtracted.getAttemptedDetectables().stream())
             .anyMatch(attemptedDetectableReport -> {
                 logger.debug("Attempted Detectable Status Code: {}", attemptedDetectableReport.getStatusCode());
                 return attemptedDetectableReport.getStatusCode() == DetectorStatusCode.EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY;
             });
     }
     ```

2. **Publishing a New Exit Code**  
   - The `performDetectors` method in the `DetectorTool` class was updated to use the `hasOutOfMemoryIssue` method.  
   - If an OOM incident is detected, a new exit code (`FAILURE_OUT_OF_MEMORY`) is published via the `ExitCodePublisher`.  

     ```java
     boolean outOfMemoryIssueFound = detectorIssuePublisher.hasOutOfMemoryIssue(reports);
     if (outOfMemoryIssueFound) {
         logger.error("Detected an issue: EXECUTABLE_TERMINATED_LIKELY_OUT_OF_MEMORY.");
         exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_OUT_OF_MEMORY, "Executable terminated likely due to out of memory.");
     }
     ```

3. **Handling Exit Code Prioritization**  
   - The unique exit code for OOM incidents needed to take precedence in the application's exit code evaluation.  
   - The `getWinningExitCode` method in `ExitCodeManager` was modified to handle this special case, ensuring `FAILURE_OUT_OF_MEMORY` is correctly prioritized.  

     ```java
     public ExitCodeType getWinningExitCode() {
         ExitCodeType winningExitCodeType = ExitCodeType.SUCCESS;
         for (ExitCodeRequest exitCodeRequest : exitCodeRequests) {
             winningExitCodeType = ExitCodeType.getWinningExitCodeType(winningExitCodeType, exitCodeRequest.getExitCodeType());
         }

         if (!winningExitCodeType.isSuccess() &&
             exitCodeRequests.stream().anyMatch(request -> request.getExitCodeType() == ExitCodeType.FAILURE_OUT_OF_MEMORY)) {
             return ExitCodeType.FAILURE_OUT_OF_MEMORY;
         }

         return winningExitCodeType;
     }
     ```

4. **Challenges and Resolutions**  
   - Initially, a lower value exit code (e.g., `-1`) was tested to prioritize OOM errors, but it was deemed unsuitable for representing the failure state.  
   - Instead, the prioritization logic was incorporated into `getWinningExitCode` to allow for a meaningful and unique exit code without conflicting with existing exit codes.  

#### Testing  
- Simulated various OOM scenarios to verify detection and publishing of the custom exit code.  
- Confirmed that the modified `getWinningExitCode` logic correctly prioritizes the OOM exit code over other failure types.

#### Impact  
- Ensures better visibility and handling of OOM errors in sub-processes.  
- Avoids exit code conflicts by utilizing prioritization logic rather than relying solely on numeric values.  

#### Notes  
Please review the changes, especially the modifications in `getWinningExitCode`, to confirm alignment with our design principles.  

**_This update has been scheduled for Detect 10.4_**
