### PR TITLE
Make error logging more clear when configuration file parse fails

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/Application.java
+++ b/src/main/java/com/blackduck/integration/detect/Application.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 import com.google.gson.Gson;
@@ -59,7 +60,7 @@ import com.blackduck.integration.detect.workflow.status.DetectIssueType;
 import com.blackduck.integration.detect.workflow.status.DetectStatusManager;
 
 public class Application implements ApplicationRunner {
-    private final Logger logger = LoggerFactory.getLogger(Application.class);
+    private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
     private static boolean SHOULD_EXIT = true;
     
@@ -89,15 +90,16 @@ public class Application implements ApplicationRunner {
         configureLoggingGroupIfNeeded(args);
         SpringApplicationBuilder builder = new SpringApplicationBuilder(Application.class);
         builder.logStartupInfo(false);
+        builder.listeners(new SpringConfigErrorListener());
+
         boolean selfUpdated = false;
         ApplicationUpdaterUtility utility = new ApplicationUpdaterUtility();
         try(ApplicationUpdater updater = new ApplicationUpdater(utility, args)) {
             selfUpdated = updater.selfUpdate();
             updater.closeUpdater();
         } catch (IOException ex) {
-            Logger staticLogger = LoggerFactory.getLogger(Application.class);
-            staticLogger.warn("There was a problem running the Self-Update feature.");
-            staticLogger.debug("Reason: ", ex);
+            logger.warn("There was a problem running the Self-Update feature.");
+            logger.debug("Reason: ", ex);
         }
         if (!selfUpdated) {
             try {

--- a/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
+++ b/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
@@ -15,8 +15,8 @@ public class SpringConfigErrorListener implements ApplicationListener<Applicatio
     public void onApplicationEvent(ApplicationFailedEvent event) {
         logger.error("An exception of type {} was encountered during application configuration.", event.getException().getClass());
         logger.error("The exception message was: {}", event.getException().getMessage());
-        logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/overview.html for possible configuration sources and values.");            
         logger.error("A likely cause is an unparseable configuration file.");
+        logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/overview.html for possible configuration sources and values.");
 
         // issue an exit call to prevent a long confusing stacktrace from being printed by Spring
         System.exit(ExitCodeType.FAILURE_CONFIGURATION.getExitCode());

--- a/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
+++ b/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
@@ -13,9 +13,9 @@ public class SpringConfigErrorListener implements ApplicationListener<Applicatio
 
     @Override
     public void onApplicationEvent(ApplicationFailedEvent event) {
-        logger.error("An exception of type {} was encountered during application configuration.", event.getException().getClass());
+        logger.error("Spring Framework issued an ApplicationFailedEvent during application startup.");
+        logger.error("An exception of type {} was encountered.", event.getException().getClass());
         logger.error("The exception message was: {}", event.getException().getMessage());
-        logger.error("A likely cause is an unparseable configuration file.");
         logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/overview.html for possible configuration sources and values.");
 
         // issue an exit call to prevent a long confusing stacktrace from being printed by Spring

--- a/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
+++ b/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
@@ -1,0 +1,24 @@
+package com.blackduck.integration.detect;
+
+import org.springframework.context.ApplicationListener;
+
+import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+
+public class SpringConfigErrorListener implements ApplicationListener<ApplicationFailedEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(SpringConfigErrorListener.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationFailedEvent event) {
+        logger.error("An exception of type {} was encountered during application configuration.", event.getException().getClass());
+        logger.error("The exception message was: {}", event.getException().getMessage());
+        logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/overview.html for possible configuration sources and values.");            
+        logger.error("A likely cause is an unparseable configuration file.");
+
+        // issue an exit call to prevent a long confusing stacktrace from being printed by Spring
+        System.exit(ExitCodeType.FAILURE_CONFIGURATION.getExitCode());
+    }
+}

--- a/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
+++ b/src/main/java/com/blackduck/integration/detect/SpringConfigErrorListener.java
@@ -16,7 +16,7 @@ public class SpringConfigErrorListener implements ApplicationListener<Applicatio
         logger.error("Spring Framework issued an ApplicationFailedEvent during application startup.");
         logger.error("An exception of type {} was encountered.", event.getException().getClass());
         logger.error("The exception message was: {}", event.getException().getMessage());
-        logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/overview.html for possible configuration sources and values.");
+        logger.error("Please check https://documentation.blackduck.com/bundle/detect/page/configuring/configfile.html for possible configuration sources and values.");
 
         // issue an exit call to prevent a long confusing stacktrace from being printed by Spring
         System.exit(ExitCodeType.FAILURE_CONFIGURATION.getExitCode());

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -8,7 +8,7 @@ public enum ExitCodeType {
     FAILURE_PROXY_CONNECTIVITY(4, "Detect was unable to use the configured proxy. Check your configuration and connection."),
     FAILURE_DETECTOR(5, "Detect had one or more detector failures while extracting dependencies. Check that all projects build and your environment is configured correctly."),
     FAILURE_SCAN(6, "Detect was unable to run the signature scanner against your source. Check your configuration."),
-    FAILURE_CONFIGURATION(7, "Detect was unable to start due to issues with its configuration. Check and fix your configuration."),
+    FAILURE_CONFIGURATION(7, "Detect was unable to start due to configuration issues. Check and fix your configuration."),
     FAILURE_DETECTOR_REQUIRED(9, "Detect did not run all of the required detectors. Fix detector issues or disable required detectors."),
     FAILURE_BLACKDUCK_VERSION_NOT_SUPPORTED(
         10,

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -8,7 +8,7 @@ public enum ExitCodeType {
     FAILURE_PROXY_CONNECTIVITY(4, "Detect was unable to use the configured proxy. Check your configuration and connection."),
     FAILURE_DETECTOR(5, "Detect had one or more detector failures while extracting dependencies. Check that all projects build and your environment is configured correctly."),
     FAILURE_SCAN(6, "Detect was unable to run the signature scanner against your source. Check your configuration."),
-    FAILURE_CONFIGURATION(7, "Detect was unable to start due to issues with it's configuration. Check and fix your configuration."),
+    FAILURE_CONFIGURATION(7, "Detect was unable to start due to issues with its configuration. Check and fix your configuration."),
     FAILURE_DETECTOR_REQUIRED(9, "Detect did not run all of the required detectors. Fix detector issues or disable required detectors."),
     FAILURE_BLACKDUCK_VERSION_NOT_SUPPORTED(
         10,


### PR DESCRIPTION
# Description

## Examples of what gets logged after this change

### Example 1: bad Yaml file

```
2025-05-08 11:03:12 MDT ERROR [main] --- An exception of type class org.yaml.snakeyaml.scanner.ScannerException was encountered during application configuration.
2025-05-08 11:03:12 MDT ERROR [main] --- The exception message was: while scanning an anchor
 in 'reader', line 1, column 1:
    &
    ^
unexpected character found 
(10)
 in 'reader', line 1, column 2:
    &
     ^

2025-05-08 11:03:12 MDT ERROR [main] --- A likely cause is an unparseable configuration file.
2025-05-08 11:03:12 MDT ERROR [main] --- Please check https://documentation.blackduck.com/bundle/detect/page/configuring/configfile.html for possible configuration sources and values.
```

### Example 2: file permissions issue

```
2025-05-12 10:34:16 MDT ERROR [main] --- Spring Framework issued an ApplicationFailedEvent during application startup.
2025-05-12 10:34:16 MDT ERROR [main] --- An exception of type class java.lang.IllegalStateException was encountered.
2025-05-12 10:34:16 MDT ERROR [main] --- The exception message was: java.io.FileNotFoundException: application.yml (Permission denied)
2025-05-12 10:34:16 MDT ERROR [main] --- Please check https://documentation.blackduck.com/bundle/detect/page/configuring/configfile.html for possible configuration sources and values.
```

## Example From Before The Change

Before the change, the output did not contain some of the hints as to what might be wrong and had a long, not very useful stack trace:

```
2025-05-07 11:51:42 MDT ERROR [main] --- Application run failed
org.yaml.snakeyaml.scanner.ScannerException: while scanning an anchor
 in 'reader', line 1, column 1:
    &
    ^
unexpected character found 
(10)
 in 'reader', line 1, column 2:
    &
     ^

        at org.yaml.snakeyaml.scanner.ScannerImpl.scanAnchor(ScannerImpl.java:1498)
        at org.yaml.snakeyaml.scanner.ScannerImpl.fetchAnchor(ScannerImpl.java:968)
        at org.yaml.snakeyaml.scanner.ScannerImpl.fetchMoreTokens(ScannerImpl.java:401)
        at org.yaml.snakeyaml.scanner.ScannerImpl.checkToken(ScannerImpl.java:238)
        at org.yaml.snakeyaml.parser.ParserImpl$ParseImplicitDocumentStart.produce(ParserImpl.java:212)
        at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:162)
        at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:152)
        at org.yaml.snakeyaml.composer.Composer.checkNode(Composer.java:109)
        at org.yaml.snakeyaml.constructor.BaseConstructor.checkData(BaseConstructor.java:149)
        at org.yaml.snakeyaml.Yaml$1.hasNext(Yaml.java:510)
        at org.springframework.beans.factory.config.YamlProcessor.process(YamlProcessor.java:199)
        at org.springframework.beans.factory.config.YamlProcessor.process(YamlProcessor.java:166)
        at org.springframework.boot.env.OriginTrackedYamlLoader.load(OriginTrackedYamlLoader.java:88)
        at org.springframework.boot.env.YamlPropertySourceLoader.load(YamlPropertySourceLoader.java:50)
        at org.springframework.boot.context.config.StandardConfigDataLoader.load(StandardConfigDataLoader.java:54)
        at org.springframework.boot.context.config.StandardConfigDataLoader.load(StandardConfigDataLoader.java:36)
        at org.springframework.boot.context.config.ConfigDataLoaders.load(ConfigDataLoaders.java:108)
        at org.springframework.boot.context.config.ConfigDataImporter.load(ConfigDataImporter.java:132)
        at org.springframework.boot.context.config.ConfigDataImporter.resolveAndLoad(ConfigDataImporter.java:87)
        at org.springframework.boot.context.config.ConfigDataEnvironmentContributors.withProcessedImports(ConfigDataEnvironmentContributors.java:116)
        at org.springframework.boot.context.config.ConfigDataEnvironment.processInitial(ConfigDataEnvironment.java:240)
        at org.springframework.boot.context.config.ConfigDataEnvironment.processAndApply(ConfigDataEnvironment.java:227)
        at org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor.postProcessEnvironment(ConfigDataEnvironmentPostProcessor.java:102)
        at org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor.postProcessEnvironment(ConfigDataEnvironmentPostProcessor.java:94)
        at org.springframework.boot.env.EnvironmentPostProcessorApplicationListener.onApplicationEnvironmentPreparedEvent(EnvironmentPostProcessorApplicationListener.java:102)
        at org.springframework.boot.env.EnvironmentPostProcessorApplicationListener.onApplicationEvent(EnvironmentPostProcessorApplicationListener.java:87)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:178)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:171)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:145)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:133)
        at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:85)
        at org.springframework.boot.SpringApplicationRunListeners.lambda$environmentPrepared$2(SpringApplicationRunListeners.java:66)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:120)
        at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:114)
        at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:65)
        at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:343)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:301)
        at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:164)
        at com.blackduck.integration.detect.Application.main(Application.java:104)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65)
```