### PR TITLE
Quickstart doc fix

### DIFF
--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -2,7 +2,7 @@
 
 The following is a simple example to help you get started using [detect_product_long].
 
-<note type="hint">For another quick path to scanning with [detect_product_short], see [Autonomous Scanning](../runningdetect/autonomousscan.dita).
+<note type="hint">For another quick path to scanning with [detect_product_short], see [Autonomous Scanning](../runningdetect/autonomousscan.dita).</note>
 
 ## Step 1: Locate or acquire a source code project on which you will run [detect_product_short].
 
@@ -51,9 +51,11 @@ In the junit4 case, [detect_product_short] will:
 1. Run the Maven detector, which uses Maven to discover dependencies.
 2. Run the [blackduck_signature_scanner_name] which scans the files in the source directory to discover dependencies.
 3. Upload the discovered dependencies to [bd_product_short].
-4. Provide in the log a Black Duck Project BOM URL that you can use to view the results in [bd_product_short].
+4. Add a log entry for the [bd_product_long] Project BOM URL that you can use to view the results in [bd_product_short].
 
-Point your browser to the Black Duck Project BOM URL to see the Bill Of Materials for junit4.
+Point your browser to the [bd_product_long] Project BOM URL to see the Bill Of Materials for junit4.  
+
+For guidance on getting started using, and viewing results in [bd_product_long], check out [Getting Started with Black Duck SCA](https://documentation.blackduck.com/bundle/bd-hub/page/Administration/Hub101.html)
 
 ## Next steps
 

--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -16,10 +16,9 @@ To understand what [detect_product_short] does, it can be helpful to think about
 
 1. Look in the project directory (junit4) for hints about how dependencies are managed. In this case, the *mvnw* and *pom.xml* files are hints that dependencies are managed using Maven.
 1. Since it's a Maven project, you would likely run `./mvnw dependency:tree` to reveal the project's dependencies; both direct and transitive.
+1. Examine files in the project directory, which might identify additional dependencies not known to the package manager such as a .jar file copied in.
 
-This is basically what [detect_product_short] does on this project. In addition, [detect_product_short] runs the
-[blackduck_signature_scanner_name] on the directory, which may discover additional dependencies
-added to the project by means other than the package manager.
+This is essentially the process that [detect_product_short] expands upon and automates when it executes project manager tools and runs the [blackduck_signature_scanner_name] on the directory. Using detectors, inspectors, and other tools, [detect_product_short] may discover not only dependencies managed at the package level, but additional dependencies added to the project by means other than the package manager.
 
 ## Step 2: Run [detect_product_short] connected to [blackduck_product_name].
 

--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -53,9 +53,9 @@ In the junit4 case, [detect_product_short] will:
 3. Upload the discovered dependencies to [bd_product_short].
 4. Add a log entry for the [bd_product_long] Project BOM URL that you can use to view the results in [bd_product_short].
 
-Point your browser to the [bd_product_long] Project BOM URL to see the Bill Of Materials for junit4.  
+Once the scan is complete, navigate with your browser to the [bd_product_short] Project BOM URL to see the Bill Of Materials for junit4.  
 
-For guidance on getting started using, and viewing results in [bd_product_long], check out [Getting Started with Black Duck SCA](https://documentation.blackduck.com/bundle/bd-hub/page/Administration/Hub101.html)
+For guidance on getting started using, and viewing results in [bd_product_short], check out [Getting Started with Black Duck SCA](https://documentation.blackduck.com/bundle/bd-hub/page/Administration/Hub101.html)
 
 ## Next steps
 


### PR DESCRIPTION
I notice a note at the top was borked, so I made a few additional tweaks while fixing it. 
Nothing major, just a few lines around the process and a link to the SCA quick start for results viewing.