### PR TITLE
Remediate Jackson Core vulnerability with bump to BD Common library d…

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,3 +24,4 @@
 
 * (IDETECT-4447) - ID strings of detected Yarn project dependencies are now correctly formed. Related warning messages have been improved to identify entries in the yarn.lock file that have not been resolved through package.json files and could not be resolved with any standard NPM packages.
 * (IDETECT-4533) - Resolved an issue with [detect_product_short] Gradle Native Inspector causing scans to hang indefinitely when submodule has the same name as the parent module.
+* (IDETECT-4560) - Updated version of Jackson-Core (a transitive dependency) to address a vulnerability.

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,4 @@
 // Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
 // to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='67.0.3'
+gradle.ext.blackDuckCommonVersion='67.0.4'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
…ependency.

Remediate Jackson Core vulnerability with bump to BD Common library dependency.

# Description

Please include a short description of the changes and problems fixed.

# Github Issues

IDETECT-4560
