### PR TITLE
Fix: Logging Level Not Correctly Set from External Configuration Files

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/Application.java
+++ b/src/main/java/com/blackduck/integration/detect/Application.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -64,7 +65,10 @@ public class Application implements ApplicationRunner {
     
     private static final String STATUS_JSON_FILE_NAME = "status.json";
     public static final Long START_TIME = System.currentTimeMillis();
-
+    private static final String SPRING_CONFIG_LOCATION_ENV = "SPRING_CONFIG_LOCATION";
+    private static final String SPRING_CONFIG_LOCATION_PROPERTY = "spring.config.location";
+    private static final String LOGGING_GROUP_DETECT = "logging.group.detect";
+    private static final String DEFAULT_LOGGING_GROUP = "com.blackduck.integration";
     private final ConfigurableEnvironment environment;
 
     @Autowired
@@ -82,6 +86,7 @@ public class Application implements ApplicationRunner {
     }
 
     public static void main(String[] args) {
+        configureLoggingGroupIfNeeded(args);
         SpringApplicationBuilder builder = new SpringApplicationBuilder(Application.class);
         builder.logStartupInfo(false);
         boolean selfUpdated = false;
@@ -102,6 +107,17 @@ public class Application implements ApplicationRunner {
                 System.exit(ExitCodeType.FAILURE_UNKNOWN_ERROR.getExitCode());
             }
         }
+    }
+
+    private static void configureLoggingGroupIfNeeded(String[] args) {
+        if (System.getenv(SPRING_CONFIG_LOCATION_ENV) != null || containsSpringConfigLocation(args)) {
+            System.setProperty(LOGGING_GROUP_DETECT, DEFAULT_LOGGING_GROUP);
+        }
+    }
+
+    private static boolean containsSpringConfigLocation(String[] args) {
+        return Arrays.stream(args)
+            .anyMatch(arg -> arg.contains(SPRING_CONFIG_LOCATION_PROPERTY));
     }
 
     @Override


### PR DESCRIPTION
### Ticket

IDETECT-4615

### **Solution Approach**  
This solution ensures that custom configuration file **does not** replace the default `application.properties` configuration when the configuration is passed via environment variable or command-line argument.
It sets the `logging.group.detect` property only when a custom configuration file is explicitly provided via `SPRING_CONFIG_LOCATION` (environment variable) or `--spring.config.location` (command-line argument).
This solution replicates the behavior of SPRING_CONFIG_ADDITIONAL_LOCATION or --spring.config.additional-location.

The method `configureLoggingGroupIfNeeded` checks for these sources before setting the property, while `containsSpringConfigLocation` efficiently scans command-line arguments using `Arrays.stream().anyMatch()` for a clean lookup.

Spring Boot prioritizes configuration sources in a specific order: command-line arguments have the highest precedence, followed by environment variables, system properties, and finally `application.properties`. By setting `logging.group.detect` early in `main`, we ensure it takes effect only when an external configuration file is provided and prevents it from being overwritten by the default `application.properties`.