### PR TITLE
Fix for detect failure with duplicate keys in `package.json` for Yarn projects

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/yarn/packagejson/PackageJsonReader.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/yarn/packagejson/PackageJsonReader.java
@@ -26,7 +26,7 @@ public class PackageJsonReader {
     }
 
     public List<String> extractWorkspaceDirPatterns(String packageJsonText) {
-        Map<String, Object> packageJsonMap = gson.fromJson(packageJsonText, Map.class);
+        Map<String, Object> packageJsonMap = gson.fromJson(JsonSanitizer.sanitize(packageJsonText), Map.class);
         // Possible alt. approach: pass it a TypeAdapter
         Object workspacesObject = packageJsonMap.get(WORKSPACES_OBJECT_KEY);
         List<String> workspaceSubdirPatterns = new LinkedList<>();
@@ -34,11 +34,11 @@ public class PackageJsonReader {
             logger.trace("workspacesObject type: {}", workspacesObject.getClass().getName());
             if (workspacesObject instanceof Map) {
                 logger.trace("workspacesObject is a Map");
-                YarnPackageJsonWorkspacesAsObject rootPackageJsonNewSyntax = gson.fromJson(packageJsonText, YarnPackageJsonWorkspacesAsObject.class);
+                YarnPackageJsonWorkspacesAsObject rootPackageJsonNewSyntax = gson.fromJson(JsonSanitizer.sanitize(packageJsonText), YarnPackageJsonWorkspacesAsObject.class);
                 workspaceSubdirPatterns.addAll(rootPackageJsonNewSyntax.workspaces.workspaceSubdirPatterns);
             } else if (workspacesObject instanceof List) {
                 logger.trace("workspacesObject is a List");
-                YarnPackageJsonWorkspacesAsList rootPackageJsonOldSyntax = gson.fromJson(packageJsonText, YarnPackageJsonWorkspacesAsList.class);
+                YarnPackageJsonWorkspacesAsList rootPackageJsonOldSyntax = gson.fromJson(JsonSanitizer.sanitize(packageJsonText), YarnPackageJsonWorkspacesAsList.class);
                 workspaceSubdirPatterns.addAll(rootPackageJsonOldSyntax.workspaceSubdirPatterns);
             } else {
                 logger.warn("package.json 'workspaces' object is an unrecognized format; workspace declarations will be ignored");

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -30,6 +30,7 @@
 
 * (IDETECT-4642) - Improved handling of pnpm packages that contain detailed version information in the pnpm-lock.yaml. Resolving [detect_product_short] missing some packages through failure to link direct and transitive dependencies. 
 * (IDETECT-4641) - Improved [detect_product_short]'s Yarn detector to handle non-standard version entries for component dependencies.
+* (IDETECT-4594) - Resolved an issue that caused [detect_product_short] to fail with duplicate keys in `package.json` files across `npm`, `pnpm`, `lerna` and `yarn` projects.
 
 ### Dependency updates
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -30,7 +30,7 @@
 
 * (IDETECT-4642) - Improved handling of pnpm packages that contain detailed version information in the pnpm-lock.yaml. Resolving [detect_product_short] missing some packages through failure to link direct and transitive dependencies. 
 * (IDETECT-4641) - Improved [detect_product_short]'s Yarn detector to handle non-standard version entries for component dependencies.
-* (IDETECT-4594) - Resolved an issue that caused [detect_product_short] to fail with duplicate keys in `package.json` files across `npm`, `pnpm`, `lerna` and `yarn` projects.
+* (IDETECT-4594) - Resolved [detect_product_short] failing to handle duplicate keys in package.json files across npm, pnpm, Lerna, and Yarn projects.
 
 ### Dependency updates
 


### PR DESCRIPTION
This update fixes the detect failure when handling duplicate keys in `package.json` for `yarn` projects. Previously, it was unable to handle duplicate keys and threw a `JsonSyntaxException` due to improper use of `JsonSantizer.sanitize(packageJsonText)`.