### PR TITLE
pnpm missing packages

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmYamlTransformer.java
@@ -193,6 +193,7 @@ public class PnpmYamlTransformer {
 
     private String convertRawEntryToPackageId(String name, String version, PnpmLinkedPackageResolver linkedPackageResolver, @Nullable String reportingProjectPackagePath) {
         name = StringUtils.strip(name, "'");
+        
         if (version.startsWith(LINKED_PACKAGE_PREFIX)) {
             // a linked project package's version will be referenced in the format: <linkPrefix><pathToLinkedPackageRelativeToReportingProjectPackage>
             version = linkedPackageResolver.resolveVersionOfLinkedPackage(reportingProjectPackagePath, version.replace(LINKED_PACKAGE_PREFIX, ""));
@@ -205,16 +206,15 @@ public class PnpmYamlTransformer {
             packageFormat = "/%s@%s";
         }
 
+        version = removeExtraVersionInformation(version);
+
         return String.format(packageFormat, name, version);
     }
 
     private Optional<NameVersion> parseNameVersionFromId(String id) {
         // ids follow format: /name@version in v6, name@version in v9
         try {
-            // It seems critical not to send this extra information in () or the kb will fail matching it.
-            if (id.contains("(")) {
-                id = id.split("\\(")[0];
-            }
+            id = removeExtraVersionInformation(id);
 
             int indexOfLastSlash = id.lastIndexOf("@");
             // v9 lockfile does not have names starting with /, v 6 does
@@ -273,4 +273,13 @@ public class PnpmYamlTransformer {
                 .anyMatch(id::equals); // for file dependencies, they are declared as <name> : <fileIdAsReportedInPackagesSection>
     }
  
+    private String removeExtraVersionInformation(String version) {
+        // Need to remove extra information from version or we will not appropriately
+        // perform KB matches later.
+        if (version != null && version.contains("(")) {
+            version = version.split("\\(")[0];
+        }
+        
+        return version;
+    }
 }

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -26,7 +26,7 @@
 
 ### Resolved issues
 
-* (IDETECT-4642) - Improved handling of pnpm packages that contain detailed version information in the pnpm-lock.yaml. This previously prevented linking direct and transitive dependencies, causing [detect_product_short] to miss some packages. 
+* (IDETECT-4642) - Improved handling of pnpm packages that contain detailed version information in the pnpm-lock.yaml. Resolving [detect_product_short] missing some packages through failure to link direct and transitive dependencies. 
 
 ### Dependency updates
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -26,7 +26,7 @@
 
 ### Resolved issues
 
-* 
+* (IDETECT-4642) - Improved handling of pnpm packages that contain detailed version information in the pnpm-lock.yaml. This previously prevented linking direct and transitive dependencies, causing [detect_product_short] to miss some packages. 
 
 ### Dependency updates
 


### PR DESCRIPTION
Some pnpm packages contain detailed version information that causes Detect to not correctly link parent and child relationships in the BDIO. 

Specifically, direct dependencies are captured with the extraneous information while transitive dependencies are not. So the old code would never pair them together and the whole relationship was missing from the BDIO causing both parent and child packages to be missed.