### PR TITLE
Update bd-common-version to 67.0.5

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,4 +1,2 @@
-// Updating blackduck-common version here might necessitate an update to integration-common version in src/main/resources/create-gradle-airgap-script.ftl \
-// to ensure the integration-common versions in both airgap and non-airgap are the same. 
-gradle.ext.blackDuckCommonVersion='67.0.4'
+gradle.ext.blackDuckCommonVersion='67.0.5'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
Brings in https://github.com/blackducksoftware/integration-rest/pull/35 from integration-rest to fix IDETECT-4262.