### PR TITLE
auto update fallbacks

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
@@ -674,16 +674,14 @@ public class ApplicationUpdater extends URLClassLoader {
 
         if (newFileName == null) {
             newFileName = extractFileNameFromUrl(downloadUrl);
-        }
-
-        File potentialNewJar = downloadNewJar(response, installDirectory, newFileName);
-
-        if (potentialNewJar == null) {
-            logger.warn("Failed to download the new Detect JAR.");
+        } else {
+            logger.warn("Unable to determine Detect jar filename. Detect update will not occur.");
             return null;
         }
 
-        if (newVersionString == null) {
+        File potentialNewJar = downloadNewJarIfNeeded(response, installDirectory, newFileName, newVersionString);
+
+        if (newVersionString == null && potentialNewJar != null) {
             newVersionString = getVersionFromJar(potentialNewJar);
         }
 
@@ -694,9 +692,25 @@ public class ApplicationUpdater extends URLClassLoader {
 
         currentInstalledVersion = getVersionFromDetectFileName(currentInstalledVersion);
         if (shouldUpdate(currentInstalledVersion, newVersionString)) {
+            if (potentialNewJar == null) {
+                potentialNewJar = downloadNewJar(response, installDirectory, newFileName); 
+                
+                if (potentialNewJar == null) {
+                    logger.warn("Failed to download the new Detect JAR.");
+                    return null;
+                }
+            }
+            
             return validateDownloadedJar(potentialNewJar);
         } else {
             logger.info("New version {} is not applicable for update. Using existing version {} instead.", newVersionString, currentInstalledVersion);
+        }
+        return null;
+    }
+    
+    private File downloadNewJarIfNeeded(Response response, File installDirectory, String newFileName, String newVersionString) throws IOException, IntegrationException {
+        if (newVersionString == null) {
+            return downloadNewJar(response, installDirectory, newFileName);
         }
         return null;
     }

--- a/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
@@ -685,7 +685,7 @@ public class ApplicationUpdater extends URLClassLoader {
             if (newVersionString == null) {
                 // If we still have not obtained the version, get it from the jar's version.txt file
                 newVersionString = getVersionFromJar(potentialNewJar);
-            }
+            } // TODO the failure here is currently handled later which is a bit weird
             
             // If we have the version at this point, see if we should update.
             currentInstalledVersion = getVersionFromDetectFileName(currentInstalledVersion);
@@ -694,6 +694,8 @@ public class ApplicationUpdater extends URLClassLoader {
                 if (!newVersionString.equals(currentInstalledVersion)
                         && !isDownloadVersionTooOld(currentInstalledVersion, newVersionString)) {
                     return validateDownloadedJar(potentialNewJar);
+                } else {
+                    // TODO perhaps explain why not updating here as it isn't really a problem with the response
                 }
             }
         }

--- a/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
+++ b/src/main/java/com/blackduck/integration/detect/ApplicationUpdater.java
@@ -665,8 +665,6 @@ public class ApplicationUpdater extends URLClassLoader {
         if (newVersionString == null && newFileName != null) {
             newVersionString = getVersionFromDetectFileName(newFileName);
         }
-        
-        File potentialNewJar = null;
 
         if (response.isStatusCodeSuccess()) {
             if (newFileName == null) {
@@ -676,10 +674,10 @@ public class ApplicationUpdater extends URLClassLoader {
                 URL url = new URL(trueDownloadUrl);
                 String path = url.getPath();
                 newFileName = path.substring(path.lastIndexOf('/') + 1);
-            }
+            } // TODO need to error if can't get filename
             
             // Initial call successful, follow the redirect to download the jar
-            potentialNewJar = handleSuccessResponse(response, installDirectory.getAbsolutePath(), newFileName);
+            File potentialNewJar = handleSuccessResponse(response, installDirectory.getAbsolutePath(), newFileName);
             logger.debug("{} New File Name: {}", LOG_PREFIX, newFileName);
             
             if (newVersionString == null) {


### PR DESCRIPTION
This PR adds support for primarily two new autoupdated cases:

1) It allows the jar to be named anything
2) It allows for updating even when version and file name headers are not set. In these cases we'll try to obtain the file name from the URL and the version from the filename or the jar's version.txt contents.

The flow is a bit more complex than before but I tried to make it sequential in that we try to get the filename and version in the cheapest ways first and ultimately skip the update if we can never obtain them.