### PR TITLE
streamline clone properties

### DIFF
--- a/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/list/AllNoneEnumListBase.java
@@ -76,6 +76,22 @@ public class AllNoneEnumListBase<E extends Enum<E>, B extends Enum<B>> implement
             return toPresentValues();
         }
     }
+    
+    /**
+     * This returns null if the properties' value is set to ALL values of the Enum.
+     * It returns an empty array if the value is set to NONE.
+     * This streamlines things for newer 2023.10.0 and later endpoints.
+     * Older endpoints should use representedValues.
+     */
+    public List<B> representedValuesStreamlined() {
+        if (containsNone()) {
+            return new ArrayList<>();
+        } else if (containsAll()) {
+            return null;
+        } else {
+            return toPresentValues();
+        }
+    }
 
     public Set<B> representedValueSet() {
         return new HashSet<>(representedValues());

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='67.0.6'
+gradle.ext.blackDuckCommonVersion='67.0.7'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1370,7 +1370,7 @@ public class OperationRunner {
                     projectGroupFindResult,
                     cloneFindResult,
                     projectVersionLicensesFindResult,
-                    detectConfigurationFactory.createDetectProjectServiceOptions()
+                    detectConfigurationFactory.createDetectProjectServiceOptions(blackDuckRunData.getBlackDuckServerVersion())
                 )
         );
     }

--- a/src/test/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactoryTests.java
+++ b/src/test/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactoryTests.java
@@ -1,30 +1,30 @@
 package com.blackduck.integration.detect.configuration;
 
 import static com.blackduck.integration.detect.configuration.DetectConfigurationFactoryTestUtils.factoryOf;
-import static com.blackduck.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 import static com.blackduck.integration.detect.configuration.DetectConfigurationFactoryTestUtils.scanSettingsFactoryOf;
+import static com.blackduck.integration.detect.configuration.DetectConfigurationFactoryTestUtils.spyFactoryOf;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import com.blackduck.integration.detect.configuration.connection.BlackDuckConnectionDetails;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.blackduck.integration.blackduck.api.generated.enumeration.ProjectCloneCategoriesType;
+import com.blackduck.integration.blackduck.version.BlackDuckVersion;
 import com.blackduck.integration.common.util.Bdo;
-import com.blackduck.integration.detect.configuration.DetectConfigurationFactory;
-import com.blackduck.integration.detect.configuration.DetectProperties;
-import com.blackduck.integration.detect.configuration.DetectUserFriendlyException;
+import com.blackduck.integration.detect.configuration.connection.BlackDuckConnectionDetails;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.blackduck.integration.detect.configuration.enumeration.DefaultDetectorSearchExcludedDirectories;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
 import com.blackduck.integration.detect.tool.signaturescanner.BlackDuckSignatureScannerOptions;
+import com.blackduck.integration.detect.workflow.blackduck.project.options.ProjectSyncOptions;
 import com.blackduck.integration.rest.credentials.Credentials;
 
 public class DetectConfigurationFactoryTests {
@@ -155,5 +155,53 @@ public class DetectConfigurationFactoryTests {
 
         Assertions.assertTrue(blackduckUrlString.isPresent());
         blackduckUrlString.ifPresent(str -> Assertions.assertEquals(str, blackduckUserUrl));
+    }
+    
+    @Test
+    public void testAllCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "ALL"));
+
+        BlackDuckVersion minVersion = new BlackDuckVersion(2023, 10, 0);
+        Optional<BlackDuckVersion> serverVersion = Optional.of(minVersion);
+
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions(serverVersion);
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
+
+        Assertions.assertTrue(cloneCategories == null);
+    }
+
+    @Test
+    public void testNoCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, "NONE"));
+
+        BlackDuckVersion minVersion = new BlackDuckVersion(2023, 10, 0);
+        Optional<BlackDuckVersion> serverVersion = Optional.of(minVersion);
+
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions(serverVersion);
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
+
+        Assertions.assertTrue(cloneCategories.isEmpty()); 
+    }
+
+    @Test
+    public void testSpecificCloneCategories() {
+        DetectConfigurationFactory factory = factoryOf(
+                Pair.of(DetectProperties.DETECT_PROJECT_CLONE_CATEGORIES, 
+                        ProjectCloneCategoriesType.CUSTOM_FIELD_DATA.toString() 
+                        + "," 
+                        + ProjectCloneCategoriesType.DEEP_LICENSE.toString()
+                ));
+
+        BlackDuckVersion minVersion = new BlackDuckVersion(2023, 10, 0);
+        Optional<BlackDuckVersion> serverVersion = Optional.of(minVersion);
+
+        ProjectSyncOptions projectSyncOptions = factory.createDetectProjectServiceOptions(serverVersion);
+
+        List<ProjectCloneCategoriesType> cloneCategories = projectSyncOptions.getCloneCategories();
+
+        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.CUSTOM_FIELD_DATA));
+        Assertions.assertTrue(cloneCategories.contains(ProjectCloneCategoriesType.DEEP_LICENSE));
     }
 }


### PR DESCRIPTION
This moves us to the new v7 API where we no longer have to send a list of values. This adds a bit of safety as we a) don't miss values when a user asks for ALL and b) don't send old values that cause BD to fail.
