### PR TITLE
Idetect-4641 - Add support for non-standard version entries in Yarn component dependency section.

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/yarn/VersionUtility.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/yarn/VersionUtility.java
@@ -2,9 +2,8 @@ package com.blackduck.integration.detectable.detectables.yarn;
 
 import com.blackduck.integration.bdio.graph.builder.LazyIdSource;
 import com.blackduck.integration.util.NameVersion;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.regex.*;
 
 public class VersionUtility {
     
@@ -20,7 +19,15 @@ public class VersionUtility {
                 sb.append(cleanVersion.charAt(i));
             }
         }
-        return new Version(sb.toString().split("\\.", 3));
+        Matcher matcher = Pattern.compile("(\\d+(?:\\.\\d+)+)(?!.*\\d+\\.\\d+)").matcher(sb.toString());
+        List<String> parts = new ArrayList<>();
+        if (matcher.find()) {
+            Matcher versionMatcher = Pattern.compile("(\\d+)").matcher(matcher.group(1));
+            while (parts.size() < 3 && versionMatcher.find()) {
+                parts.add(versionMatcher.group());
+            }
+        }
+        return new Version(parts.toArray(new String[0]));
     }
     
     Optional<String> resolveYarnVersion(List<Version> versionList, String version) {

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -26,7 +26,7 @@
 
 ### Resolved issues
 
-* 
+* (IDETECT-4641) - Improved [detect_product_short]'s Yarn detector to handle non-standard version entries for component dependencies.
 
 ### Dependency updates
 


### PR DESCRIPTION
# Description

Add support for non-standard version entries in Yarn component dependency section.

# Github Issues

Idetect-4641
