### PR TITLE
cp-idetect-4646

### DIFF
--- a/documentation/src/main/markdown/components/overview.md
+++ b/documentation/src/main/markdown/components/overview.md
@@ -12,7 +12,7 @@ Each [detect_product_short] run consists of running any applicable [detect_produ
 
 [detect_product_short] uses [detectors](detectors.md), appropriate to your package manager ecosystem, to find and extract dependencies from all supported package managers.
 
-For a quick tutorial on detectors see: [Detectors Introduction](https://community.blackduck.com/s/article/Black-Duck-Detectors-Introduction).
+For a quick tutorial on detectors, see: [Detectors Introduction](https://community.blackduck.com/s/article/Black-Duck-Detectors-Introduction).
 
 ## Inspectors
 

--- a/documentation/src/main/markdown/components/overview.md
+++ b/documentation/src/main/markdown/components/overview.md
@@ -12,6 +12,9 @@ Each [detect_product_short] run consists of running any applicable [detect_produ
 
 [detect_product_short] uses [detectors](detectors.md), appropriate to your package manager ecosystem, to find and extract dependencies from all supported package managers.
 
+For a quick tutorial on detectors see: [Detectors Introduction](https://community.blackduck.com/s/article/Black-Duck-Detectors-Introduction).
+
 ## Inspectors
 
 An [inspector](inspectors.md) is typically a plugin that [detect_product_short] uses to access the internal resources of a package manager through its API.
+

--- a/documentation/src/main/markdown/gettingstarted/configuring.md
+++ b/documentation/src/main/markdown/gettingstarted/configuring.md
@@ -1,8 +1,8 @@
 # Configuration Overview
 
-What [detect_product_long] looks at and how it performs its analysis depends on how you configure [detect_product_short].
+What [detect_product_long] looks at and how it performs analysis depends on how it is configured.
 
-> For accurate SCA analysis, [detect_product_short] should be executed as a post-build step typically in the native build environment.
+<note type="note">For accurate SCA analysis, [detect_product_short] should typically be executed as a post-build step in the native build environment.</note>
 
 Using properties, you can configure the following:
 
@@ -13,4 +13,3 @@ Using properties, you can configure the following:
 * Sensitivity to policy violations
 * Reporting
 * Logging
-

--- a/documentation/src/main/markdown/gettingstarted/overview.md
+++ b/documentation/src/main/markdown/gettingstarted/overview.md
@@ -2,5 +2,7 @@
 
 Before you start using [detect_product_short], it is recommended that you become familiar with the makeup of [detect_product_short] and how it works. Review the 'Getting started with [detect_product_short]' pages listed in the left-hand menu, to learn about, and prepare to start using [detect_product_short].
 
+For a quick tutorial see: [Introduction to Scanning](https://community.blackduck.com/s/article/Black-Duck-Introduction-to-Scanning).
+
 <note type="note">[detect_product_short] documentation is incremental in nature with new functionality and changes indentified in the [Release notes](../currentreleasenotes.md) and [Properties](../properties/all-properties.md). However, documentation is also available for previous [detect_product_short] versions by navigating to the documentation portal [linked here](https://documentation.blackduck.com/bundle) and clicking on the **Archived** button.</note>
 

--- a/documentation/src/main/markdown/runningdetect/basics/decidinghowtouse.md
+++ b/documentation/src/main/markdown/runningdetect/basics/decidinghowtouse.md
@@ -8,3 +8,5 @@ Before you download and run [detect_product_short], you should make the followin
 - What [tools and detectors](../../components/overview.md) do you want to include or exclude?
 - Do you want to run [detect_product_short] offline, or connected to [bd_product_short]?
 - Would you like to share scan settings and run autonomous [detect_product_short] scans?
+
+For a quick introduction to configuring scans, see: [Scanning Best Practices Interactive Tutorial](https://community.blackduck.com/s/article/Black-Duck-Scanning-Best-Practices-Interactive-Tutorial).


### PR DESCRIPTION
Add training team links to appropriate doc sections. (Fulfilling a Doc OKR)
Fix some formatting and note structure on the getting started>configuring page.
