### PR TITLE
rev bd-common to use v2 pm scan endpoint

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='67.0.5'
+gradle.ext.blackDuckCommonVersion='67.0.6'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
This moves package manager scans to the newer v2 package manager scan endpoint by bringing in the latest blackduck-common library.