### PR TITLE
Gracefully handle invalid property keys passed to Detect

### DIFF
--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/ExternalProperties.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/ExternalProperties.java
@@ -1,0 +1,97 @@
+package com.blackduck.integration.configuration.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ExternalProperties {
+
+    public enum DockerPassthroughProperties {
+        BDIO_PROJECT_NAME("bdio.project.name"),
+        BDIO_PROJECT_VERSION("bdio.project.version"),
+        BDIO_CODELOCATION_PREFIX("bdio.codelocation.prefix"),
+        BDIO_CODELOCATION_NAME("bdio.codelocation.name"),
+        WORKING_DIR_PATH("working.dir.path"),
+        SYSTEM_PROPERTIES_PATH("system.properties.path"),
+        CLEANUP_WORKING_DIR("cleanup.working.dir"),
+        TARGET_IMAGE_LINUX_DISTRO_OVERRIDE("linux.distro"),
+        COMMAND_TIMEOUT("command.timeout"),
+        SERVICE_TIMEOUT("service.timeout"),
+        LOGGING_LEVEL("logging.level.detect"),
+        OUTPUT_PATH("output.path"),
+        OUTPUT_INCLUDE_CONTAINERFILESYSTEM("output.include.containerfilesystem"),
+        OUTPUT_INCLUDE_SQUASHEDIMAGE("output.include.squashedimage"),
+        CONTAINER_FILESYSTEM_EXCLUDED_PATHS("output.containerfilesystem.excluded.paths"),
+        USE_PLATFORM_DEFAULT_DOCKER_HOST("use.platform.default.docker.host"),
+        DOCKER_IMAGE("docker.image"),
+        DOCKER_IMAGE_PLATFORM("docker.image.platform"),
+        DOCKER_TAR("docker.tar"),
+        DOCKER_IMAGE_ID("docker.image.id"),
+        DOCKER_IMAGE_REPO("docker.image.repo"),
+        DOCKER_PLATFORM_TOP_LAYER_ID("docker.platform.top.layer.id"),
+        DOCKER_IMAGE_TAG("docker.image.tag"),
+        CALLER_NAME("caller.name"),
+        CALLER_VERSION("caller.version"),
+        INSPECTOR_REPOSITORY("inspector.repository"),
+        INSPECTOR_IMAGE_FAMILY("inspector.image.family"),
+        INSPECTOR_IMAGE_VERSION("inspector.image.version"),
+        CLEANUP_TARGET_IMAGE("cleanup.target.image"),
+        CLEANUP_INSPECTOR_CONTAINER("cleanup.inspector.container"),
+        CLEANUP_INSPECTOR_IMAGE("cleanup.inspector.image"),
+        ORGANIZE_COMPONENTS_BY_LAYER("bdio.organize.components.by.layer"),
+        INCLUDE_REMOVED_COMPONENTS("bdio.include.removed.components"),
+        SHARED_DIR_PATH_LOCAL("shared.dir.path.local"),
+        SHARED_DIR_PATH_IMAGEINSPECTOR("shared.dir.path.imageinspector"),
+        IMAGEINSPECTOR_SERVICE_URL("imageinspector.service.url"),
+        IMAGEINSPECTOR_SERVICE_START("imageinspector.service.start"),
+        IMAGEINSPECTOR_CONTAINER_PORT_ALPINE("imageinspector.service.container.port.alpine"),
+        IMAGEINSPECTOR_CONTAINER_PORT_CENTOS("imageinspector.service.container.port.centos"),
+        IMAGEINSPECTOR_CONTAINER_PORT_UBUNTU("imageinspector.service.container.port.ubuntu"),
+        IMAGEINSPECTOR_HOST_PORT_ALPINE("imageinspector.service.port.alpine"),
+        IMAGEINSPECTOR_HOST_PORT_CENTOS("imageinspector.service.port.centos"),
+        IMAGEINSPECTOR_HOST_PORT_UBUNTU("imageinspector.service.port.ubuntu"),
+        IMAGEINSPECTOR_DEFAULT_DISTRO("imageinspector.service.distro.default"),
+        IMAGEINSPECTOR_SERVICE_LOG_LENGTH("imageinspector.service.log.length"),
+        OFFLINE_MODE("offline.mode"),
+        HELP_OUTPUT_PATH("help.output.path"),
+        HELP_INPUT_PATH("help.input.path");
+
+        private static final String PREFIX = "detect.docker.passthrough.";
+        private final String key;
+
+        DockerPassthroughProperties(String key) {
+            this.key = PREFIX + key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
+    public enum PhoneHomePassthroughProperties {
+        DESKTOP_PLATFORM_NAME("desktop.platformname"),
+        DESKTOP_PLATFORM_RELEASE("desktop.platformrelease"),
+        DESKTOP_VERSION("desktop.version");
+
+        private static final String PREFIX = "detect.phone.home.passthrough.";
+        private final String key;
+
+        PhoneHomePassthroughProperties(String key) {
+            this.key = PREFIX + key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
+    public static Set<String> getAllExternalPropertyKeys() {
+        Set<String> keys = new HashSet<>();
+        for (DockerPassthroughProperties dockerPassthroughProperty : DockerPassthroughProperties.values()) {
+            keys.add(dockerPassthroughProperty.getKey());
+        }
+        for (PhoneHomePassthroughProperties phoneHomePassthroughProperty : PhoneHomePassthroughProperties.values()) {
+            keys.add(phoneHomePassthroughProperty.getKey());
+        }
+        return keys;
+    }
+}

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
@@ -1,9 +1,0 @@
-package com.blackduck.integration.configuration.config;
-
-import com.blackduck.integration.configuration.parse.ValueParseException;
-
-public class InvalidPropertyKeyException extends RuntimeException {
-    public InvalidPropertyKeyException(String message) {
-        super(message);
-    }
-}

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
@@ -1,0 +1,10 @@
+package com.blackduck.integration.configuration.config;
+
+public class InvalidPropertyKeyException extends RuntimeException {
+    public InvalidPropertyKeyException(String propertyKeys) {
+        super(String.format(
+                "Invalid property key(s): %s",
+                propertyKeys
+        ));
+    }
+}

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/InvalidPropertyKeyException.java
@@ -1,10 +1,9 @@
 package com.blackduck.integration.configuration.config;
 
+import com.blackduck.integration.configuration.parse.ValueParseException;
+
 public class InvalidPropertyKeyException extends RuntimeException {
-    public InvalidPropertyKeyException(String propertyKeys) {
-        super(String.format(
-                "Invalid property key(s): %s",
-                propertyKeys
-        ));
+    public InvalidPropertyKeyException(String message) {
+        super(message);
     }
 }

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/MaskedRawValueResult.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/MaskedRawValueResult.java
@@ -1,0 +1,21 @@
+package com.blackduck.integration.configuration.config;
+
+import java.util.Map;
+
+public class MaskedRawValueResult {
+    private final String aggregatedMessage;
+    private final Map<String, String> rawMap;
+
+    public MaskedRawValueResult(String aggregatedMessage, Map<String, String> rawMap) {
+        this.aggregatedMessage = aggregatedMessage;
+        this.rawMap = rawMap;
+    }
+
+    public String getAggregatedMessage() {
+        return aggregatedMessage;
+    }
+
+    public Map<String, String> getRawMap() {
+        return rawMap;
+    }
+}

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
@@ -240,13 +240,10 @@ public class PropertyConfiguration {
     // This method is used to get the masked raw value map with an aggregated message about invalid keys.
     // It uses the existing getMaskedRawValueMap method to get the valid properties and their values.
     @NotNull
-    public Map<String, Object> getMaskedRawValueMapWithMessage(@NotNull Set<Property> properties, Predicate<String> shouldMask) {
+    public MaskedRawValueResult getMaskedRawValueResult(@NotNull Set<Property> properties, Predicate<String> shouldMask) {
         Map<String, String> rawMap = getMaskedRawValueMap(properties, shouldMask);
         String aggregatedMessage = handleInvalidKeys(properties, getCurrentDetectPropertyKeys());
-        Map<String, Object> result = new HashMap<>();
-        result.put("rawMap", rawMap);
-        result.put("aggregatedMessage", aggregatedMessage);
-        return result;
+        return new MaskedRawValueResult(aggregatedMessage, rawMap);
     }
 
     // This method is used to get the current detect property keys from the property sources like command line args,

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
@@ -35,6 +35,7 @@ public class PropertyConfiguration {
     private final List<PropertySource> orderedPropertySources;
     private SortedMap<String, String> scanSettingsProperties;
     private static final String SCAN_SETTINGS_FAILURE_MSG = "There was an error parsing the value from Scan Settings File";
+    private static final String DETECT_PROPERTY_DOC_URL = "https://documentation.blackduck.com/bundle/detect/page/properties/all-properties.html";
 
     public PropertyConfiguration(@NotNull List<PropertySource> orderedPropertySources, SortedMap<String, String> scanSettingsProperties) {
         this.orderedPropertySources = orderedPropertySources;
@@ -177,15 +178,6 @@ public class PropertyConfiguration {
             .collect(Collectors.toSet());
     }
 
-    @NotNull
-    public Set<String> getCurrentDetectPropertyKeys() {
-        return orderedPropertySources.stream()
-                .map(PropertySource::getKeys)
-                .flatMap(Set::stream)
-                .filter(key -> key.startsWith("detect") || key.startsWith("blackduck"))
-                .collect(Collectors.toSet());
-    }
-
     public <V, R> Optional<ValueParseException> getPropertyException(@NotNull TypedProperty<V, R> property) {
         assertPropertyNotNull(property);
         return valueFromCache(property).getException();
@@ -245,6 +237,8 @@ public class PropertyConfiguration {
         return rawMap;
     }
 
+    // This method is used to get the masked raw value map with an aggregated message about invalid keys.
+    // It uses the existing getMaskedRawValueMap method to get the valid properties and their values.
     @NotNull
     public Map<String, Object> getMaskedRawValueMapWithMessage(@NotNull Set<Property> properties, Predicate<String> shouldMask) {
         Map<String, String> rawMap = getMaskedRawValueMap(properties, shouldMask);
@@ -255,6 +249,33 @@ public class PropertyConfiguration {
         return result;
     }
 
+    // This method is used to get the current detect property keys from the property sources like command line args,
+    // configuration file, environment variables etc.
+    @NotNull
+    public Set<String> getCurrentDetectPropertyKeys() {
+        LevenshteinDistance levenshtein = new LevenshteinDistance();
+        int maxDistance = 3;
+
+        return orderedPropertySources.stream()
+                .map(PropertySource::getKeys)
+                .flatMap(Set::stream)
+                .filter(key -> isMatchingKey(key, levenshtein, maxDistance))
+                .collect(Collectors.toSet());
+    }
+
+    // This method checks if the property key extracted from the sources matches any of the `detect` or `blackduck`
+    // related property keys using Levenshtein distance algorithm.
+    private boolean isMatchingKey(String key, LevenshteinDistance levenshtein, int maxDistance) {
+        String[] segments = key.split("\\.");
+        return levenshtein.apply(segments[0], "detect") <= maxDistance ||
+                levenshtein.apply(segments[0], "blackduck") <= maxDistance ||
+                (segments.length > 1 &&
+                        levenshtein.apply(segments[0], "logging") <= maxDistance &&
+                        levenshtein.apply(segments[1], "level") <= maxDistance);
+    }
+
+    // This method is used to handle invalid keys by checking if they are present in the valid keys set.
+    // If not, it suggests similar keys using Jaro-Winkler similarity algorithm.
     public static String handleInvalidKeys(Set<Property> properties, Set<String> currentPropertyKeys) {
         Set<String> validKeys = properties.stream().map(Property::getKey).collect(Collectors.toSet());
         validKeys.addAll(ExternalProperties.getAllExternalPropertyKeys());
@@ -273,13 +294,17 @@ public class PropertyConfiguration {
             }
         }
         if (!invalidKeys.isEmpty()) {
-            aggregatedMessage.append("The following property keys are not valid: ").append(String.join(", ", invalidKeys));
+            aggregatedMessage.append("The following property keys are not valid: ")
+                    .append(String.join(", ", invalidKeys))
+                    .append(String.format(". For a comprehensive list of detect properties, visit: %s", DETECT_PROPERTY_DOC_URL));
         }
         return aggregatedMessage.toString();
     }
 
+    // This method finds similar keys to the invalid key using Jaro-Winkler similarity algorithm.
+    // jaroWinklerThreshold value is set to 0.94 for a strict match. Thus suggesting most appropriate property keys.
     public static List<String> findSimilarKeys(String invalidKey, Set<String> validKeys, JaroWinklerSimilarity jaroWinkler) {
-        double jaroWinklerThreshold = 0.95;
+        double jaroWinklerThreshold = 0.94;
         return validKeys.stream()
                 .filter(key -> jaroWinkler.apply(invalidKey, key) >= jaroWinklerThreshold)
                 .sorted(Comparator.comparingDouble(key -> -jaroWinkler.apply(invalidKey, key)))

--- a/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/config/PropertyConfiguration.java
@@ -248,11 +248,11 @@ public class PropertyConfiguration {
 
     public static void handleInvalidKeys(Set<Property> properties, Set<String> currentPropertyKeys) {
         Set<String> validKeys = properties.stream().map(Property::getKey).collect(Collectors.toSet());
-        LevenshteinDistance levenshtein = new LevenshteinDistance();
+        validKeys.addAll(ExternalProperties.getAllExternalPropertyKeys());
         JaroWinklerSimilarity jaroWinkler = new JaroWinklerSimilarity();
         for (String key : currentPropertyKeys) {
             if (!validKeys.contains(key)) {
-                List<String> similarKeys = findSimilarKeys(key, validKeys, levenshtein, jaroWinkler);
+                List<String> similarKeys = findSimilarKeys(key, validKeys, jaroWinkler);
                 if (!similarKeys.isEmpty()) {
                     logger.warn("Property key '{}' is not valid. The most similar keys are: {}", key, similarKeys);
                 }
@@ -260,11 +260,11 @@ public class PropertyConfiguration {
         }
     }
 
-    public static List<String> findSimilarKeys(String invalidKey, Set<String> validKeys, LevenshteinDistance levenshtein, JaroWinklerSimilarity jaroWinkler) {
-        int levenshteinThreshold = 3;
-        double jaroWinklerThreshold = 0.94;
+    public static List<String> findSimilarKeys(String invalidKey, Set<String> validKeys, JaroWinklerSimilarity jaroWinkler) {
+        double jaroWinklerThreshold = 0.95;
         return validKeys.stream()
                 .filter(key -> jaroWinkler.apply(invalidKey, key) >= jaroWinklerThreshold)
+                .sorted(Comparator.comparingDouble(key -> -jaroWinkler.apply(invalidKey, key)))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -13,6 +13,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Collections;
 
+import com.blackduck.integration.configuration.config.MaskedRawValueResult;
 import com.blackduck.integration.configuration.property.types.enumallnone.list.AllEnumList;
 import com.blackduck.integration.configuration.property.types.path.PathValue;
 import com.blackduck.integration.detect.configuration.connection.BlackDuckConnectionDetails;
@@ -340,17 +341,17 @@ public class DetectBoot {
     }
 
     private SortedMap<String, String> collectMaskedRawPropertyValues(PropertyConfiguration propertyConfiguration) {
-        Map<String, Object> result = propertyConfiguration.getMaskedRawValueMapWithMessage(
-                new HashSet<>(DetectProperties.allProperties().getProperties()),
-                DetectPropertyUtil.getPasswordsAndTokensPredicate()
+        MaskedRawValueResult result = propertyConfiguration.getMaskedRawValueResult(
+            new HashSet<>(DetectProperties.allProperties().getProperties()),
+            DetectPropertyUtil.getPasswordsAndTokensPredicate()
         );
-        String aggregatedMessage = (String) result.get("aggregatedMessage");
+
+        String aggregatedMessage = result.getAggregatedMessage();
         if (aggregatedMessage != null && !aggregatedMessage.isEmpty()) {
             DetectIssue.publish(eventSystem, DetectIssueType.PROPERTY_KEY, "Property Key Issue", aggregatedMessage);
         }
 
-        Map<String, String> rawMap = (Map<String, String>) result.get("rawMap");
-        return new TreeMap<>(rawMap);
+        return new TreeMap<>(result.getRawMap());
     }
 
     private void publishCollectedPropertyValues(Map<String, String> maskedRawPropertyValues) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/boot/DetectBoot.java
@@ -350,7 +350,6 @@ public class DetectBoot {
         }
 
         Map<String, String> rawMap = (Map<String, String>) result.get("rawMap");
-
         return new TreeMap<>(rawMap);
     }
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/status/DetectIssueType.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/status/DetectIssueType.java
@@ -8,5 +8,6 @@ public enum DetectIssueType {
     BINARY_SCAN,
     IMPACT_ANALYSIS,
     DETECTABLE_TOOL,
-    IAC_SCANNER
+    IAC_SCANNER,
+    PROPERTY_KEY
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/status/DetectStatusLogger.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/status/DetectStatusLogger.java
@@ -79,10 +79,12 @@ public class DetectStatusLogger {
             Predicate<DetectIssue> detectableToolsFilter = issue -> issue.getType() == DetectIssueType.DETECTABLE_TOOL;
             Predicate<DetectIssue> exceptionsFilter = issue -> issue.getType() == DetectIssueType.EXCEPTION;
             Predicate<DetectIssue> deprecationsFilter = issue -> issue.getType() == DetectIssueType.DEPRECATION;
+            Predicate<DetectIssue> propertyKeysFilter = issue -> issue.getType() == DetectIssueType.PROPERTY_KEY;
             logIssuesInGroup(logger, "DETECTORS:", detectorsFilter, detectIssues);
             logIssuesInGroup(logger, "DETECTABLE TOOLS:", detectableToolsFilter, detectIssues);
             logIssuesInGroup(logger, "EXCEPTIONS:", exceptionsFilter, detectIssues);
             logIssuesInGroup(logger, "DEPRECATIONS:", deprecationsFilter, detectIssues);
+            logIssuesInGroup(logger, "PROPERTY KEYS:", propertyKeysFilter, detectIssues);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4639


**Description**

This update ensures that invalid property keys passed to detect are handled gracefully by providing warnings and suggesting similar valid keys, without throwing exceptions. An aggregated message is logged at the end of execution to inform users about invalid properties and their suggested corrections.


**Implementation Details**

- The [Levenshtein Distance algorithm](https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/similarity/LevenshteinDistance.html) from the **_apache-commons-text_** library has been used to filter `detect` and `blackduck` poperties and identify potentially invalid or misspelled property keys from various property sources, such as command-line arguments, environment variables, and configuration files. 

- Invalid property keys are identified by comparing them against a source of truth. So, a valid list of property keys was needed. All `detect` and `blackduck` properties are extracted from the `DetectProperties` class.

- The docker and phone home passthrough properties (passed via `detect.docker.passthrough` and `detect.phone.home.passthrough`) are handled separately. A new class, `ExternalProperties`, has been introduced to store these properties, and a method named `getAllExternalPropertyKeys()` has been added to retrieve them.

- The [Jaro-Winkler Similarity algorithm](https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/similarity/JaroWinklerSimilarity.html) from **_apache-commons-text_** has been used to suggest corrections for invalid property keys.

- A new `DetectIssueType` enum named `PROPERTY_KEY` has been introduced. It logs accumulated messages about invalid property keys during the Detect Issue phase, ensuring users are informed at the end of execution.

- All `nuget` inspector property keys remain unaffected, ensuring that invalid property keys do not interfere with existing functionality in the `NugetInspectorArguments` class.

- Invalid property keys are prevented (default detect behavior) from being set in the autonomous scan settings file when `detect.autonomous.scan.enabled=true`.

