### PR TITLE
rename pnpm filter property to be based on packages

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -25,7 +25,7 @@
 * Support for Conda has been extended to 25.1.1.
 * Cargo CLI Detector, leveraging `cargo tree` to extract direct and transitive dependencies, improving accuracy over the previous flat lockfile detection. This build-based detector is triggered for Cargo projects with a `Cargo.toml` file and requires Cargo version **1.44.0+**. For further information, see [Cargo package manager support](packagemgrs/cargo.md).
 * Added property [detect.cargo.path](properties/detectors/cargo.md) to allow user specification of a custom Cargo executable path.   
-* New `detect.pnpm.included.directories` and `detect.pnpm.included.directories` properties for pnpm provide increased control over what directories [detect_product_short] scans under a pnpm project. See the [pnpm](properties/configuration/pnpm.html) property page for more information.
+* New `detect.pnpm.included.packages` and `detect.pnpm.excluded.packages` properties for pnpm provide increased control over what directories [detect_product_short] scans under a pnpm project. See the [pnpm](properties/configuration/pnpm.html) property page for more information.
 
 ### Resolved issues
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1346,7 +1346,7 @@ public class DetectProperties {
             .build();
     
     public static final CaseSensitiveStringListProperty DETECT_PNPM_EXCLUDED_DIRECTORIES =
-            CaseSensitiveStringListProperty.newBuilder("detect.pnpm.excluded.directories")
+            CaseSensitiveStringListProperty.newBuilder("detect.pnpm.excluded.packages")
                 .setInfo("pnpm Exclude Directories", DetectPropertyFromVersion.VERSION_10_4_0)
                 .setHelp(
                     "A comma-separated list of pnpm directories to exclude.",
@@ -1357,7 +1357,7 @@ public class DetectProperties {
                 .build();
     
     public static final CaseSensitiveStringListProperty DETECT_PNPM_INCLUDED_DIRECTORIES =
-            CaseSensitiveStringListProperty.newBuilder("detect.pnpm.included.directories")
+            CaseSensitiveStringListProperty.newBuilder("detect.pnpm.included.packages")
                 .setInfo("pnpm Include Directories", DetectPropertyFromVersion.VERSION_10_4_0)
                 .setHelp(
                     "A comma-separated list of pnpm directories to include.",


### PR DESCRIPTION
A simple rename of pnpm filter based properties to mention packages instead of directories. This better aligns with what pnpm calls their folder structure.