### PR TITLE
Derive file name from URL

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -335,7 +335,9 @@ public class DetectProperties {
         NullableStringProperty.newBuilder("detect.container.scan.file.path")
             .setInfo("Container Scan Target", DetectPropertyFromVersion.VERSION_9_1_0)
             .setHelp(
-                "If specified, this file and this file only will be uploaded for container scan analysis. The CONTAINER_SCAN tool does not provide project and version name defaults to Detect, so you need to set project and version names via properties when only the CONTAINER_SCAN tool is invoked.")
+                "If specified, this file and this file only will be uploaded for container scan analysis.",
+                "Detect will accept either a user provided local file path, or remote HTTP/HTTPS URL to fetch a container image for scanning. The CONTAINER_SCAN tool does not provide project and version name defaults to Detect, so you need to set project and version names via properties when only the CONTAINER_SCAN tool is invoked."
+            )
             .setGroups(DetectGroup.CONTAINER_SCANNER, DetectGroup.SOURCE_PATH)
             .build();
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -419,10 +419,9 @@ public class OperationRunner {
     }
     
     public File downloadContainerImage(Gson gson, File downloadDirectory, String containerImageUri) throws DetectUserFriendlyException, IntegrationException, IOException {
-        String targetPathName = downloadDirectory.toString().concat("/targetImage");
         ConnectionFactory connectionFactory = new ConnectionFactory(detectConfigurationFactory.createConnectionDetails());
         ArtifactResolver artifactResolver = new ArtifactResolver(connectionFactory, gson);
-        return artifactResolver.downloadArtifact(new File(targetPathName), containerImageUri);
+        return artifactResolver.parseFileNameAndDownloadArtifact(downloadDirectory, containerImageUri);
     }
 
     public File getContainerScanImage(Gson gson, File downloadDirectory) throws OperationException {
@@ -431,7 +430,8 @@ public class OperationRunner {
             File containerImageFile = null;
             if (containerImageFilePath.isPresent()) {
                 String containerImageUri = containerImageFilePath.get();
-                if (containerImageUri.startsWith("http")) {
+
+                if (containerImageUri.startsWith("http://") || containerImageUri.startsWith("https://")) {
                     containerImageFile = downloadContainerImage(gson, downloadDirectory, containerImageUri);
                 } else {
                     containerImageFile = new File(containerImageUri);

--- a/src/main/java/com/blackduck/integration/detect/workflow/ArtifactResolver.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/ArtifactResolver.java
@@ -118,6 +118,12 @@ public class ArtifactResolver {
         }
     }
 
+    public File parseFileNameAndDownloadArtifact(File targetDir, String source) throws IntegrationException, IOException {
+        String fileName = parseFileName(source);
+        File target = new File(targetDir, fileName);
+        return downloadArtifact(target, source);
+    }
+
     public File downloadArtifact(File target, String source) throws IntegrationException, IOException {
         logger.debug(String.format("Downloading for artifact to '%s' from '%s'.", target.getAbsolutePath(), source));
         Request request = new Request.Builder().url(new HttpUrl(source)).build();
@@ -137,5 +143,4 @@ public class ArtifactResolver {
             }
         }
     }
-
 }


### PR DESCRIPTION
# Description

Derive file name from URL when container image path is a URL.
This ensures that the code location name is more meaningful/identifiable in the BD UI.

