### PR TITLE
Doc improvements for NuGet Inspector

### DIFF
--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -24,8 +24,8 @@ The detectors run a platform dependent self-contained executable that is current
 ## Excluding dependency types
 [detect_product_short] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
-This property supports exclusion of development only dependencies in projects that use PackageReference or packages.config.
-<note type="note">Support for declaring dependencies in JSON files has been deprecated by NuGet. As such this property does not apply to scans that analyze project.json, project.lock.json or project.assets.json.</note>
+This property supports exclusion of development-only dependencies in projects that use `PackageReference` or `packages.config`.
+<note type="note">Support for declaring dependencies in JSON files has been deprecated by NuGet. As such this property does not apply to scans that analyze `project.json`, `project.lock.json` or `project.assets.json`.</note>
 
 A project might be using a dependency purely as a development harness and you might not want to expose that to projects that will consume the package. You can use the PrivateAssets metadata to control this behavior. [detect_product_short] looks for the PrivateAssets attribute used within PackageReference tags to identify a development dependency. [detect_product_short] will ignore the contents of the tag and only observe the presence of these PrivateAssets to exclude those development related dependencies.
 For packages.config file, [detect_product_short] will look for developmentDependency tags to determine whether to include or exclude a dependency.

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -17,15 +17,15 @@ The detectors run a platform dependent self-contained executable that is current
 
 <note type="note">
 
-* NuGet Project Inspector relies on Project Inspector thus does not accept NuGet specific configuration properties.   
+* NuGet Project Inspector relies on Project Inspector thus does not accept NuGet specific configuration properties. // do customers know PI is a separate project? If not, this sentence makes no sense. 
 * The NuGet Detectors do not work with mono.
 </note>
 
 ## Excluding dependency types
 [detect_product_short] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
-This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies.
-<note type="note">Support for storing dependencies in Json files has been deprecated by Nuget. As such we will not be enhancing the properties to exclude dependency types in this manner.</note>
+This property supports exclusion of development only dependencies in projects that use PackageReference or packages.config. (Should mention the directory .props files though?)
+<note type="note">Support for declaring dependencies in JSON files has been deprecated by NuGet. As such this property does not apply to projects that use project.json.</note>
 
 A project might be using a dependency purely as a development harness and you might not want to expose that to projects that will consume the package. You can use the PrivateAssets metadata to control this behavior. [detect_product_short] looks for the PrivateAssets attribute used within PackageReference tags to identify a development dependency. [detect_product_short] will ignore the contents of the tag and only observe the presence of these PrivateAssets to exclude those development related dependencies.
 For packages.config file, [detect_product_short] will look for developmentDependency tags to determine whether to include or exclude a dependency.

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -17,15 +17,15 @@ The detectors run a platform dependent self-contained executable that is current
 
 <note type="note">
 
-* NuGet Project Inspector relies on Project Inspector thus does not accept NuGet specific configuration properties. // do customers know PI is a separate project? If not, this sentence makes no sense. 
+* NuGet Project Inspector does not accept NuGet specific configuration properties.
 * The NuGet Detectors do not work with mono.
 </note>
 
 ## Excluding dependency types
 [detect_product_short] offers the ability to exclude package manager specific dependency types from the BOM.
 Nuget dependency types can be filtered with the [detect.nuget.dependency.types.excluded](../properties/detectors/nuget.md#nuget-dependency-types-excluded) property.
-This property supports exclusion of development only dependencies in projects that use PackageReference or packages.config. (Should mention the directory .props files though?)
-<note type="note">Support for declaring dependencies in JSON files has been deprecated by NuGet. As such this property does not apply to projects that use project.json.</note>
+This property supports exclusion of development only dependencies in projects that use PackageReference or packages.config.
+<note type="note">Support for declaring dependencies in JSON files has been deprecated by NuGet. As such this property does not apply to scans that analyze project.json, project.lock.json or project.assets.json.</note>
 
 A project might be using a dependency purely as a development harness and you might not want to expose that to projects that will consume the package. You can use the PrivateAssets metadata to control this behavior. [detect_product_short] looks for the PrivateAssets attribute used within PackageReference tags to identify a development dependency. [detect_product_short] will ignore the contents of the tag and only observe the presence of these PrivateAssets to exclude those development related dependencies.
 For packages.config file, [detect_product_short] will look for developmentDependency tags to determine whether to include or exclude a dependency.

--- a/documentation/src/main/markdown/packagemgrs/nuget.md
+++ b/documentation/src/main/markdown/packagemgrs/nuget.md
@@ -56,7 +56,7 @@ NuGet Solution Native Inspector runs if one or more solution (.sln) files are fo
 
 NuGet Project Native Inspector runs if no solution (.sln) files are found, and one or more project files are found. NuGet Project Native Inspector derives packages (dependencies) from project (.csproj, .fsproj, etc.) file content.
 
-NuGet inspectors derive dependency information from solution (.sln) files in this order:
+NuGet inspectors look for files to derive dependency information from in this order (only the first available in the list will be analyzed):
 1. Directory.Packages.props
 2. packages.config
 3. project.lock.json

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1219,7 +1219,7 @@ public class DetectProperties {
     public static final NoneEnumListProperty<NugetDependencyType> DETECT_NUGET_DEPENDENCY_TYPES_EXCLUDED =
         NoneEnumListProperty.newBuilder("detect.nuget.dependency.types.excluded", NoneEnum.NONE, NugetDependencyType.class)
             .setInfo("Nuget Dependency Types Excluded", DetectPropertyFromVersion.VERSION_9_4_0)
-            .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property supports exclusion of dependencies in projects that use PackageReference, and packages.config for listing dependencies that are not stored in JSON files.")
+            .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property supports exclusion of dependencies in projects that use PackageReference or packages.config. This property does not apply to ")
             .setExample(String.format("%s", NugetDependencyType.DEV.name()))
             .setGroups(DetectGroup.NUGET, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
             .build();

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1219,7 +1219,7 @@ public class DetectProperties {
     public static final NoneEnumListProperty<NugetDependencyType> DETECT_NUGET_DEPENDENCY_TYPES_EXCLUDED =
         NoneEnumListProperty.newBuilder("detect.nuget.dependency.types.excluded", NoneEnum.NONE, NugetDependencyType.class)
             .setInfo("Nuget Dependency Types Excluded", DetectPropertyFromVersion.VERSION_9_4_0)
-            .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property supports exclusion of dependencies in projects that use PackageReference or packages.config. This property does not apply to ")
+            .setHelp(createTypeFilterHelpText("Nuget dependency types"), "This property supports exclusion of dependencies in projects that use PackageReference or packages.config. This property does not apply to scans that analyze project.json, project.lock.json or project.assets.json.")
             .setExample(String.format("%s", NugetDependencyType.DEV.name()))
             .setGroups(DetectGroup.NUGET, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
             .build();


### PR DESCRIPTION
Minor documentation improvements to deal with questions we've been receiving around detect.nuget.dependency.types.excluded property (IDETECT-4573, IDETECT-4606) and the cascading logic.