### PR TITLE
Do not fail extraction if inspector cannot find the root project and minor doc update

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/PipInspectorExtractor.java
@@ -63,7 +63,7 @@ public class PipInspectorExtractor {
 
             for (Path requirementFilePath : requirementsPaths) {
                 List<String> inspectorOutput = runInspector(directory, pythonExe, pipInspector, projectName, requirementFilePath);
-                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString(), StringUtils.isNotEmpty(projectName));
+                Optional<NameVersionCodeLocation> result = pipInspectorTreeParser.parse(inspectorOutput, directory.toString());
                 if (result.isPresent()) {
                     codeLocations.add(result.get().getCodeLocation());
                     String potentialProjectVersion = result.get().getProjectVersion();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
@@ -34,7 +34,7 @@ public class PipInspectorTreeParser {
         this.externalIdFactory = externalIdFactory;
     }
 
-    public Optional<NameVersionCodeLocation> parse(List<String> pipInspectorOutputAsList, String sourcePath, boolean projectNameWasGiven) {
+    public Optional<NameVersionCodeLocation> parse(List<String> pipInspectorOutputAsList, String sourcePath) {
         NameVersionCodeLocation parseResult = null;
 
         DependencyGraph graph = new BasicDependencyGraph();
@@ -48,7 +48,6 @@ public class PipInspectorTreeParser {
                 || trimmedLine.startsWith(UNKNOWN_REQUIREMENTS_PREFIX)
                 || trimmedLine.startsWith(UNPARSEABLE_REQUIREMENTS_PREFIX)
                 || trimmedLine.startsWith(UNKNOWN_PACKAGE_PREFIX)
-                || trimmedLine.startsWith(UNKNOWN_PROJECT_NAME) && projectNameWasGiven
             ) {
                 boolean wasUnresolved = parseErrorsFromLine(trimmedLine);
                 if (wasUnresolved) {
@@ -118,10 +117,6 @@ public class PipInspectorTreeParser {
             unResolvedPackage = true;
         }
 
-        if (trimmedLine.startsWith(UNKNOWN_PROJECT_NAME)) {
-            logger.error("Pip inspector could not resolve the project");
-            unResolvedPackage = true;
-        }
         return unResolvedPackage;
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pip/inspector/parser/PipInspectorTreeParser.java
@@ -55,6 +55,9 @@ public class PipInspectorTreeParser {
                 }
                 continue;
             }
+            if (trimmedLine.startsWith(UNKNOWN_PROJECT_NAME)) {
+                logger.info("Pip inspector did not find a package matching project name");
+            }
             Dependency currentDependency = parseDependencyFromLine(trimmedLine, sourcePath);
             adjustForIndentLevel(history, line);
             project = addDependencyToGraph(graph, history, project, currentDependency);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pip/inspector/unit/PipInspectorTreeParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pip/inspector/unit/PipInspectorTreeParserTest.java
@@ -35,7 +35,7 @@ public class PipInspectorTreeParserTest {
             "   test==4.0.0"
         );
 
-        Optional<NameVersionCodeLocation> validParse = parser.parse(pipInspectorOutput, "", true);
+        Optional<NameVersionCodeLocation> validParse = parser.parse(pipInspectorOutput, "");
         Assertions.assertTrue(validParse.isPresent());
         Assertions.assertEquals("projectName", validParse.get().getProjectName());
         Assertions.assertEquals("projectVersionName", validParse.get().getProjectVersion());
@@ -59,7 +59,7 @@ public class PipInspectorTreeParserTest {
             "   test==4.0.0"
         );
 
-        Optional<NameVersionCodeLocation> validParse = parser.parse(pipInspectorOutput, "src/path", false);
+        Optional<NameVersionCodeLocation> validParse = parser.parse(pipInspectorOutput, "src/path");
         Assertions.assertTrue(validParse.isPresent());
         Assertions.assertEquals("", validParse.get().getProjectName());
         Assertions.assertEquals("", validParse.get().getProjectVersion());
@@ -74,20 +74,6 @@ public class PipInspectorTreeParserTest {
     }
 
     @Test
-    void projectNotFoundWhenNameGivenTest() {
-        List<String> pipInspectorOutput = Arrays.asList(
-            "n?==v?",
-            "   with-dashes==1.0.0",
-            "   Uppercase==2.0.0",
-            "      child==3.0.0",
-            "   test==4.0.0"
-        );
-
-        Optional<NameVersionCodeLocation> invalidParse = parser.parse(pipInspectorOutput, "src/path", true);
-        Assertions.assertFalse(invalidParse.isPresent());
-    }
-
-    @Test
     public void packageNotFoundTest() {
         List<String> pipInspectorOutput = Arrays.asList(
             "--scikit-learn",
@@ -98,7 +84,7 @@ public class PipInspectorTreeParserTest {
             "   test==4.0.0"
         );
 
-        Optional<NameVersionCodeLocation> result = parser.parse(pipInspectorOutput, "src/path", true);
+        Optional<NameVersionCodeLocation> result = parser.parse(pipInspectorOutput, "src/path");
         Assertions.assertFalse(result.isPresent());
     }
 
@@ -107,7 +93,7 @@ public class PipInspectorTreeParserTest {
         List<String> invalidText = new ArrayList<>();
         invalidText.add("i am not a valid file");
         invalidText.add("the status should be optional.empty()");
-        Optional<NameVersionCodeLocation> invalidParse = parser.parse(invalidText, "", true);
+        Optional<NameVersionCodeLocation> invalidParse = parser.parse(invalidText, "");
         Assertions.assertFalse(invalidParse.isPresent());
     }
 
@@ -117,7 +103,7 @@ public class PipInspectorTreeParserTest {
         invalidText.add(PipInspectorTreeParser.UNKNOWN_PACKAGE_PREFIX + "probably_an_internal_dependency_PY");
         invalidText.add(PipInspectorTreeParser.UNPARSEABLE_REQUIREMENTS_PREFIX + "/not/a/real/path/encrypted/requirements.txt");
         invalidText.add(PipInspectorTreeParser.UNKNOWN_REQUIREMENTS_PREFIX + "/not/a/real/path/requirements.txt");
-        Optional<NameVersionCodeLocation> invalidParse = parser.parse(invalidText, "", true);
+        Optional<NameVersionCodeLocation> invalidParse = parser.parse(invalidText, "");
         Assertions.assertFalse(invalidParse.isPresent());
     }
 }

--- a/documentation/src/main/markdown/packagemgrs/python.md
+++ b/documentation/src/main/markdown/packagemgrs/python.md
@@ -84,7 +84,7 @@ Pip Native Inspector runs the [pip-inspector.py script](https://github.com/black
 python setup.py install
 pip install -r requirements.txt
 ````
-* Pip detector derives your project name using your setup.py file if you have one. If you do not have a setup.py file, you must provide the correct project name using the propety --detect.pip.project.name.
+* Pip detector attempts to derive the project name using your setup.py file if you have one. If you do not have a setup.py file, you can provide the correct project name using the propety `--detect.pip.project.name`.
 * If there are any dependencies specified in requirements.txt that are not specified in setup.py, then provide the requirements.txt file using the [detect_product_short] property.   
 <note type="tip">If you are using a virtual environment, be sure to switch to that virtual environment when you run [detect_product_short]. This also applies when you are using a tool such as Poetry that sets up a Python virtual environment.</note>
 


### PR DESCRIPTION
Do not fail extraction if inspector cannot find the root project and minor doc update

# Description

Outside of virtual environments, even after running `python setup.py install` PIP inspector cannot find the project package in cache.
Even running `pip list` does not show the project package in such cases, so it doesn't look like we have a clear way to modify the inspector to be able to find it.

This means that a recent change to fail extractions when the project is not found in PIP cache was too aggressive. This PR reverts parts of it.