### PR TITLE
Handle inability to extract dependencies when setup.py is used

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
@@ -17,6 +17,7 @@ import com.blackduck.integration.detectable.detectables.pip.inspector.model.Name
 import com.blackduck.integration.detectable.detectables.pip.inspector.parser.PipInspectorTreeParser;
 import com.blackduck.integration.detectable.extraction.Extraction;
 import com.blackduck.integration.detectable.util.ToolVersionLogger;
+import com.blackduck.integration.executable.ExecutableOutput;
 import com.blackduck.integration.executable.ExecutableRunnerException;
 
 public class PipInspectorExtractor {
@@ -44,6 +45,11 @@ public class PipInspectorExtractor {
         Extraction extractionResult;
         try {
             String projectName = getProjectName(directory, pythonExe, setupFile, providedProjectName);
+
+            if (StringUtils.isEmpty(projectName) && requirementFilePaths.isEmpty()) {
+                return new Extraction.Builder().failure("Unable to run the Pip Inspector without a project name nor a requirements file").build();
+            }
+
             List<CodeLocation> codeLocations = new ArrayList<>();
             String projectVersion = null;
 
@@ -57,7 +63,7 @@ public class PipInspectorExtractor {
 
             for (Path requirementFilePath : requirementsPaths) {
                 List<String> inspectorOutput = runInspector(directory, pythonExe, pipInspector, projectName, requirementFilePath);
-                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString());
+                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString(), !StringUtils.isEmpty(projectName));
                 if (result.isPresent()) {
                     codeLocations.add(result.get().getCodeLocation());
                     String potentialProjectVersion = result.get().getProjectVersion();
@@ -104,8 +110,11 @@ public class PipInspectorExtractor {
 
         if (StringUtils.isBlank(projectName) && setupFile != null && setupFile.exists()) {
             List<String> pythonArguments = Arrays.asList(setupFile.getAbsolutePath(), "--name");
-            List<String> output = executableRunner.execute(ExecutableUtils.createFromTarget(directory, pythonExe, pythonArguments)).getStandardOutputAsList();
-            projectName = output.get(output.size() - 1).replace('_', '-').trim();
+            ExecutableOutput executableOutput = executableRunner.execute(ExecutableUtils.createFromTarget(directory, pythonExe, pythonArguments));
+            if (executableOutput.getReturnCode() == 0) {
+                List<String> output = executableOutput.getStandardOutputAsList();
+                projectName = output.get(output.size() - 1).replace('_', '-').trim();
+            }
         }
 
         return projectName;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
@@ -47,7 +47,7 @@ public class PipInspectorExtractor {
             String projectName = getProjectName(directory, pythonExe, setupFile, providedProjectName);
 
             if (StringUtils.isEmpty(projectName) && requirementFilePaths.isEmpty()) {
-                return new Extraction.Builder().failure("Unable to run the Pip Inspector without a project name nor a requirements file").build();
+                return new Extraction.Builder().failure("Unable to run the Pip Inspector without a project name or a requirements file").build();
             }
 
             List<CodeLocation> codeLocations = new ArrayList<>();
@@ -63,7 +63,7 @@ public class PipInspectorExtractor {
 
             for (Path requirementFilePath : requirementsPaths) {
                 List<String> inspectorOutput = runInspector(directory, pythonExe, pipInspector, projectName, requirementFilePath);
-                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString(), !StringUtils.isEmpty(projectName));
+                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString(), StringUtils.isNotEmpty(projectName));
                 if (result.isPresent()) {
                     codeLocations.add(result.get().getCodeLocation());
                     String potentialProjectVersion = result.get().getProjectVersion();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
@@ -34,7 +34,7 @@ public class PipInspectorTreeParser {
         this.externalIdFactory = externalIdFactory;
     }
 
-    public Optional<NameVersionCodeLocation> parse(List<String> pipInspectorOutputAsList, String sourcePath) {
+    public Optional<NameVersionCodeLocation> parse(List<String> pipInspectorOutputAsList, String sourcePath, boolean projectNameWasGiven) {
         NameVersionCodeLocation parseResult = null;
 
         DependencyGraph graph = new BasicDependencyGraph();
@@ -48,6 +48,7 @@ public class PipInspectorTreeParser {
                 || trimmedLine.startsWith(UNKNOWN_REQUIREMENTS_PREFIX)
                 || trimmedLine.startsWith(UNPARSEABLE_REQUIREMENTS_PREFIX)
                 || trimmedLine.startsWith(UNKNOWN_PACKAGE_PREFIX)
+                || trimmedLine.startsWith(UNKNOWN_PROJECT_NAME) && projectNameWasGiven
             ) {
                 boolean wasUnresolved = parseErrorsFromLine(trimmedLine);
                 if (wasUnresolved) {
@@ -114,6 +115,11 @@ public class PipInspectorTreeParser {
 
         if (trimmedLine.startsWith(UNKNOWN_PACKAGE_PREFIX)) {
             logger.error(String.format("Pip inspector could not resolve the package: %s", trimmedLine.substring(UNKNOWN_PACKAGE_PREFIX.length())));
+            unResolvedPackage = true;
+        }
+
+        if (trimmedLine.startsWith(UNKNOWN_PROJECT_NAME)) {
+            logger.error("Pip inspector could not resolve the project");
             unResolvedPackage = true;
         }
         return unResolvedPackage;


### PR DESCRIPTION
Handle inability to extract dependencies when setup.py is used:

- do not attempt to use the output of `setup.py --name` when exit code is unsuccessful
- fail overall extraction when project name is provided but pip was not able to find it (this makes it more likely that detector cascading will proceed on failure)