### PR TITLE
Fallback to Bdba runner when SCASS url is not accessible

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -82,7 +82,7 @@ public class CommonScanStepRunner {
                 scassScanStepRunner.runScassScan(Optional.of(initResult.getFileToUpload()), scanCreationResponse);
 
                 return scanId;
-            } catch (IntegrationException e) {
+            } catch (Exception e) {
                 // If we can't access the SCASS uplaod URL, we create a new scanId so we can try the BDBA flow.
                 // Note: as of 2025.1.1 there is no endpoint to cancel a SCASS scan.
                 logger.info("Attempted to access SCASS URL but failed. Please allow the url through your firewall to perform SCASS SCAN.");

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,29 +74,27 @@ public class CommonScanStepRunner {
 
     public UUID performCommonUpload(NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData,
             Optional<File> scanFile, OperationRunner operationRunner, String scanType,
-            ScassScanInitiationResult initResult, String codeLocationName) throws IntegrationException, OperationException, IOException {
+            ScassScanInitiationResult initResult, String codeLocationName) throws IntegrationException, OperationException {
         ScanCreationResponse scanCreationResponse = initResult.getScanCreationResponse();
-        
-        String uploadUrl = scanCreationResponse.getUploadUrl();
+
         UUID scanId = UUID.fromString(scanCreationResponse.getScanId());
         
-        if (StringUtils.isNotEmpty(uploadUrl)) {
-            if (isAccessible(uploadUrl)) {
+        if (StringUtils.isNotEmpty(scanCreationResponse.getUploadUrl())) {
+            try {
                 // This is a SCASS capable server server, SCASS is enabled, and we can access the upload URL.
                 ScassScanStepRunner scassScanStepRunner = createScassScanStepRunner(blackDuckRunData);
                 scassScanStepRunner.runScassScan(Optional.of(initResult.getFileToUpload()), scanCreationResponse);
-                
+
                 return scanId;
-            } else {
+            } catch (IntegrationException e) {
                 // If we can't access the SCASS uplaod URL, we create a new scanId so we can try the BDBA flow.
                 // Note: as of 2025.1.1 there is no endpoint to cancel a SCASS scan.
+                logger.info("Attempted to access SCASS URL but failed. Please allow the url through your firewall to perform SCASS SCAN.");
                 scanId = createFallbackScanId(operationRunner, scanType, projectNameVersion, codeLocationName, scanFile.get().length(), blackDuckRunData);
             }
         }
-        
         // This is a SCASS capable server server but SCASS is not enabled or the GCP URL is inaccessible.
         BdbaScanStepRunner bdbaScanStepRunner = createBdbaScanStepRunner(operationRunner);
-
         bdbaScanStepRunner.runBdbaScan(projectNameVersion, blackDuckRunData, scanFile, scanId.toString(), scanType);
 
         return scanId;
@@ -122,23 +122,27 @@ public class CommonScanStepRunner {
         return operationRunner.initiatePreScassScan(blackDuckRunData, bdioHeaderFile);
     }
 
-    public boolean isAccessible(String uploadUrl) {
-        try {
-            URL url = new URL(uploadUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("HEAD");
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                return true;
-            } else {
-                logger.debug("Attempted to access SCASS URL but failed. Response code: {}", responseCode);
-                return false;
-            }
-        } catch (IOException e) {
-            logger.debug("Error checking SCASS URL: " + e.getMessage());
-            return false;
-        }
-    }
+//    public boolean isAccessible(ScanCreationResponse scanCreationResponse) {
+//        try {
+//            URL url = new URL(scanCreationResponse.getUploadUrl());
+//            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+//            connection.setRequestMethod("HEAD");
+//            List<Map<String,String>> headers = scanCreationResponse.getUploadUrlData().getHeaders();
+//            for(Map<String,String> header : headers) {
+//                connection.setRequestProperty(header.get("name"), header.get("value"));
+//            }
+//            int responseCode = connection.getResponseCode();
+//            if (responseCode == HttpURLConnection.HTTP_OK) {
+//                return true;
+//            } else {
+//                logger.debug("Attempted to access SCASS URL but failed. Response code: {}", responseCode);
+//                return false;
+//            }
+//        } catch (IOException e) {
+//            logger.debug("Error checking SCASS URL: " + e.getMessage());
+//            return false;
+//        }
+//    }
 
     private File getOutputDirectory(OperationRunner operationRunner, String scanType) throws IntegrationException {
         switch (scanType) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -2,10 +2,6 @@ package com.blackduck.integration.detect.lifecycle.run.step;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Map;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -82,9 +82,10 @@ public class CommonScanStepRunner {
                 scassScanStepRunner.runScassScan(Optional.of(initResult.getFileToUpload()), scanCreationResponse);
 
                 return scanId;
-            } catch (Exception e) {
+            } catch (IntegrationException e) {
                 // If we can't access the SCASS uplaod URL, we create a new scanId so we can try the BDBA flow.
                 // Note: as of 2025.1.1 there is no endpoint to cancel a SCASS scan.
+                logger.info(e.getMessage());
                 logger.info("Attempted to access SCASS URL but failed. Please allow the url through your firewall to perform SCASS SCAN.");
                 scanId = createFallbackScanId(operationRunner, scanType, projectNameVersion, codeLocationName, scanFile.get().length(), blackDuckRunData);
             }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -85,8 +85,7 @@ public class CommonScanStepRunner {
             } catch (IntegrationException e) {
                 // If we can't access the SCASS uplaod URL, we create a new scanId so we can try the BDBA flow.
                 // Note: as of 2025.1.1 there is no endpoint to cancel a SCASS scan.
-                logger.info(e.getMessage());
-                logger.info("Attempted to access SCASS URL but failed. Please allow the url through your firewall to perform SCASS SCAN.");
+                logger.info("Error uploading to SCASS URL: " + e.getMessage());
                 scanId = createFallbackScanId(operationRunner, scanType, projectNameVersion, codeLocationName, scanFile.get().length(), blackDuckRunData);
             }
         }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -118,28 +118,6 @@ public class CommonScanStepRunner {
         return operationRunner.initiatePreScassScan(blackDuckRunData, bdioHeaderFile);
     }
 
-//    public boolean isAccessible(ScanCreationResponse scanCreationResponse) {
-//        try {
-//            URL url = new URL(scanCreationResponse.getUploadUrl());
-//            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-//            connection.setRequestMethod("HEAD");
-//            List<Map<String,String>> headers = scanCreationResponse.getUploadUrlData().getHeaders();
-//            for(Map<String,String> header : headers) {
-//                connection.setRequestProperty(header.get("name"), header.get("value"));
-//            }
-//            int responseCode = connection.getResponseCode();
-//            if (responseCode == HttpURLConnection.HTTP_OK) {
-//                return true;
-//            } else {
-//                logger.debug("Attempted to access SCASS URL but failed. Response code: {}", responseCode);
-//                return false;
-//            }
-//        } catch (IOException e) {
-//            logger.debug("Error checking SCASS URL: " + e.getMessage());
-//            return false;
-//        }
-//    }
-
     private File getOutputDirectory(OperationRunner operationRunner, String scanType) throws IntegrationException {
         switch (scanType) {
             case BINARY:

--- a/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunnerTest.java
+++ b/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunnerTest.java
@@ -90,8 +90,6 @@ public class CommonScanStepRunnerTest {
         CommonScanStepRunner commonScanStepRunner = spy(new CommonScanStepRunner());
 
         when(scanCreationResponse.getUploadUrl()).thenReturn(uploadUrl);
-        when(commonScanStepRunner.isAccessible(uploadUrl)).thenReturn(true);
-        
         doNothing().when(scassScanStepRunner).runScassScan(any(), any());
 
         doReturn(scassScanStepRunner).when(commonScanStepRunner).createScassScanStepRunner(nullable(BlackDuckRunData.class));
@@ -129,7 +127,6 @@ public class CommonScanStepRunnerTest {
         CommonScanStepRunner commonScanStepRunner = spy(new CommonScanStepRunner());
 
         when(scanCreationResponse.getUploadUrl()).thenReturn(uploadUrl);
-        when(commonScanStepRunner.isAccessible(uploadUrl)).thenReturn(true);
         doNothing().when(scassScanStepRunner).runScassScan(any(), any());
 
         doReturn(scassScanStepRunner).when(commonScanStepRunner).createScassScanStepRunner(nullable(BlackDuckRunData.class));


### PR DESCRIPTION
This PR fixes bug IDETECT-4660 introduced in this earlier PR: https://github.com/blackducksoftware/detect/pull/1373. Earlier there was a misconception that urls which were returned by SCASS can be used for any method call but with the data we do get a parameter in scan creation response that only allows POST call with the SCASS url. 

So HEAD call was returning 400 response code as we were not sending signed headers with the url which were required, upon sending headers we got 405 response code (Method not allowed) which elaborates the earlier explanation that only POST calls are allowed. Upon discussion with SCASS team, it looks like the pattern for uploading the file is this:
Initial POST -> read chunk -> upload chunk (using uri returned by initial POST) -> read next chunk -> etc.

So if the url is inaccessible, then initial POST call would return exception which we are catching and falling back to BDBA runner and we will still save time in not moving forward with the chunk process.