### PR TITLE
Use bom-status/{scanID} Error State for Reporting Detect Success Status

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -31,7 +31,7 @@ public enum ExitCodeType {
     FAILURE_BLACKDUCK_DUPLICATE_PROJECT_ERROR(21, "Project name already exists, unable to create project."),
 
     FAILURE_COMPONENT_LOCATION_ANALYSIS(25, "Component Location Analysis failed."),
-
+    FAILURE_BOM_PREPARATION(30, "Black Duck failed to prepare BOM for the scan."),
     FAILURE_GENERAL_ERROR(99, "Detect encountered a known error, details of the error are provided."),
     FAILURE_UNKNOWN_ERROR(100, "Detect encountered an unknown error.");
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -204,7 +204,6 @@ import com.blackduck.integration.detector.rule.DetectorRuleSet;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.log.IntLogger;
 import com.blackduck.integration.log.Slf4jIntLogger;
-import com.blackduck.integration.rest.HttpMethod;
 import com.blackduck.integration.rest.HttpUrl;
 import com.blackduck.integration.rest.body.FileBodyContent;
 import com.blackduck.integration.rest.response.Response;
@@ -1589,9 +1588,6 @@ public class OperationRunner {
                     detectConfigurationFactory.findTimeoutInSeconds(),
                     calculateMaxWaitInSeconds(fibonacciSequenceIndex)
             );
-
-            // deliberate failure
-//            bomStatusScanView.setStatus(BomStatusScanStatusType.FAILURE);
             checkBomStatusAndHandleFailure(bomStatusScanView, scanUrl);
 
             return bomStatusScanView;
@@ -1600,8 +1596,9 @@ public class OperationRunner {
 
     private void checkBomStatusAndHandleFailure(BomStatusScanView bomStatusScanView, HttpUrl scanUrl) {
         if (bomStatusScanView.getStatus() == BomStatusScanStatusType.FAILURE) {
-            logger.error("BomStatusScanView indicates " + bomStatusScanView.getStatus() + " for scan URL: " + scanUrl);
-            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_GENERAL_ERROR, "BOM scan failed or was not included due to a detected issue.");
+            String errorMessage = String.format("Black Duck response indicates %s for scan URL: %s", BomStatusScanStatusType.FAILURE, scanUrl);
+            logger.error(errorMessage);
+            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BOM_PREPARATION, "Black Duck failed to prepare BOM for the scan");
         }
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1588,17 +1588,17 @@ public class OperationRunner {
                     detectConfigurationFactory.findTimeoutInSeconds(),
                     calculateMaxWaitInSeconds(fibonacciSequenceIndex)
             );
-            checkBomStatusAndHandleFailure(bomStatusScanView, scanUrl);
+            checkBomStatusAndHandleFailure(bomStatusScanView);
 
             return bomStatusScanView;
         });
     }
 
-    private void checkBomStatusAndHandleFailure(BomStatusScanView bomStatusScanView, HttpUrl scanUrl) {
+    private void checkBomStatusAndHandleFailure(BomStatusScanView bomStatusScanView) {
         if (bomStatusScanView.getStatus() == BomStatusScanStatusType.FAILURE) {
-            String errorMessage = String.format("Black Duck response indicates %s for scan URL: %s", BomStatusScanStatusType.FAILURE, scanUrl);
-            logger.error(errorMessage);
-            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BOM_PREPARATION, "Black Duck failed to prepare BOM for the scan");
+            String message = "Black Duck failed to prepare BOM for the scan";
+            logger.error("BOM Scan Status: {} - {}.", BomStatusScanStatusType.FAILURE, message);
+            exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BOM_PREPARATION, message);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4222

**Description**

This merge request addresses the issue where detect would report success even if the `/bom-status/{scanID}` endpoint indicated a failure after the scan upload. 
Previously, detect relied on notifications from Black Duck to determine BOM completion, which did not provide detailed status information. By using the `/bom-status/{scanID}` endpoint, detect can now identify and report failure status and reflect this to the final status and exit code. 

A new exit code, `FAILURE_BOM_PREPARATION (30)`, was introduced to handle BOM scan failure scenarios, providing a clear and specific error message when Black Duck fails to prepare the BOM for the scan.