### PR TITLE
Log error when csv property is used against earlier servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.2.0-SIGQA11-SNAPSHOT'
+version = '10.3.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.3.0-SNAPSHOT'
+version = '10.2.0-SIGQA12-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -951,7 +951,7 @@ public class OperationRunner {
         throws OperationException {
         return auditLog.namedPublic("Create Online Signature Scan Batch", "OnlineSigScan",
             () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(), directoryManager, codeLocationNameManager)
-                .createScanBatchWithBlackDuck(detectRunUuid, projectNameVersion, scanPaths, blackDuckRunData.getBlackDuckServerConfig(), dockerTargetData)
+                .createScanBatchWithBlackDuck(detectRunUuid, projectNameVersion, scanPaths, blackDuckRunData, dockerTargetData)
         );
     }
 

--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
@@ -140,7 +140,7 @@ public class CreateScanBatchOperation {
             if (blackDuckRunData != null 
                     && blackDuckRunData.getBlackDuckServerVersion().isPresent()
                     && !blackDuckRunData.getBlackDuckServerVersion().get().isAtLeast(MIN_CSV_ARCHIVE_VERSION)) {
-                logger.error("CSV archive was requested but associated Black Duck server is not compatible.");
+                logger.error("The associated Black Duck server version is not compatible with the CSV archive feature.");
             }
             scanJobBuilder.csvArchive(signatureScannerOptions.getCsvArchive());        
         }


### PR DESCRIPTION
The new CSV archive feature works offline and against Black Duck servers 2025.1 and later. For earlier servers we should log an error as to why things are failing so the user can fix their configuration.