### PR TITLE
Allow flexible severity failures in rapid/stateless scans

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -237,8 +237,9 @@ public class DetectConfigurationFactory {
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
         long detectTimeout = findTimeoutInSeconds();
-        return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout);
+        return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout, severitiesToFailPolicyCheck);
     }
 
     public BlackduckScanMode createScanMode() {

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -242,9 +242,12 @@ public class DetectConfigurationFactory {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
         
-        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
-        if (severitiesToFailPolicyCheck.isEmpty()) {
+        AllNoneEnumList<PolicyRuleSeverityType> value = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES);
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck;
+        if (value.containsNone()) {
             severitiesToFailPolicyCheck = new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL));
+        } else {
+            severitiesToFailPolicyCheck = value.representedValues();
         }
         
         long detectTimeout = findTimeoutInSeconds();

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -241,14 +241,7 @@ public class DetectConfigurationFactory {
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
-        
-        AllNoneEnumList<PolicyRuleSeverityType> value = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES);
-        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck;
-        if (value.containsNone()) {
-            severitiesToFailPolicyCheck = new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL));
-        } else {
-            severitiesToFailPolicyCheck = value.representedValues();
-        }
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
         
         long detectTimeout = findTimeoutInSeconds();
         return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout, severitiesToFailPolicyCheck);

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -3,6 +3,7 @@ package com.blackduck.integration.detect.configuration;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,9 @@ import com.google.gson.Gson;
 public class DetectConfigurationFactory {
     private final DetectPropertyConfiguration detectConfiguration;
     private final Gson gson;
+    
+    private static final String POLICY_SEVERITY_BLOCKER = "BLOCKER";
+    private static final String POLICY_SEVERITY_CRITICAL = "CRITICAL";
 
     public DetectConfigurationFactory(DetectPropertyConfiguration detectConfiguration, Gson gson) {
         this.detectConfiguration = detectConfiguration;
@@ -237,7 +241,12 @@ public class DetectConfigurationFactory {
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
-        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
+        
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
+        if (severitiesToFailPolicyCheck.isEmpty()) {
+            severitiesToFailPolicyCheck = new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL));
+        }
+        
         long detectTimeout = findTimeoutInSeconds();
         return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout, severitiesToFailPolicyCheck);
     }

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1395,7 +1395,7 @@ public class DetectProperties {
             .build();
     
     public static final AllNoneEnumListProperty<PolicyRuleSeverityType> DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES =
-        AllNoneEnumListProperty.newBuilder("detect.stateless.policy.check.fail.on.severities", AllNoneEnum.NONE, PolicyRuleSeverityType.class)
+        AllNoneEnumListProperty.newBuilder("detect.stateless.policy.check.fail.on.severities", Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL), PolicyRuleSeverityType.class)
             .setInfo("Fail on Stateless Policy Violation Severities", DetectPropertyFromVersion.VERSION_10_5_0)
             .setHelp(
                 "A comma-separated list of policy violation severities that will fail Detect. If this is set to NONE, Detect will not fail due to policy violations. A value of ALL is equivalent to all of the other possible values except NONE.")

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1393,6 +1393,14 @@ public class DetectProperties {
             )
             .setGroups(DetectGroup.PROJECT, DetectGroup.GLOBAL, DetectGroup.PROJECT_SETTING, DetectGroup.POLICY)
             .build();
+    
+    public static final AllNoneEnumListProperty<PolicyRuleSeverityType> DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES =
+        AllNoneEnumListProperty.newBuilder("detect.stateless.policy.check.fail.on.severities", AllNoneEnum.NONE, PolicyRuleSeverityType.class)
+            .setInfo("Fail on Stateless Policy Violation Severities", DetectPropertyFromVersion.VERSION_10_5_0)
+            .setHelp(
+                "A comma-separated list of policy violation severities that will fail Detect. If this is set to NONE, Detect will not fail due to policy violations. A value of ALL is equivalent to all of the other possible values except NONE.")
+            .setGroups(DetectGroup.PROJECT, DetectGroup.GLOBAL, DetectGroup.PROJECT_SETTING, DetectGroup.POLICY)
+            .build();
 
     public static final NullableStringProperty DETECT_PROJECT_APPLICATION_ID =
         NullableStringProperty.newBuilder("detect.project.application.id")

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -27,7 +27,6 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.blackduck.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
@@ -38,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.blackduck.integration.bdio.graph.ProjectDependencyGraph;
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.blackduck.api.generated.discovery.ApiDiscovery;
+import com.blackduck.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
 import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.blackduck.api.generated.view.BomStatusScanView;
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
@@ -700,7 +700,9 @@ public class OperationRunner {
     }
 
     public final RapidScanResultSummary logRapidReport(List<DeveloperScansScanView> scanResults, BlackduckScanMode mode) throws OperationException {
-        return auditLog.namedInternal("Print Rapid Mode Results", () -> new RapidModeLogReportOperation(exitCodePublisher, rapidScanResultAggregator, mode).perform(scanResults));
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfigurationFactory.createRapidScanOptions().getSeveritiesToFailPolicyCheck();
+        return auditLog.namedInternal("Print Rapid Mode Results", () -> 
+            new RapidModeLogReportOperation(exitCodePublisher, rapidScanResultAggregator, mode).perform(scanResults, severitiesToFailPolicyCheck));
     }
 
     public final File generateRapidJsonFile(NameVersion projectNameVersion, List<DeveloperScansScanView> scanResults) throws OperationException {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperation.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.blackduck.integration.detect.configuration.DetectUserFriendlyException;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
@@ -28,8 +29,8 @@ public class RapidModeLogReportOperation {
         this.scanMode = mode.displayName();
     }
 
-    public RapidScanResultSummary perform(List<DeveloperScansScanView> results) throws DetectUserFriendlyException {
-         RapidScanAggregateResult aggregateResult = rapidScanResultAggregator.aggregateData(results);
+    public RapidScanResultSummary perform(List<DeveloperScansScanView> results, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) throws DetectUserFriendlyException {
+        RapidScanAggregateResult aggregateResult = rapidScanResultAggregator.aggregateData(results, severitiesToFailPolicyCheck);
         logger.info(String.format("%s:", scanMode + RapidScanDetectResult.NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING));
         aggregateResult.logResult(new Slf4jIntLogger(logger));
         RapidScanResultSummary summary = aggregateResult.getSummary();

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanOptions.java
@@ -1,5 +1,8 @@
 package com.blackduck.integration.detect.workflow.blackduck.developer;
 
+import java.util.List;
+
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
 
@@ -7,11 +10,13 @@ public class RapidScanOptions {
     private final RapidCompareMode compareMode;
     private final BlackduckScanMode scanMode;
     private final long detectTimeout;
+    private final List<PolicyRuleSeverityType> severitiesToFailPolicyCheck;
 
-    public RapidScanOptions(RapidCompareMode compareMode, BlackduckScanMode scanMode, long detectTimeout) {
+    public RapidScanOptions(RapidCompareMode compareMode, BlackduckScanMode scanMode, long detectTimeout, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         this.compareMode = compareMode;
         this.scanMode = scanMode;
         this.detectTimeout = detectTimeout;
+        this.severitiesToFailPolicyCheck = severitiesToFailPolicyCheck;
     }
 
     public RapidCompareMode getCompareMode() {
@@ -24,5 +29,9 @@ public class RapidScanOptions {
 
     public long getDetectTimeout() {
         return detectTimeout;
+    }
+    
+    public List<PolicyRuleSeverityType> getSeveritiesToFailPolicyCheck() {
+        return severitiesToFailPolicyCheck;
     }
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/aggregate/RapidScanComponentGroupDetail.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 
 import com.blackduck.integration.blackduck.api.generated.component.*;
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
@@ -12,8 +14,6 @@ import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScan
 public class RapidScanComponentGroupDetail {
     
     private static final String POLICY_SEPARATOR = "/";
-    private static final String POLICY_SEVERITY_BLOCKER = "BLOCKER";
-    private static final String POLICY_SEVERITY_CRITICAL = "CRITICAL";
     
     private final RapidScanDetailGroup group;
     private final Set<String> errorMessages = new LinkedHashSet<>();
@@ -86,12 +86,14 @@ public class RapidScanComponentGroupDetail {
     // While it may be possible to reduce the overall message generation code in this class by pushing 
     // some common pieces into a parent class or interface, it is likely not worth altering the libraries 
     // as this may be temporary code.
-    public void addComponentMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsComponentViolatingPoliciesView componentPolicyViolation) {
+    public void addComponentMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsComponentViolatingPoliciesView componentPolicyViolation, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         String baseMessage = getBaseMessage(resultView);
 
         String errorMessage = "", warningMessage = "";
 
-            if (componentPolicyViolation.getPolicySeverity().equals(POLICY_SEVERITY_CRITICAL) || componentPolicyViolation.getPolicySeverity().equals(POLICY_SEVERITY_BLOCKER)) {
+        if (severitiesToFailPolicyCheck.stream()
+                .map(PolicyRuleSeverityType::name)
+                .anyMatch(severity -> severity.equals(componentPolicyViolation.getPolicySeverity()))) {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {
@@ -117,7 +119,7 @@ public class RapidScanComponentGroupDetail {
     // While it may be possible to reduce the overall message generation code in this class by pushing 
     // some common pieces into a parent class or interface, it is likely not worth altering the libraries 
     // as this may be temporary code.
-    public void addLicenseMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation) {
+    public void addLicenseMessages(DeveloperScansScanView resultView, DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         String baseMessage = getBaseMessage(resultView);
         
         List<DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView> violatingPolicies = licensePolicyViolation.getViolatingPolicies();
@@ -126,8 +128,10 @@ public class RapidScanComponentGroupDetail {
         
         for (int i = 0; i < violatingPolicies.size(); i++) {
             DeveloperScansScanItemsPolicyViolationLicensesViolatingPoliciesView violation = violatingPolicies.get(i);
-                    
-            if (violation.getPolicySeverity().equals(POLICY_SEVERITY_CRITICAL) || violation.getPolicySeverity().equals(POLICY_SEVERITY_BLOCKER)) {
+            
+            if (severitiesToFailPolicyCheck.stream()
+                    .map(PolicyRuleSeverityType::name)
+                    .anyMatch(severity -> severity.equals(violation.getPolicySeverity()))) {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {
@@ -164,7 +168,7 @@ public class RapidScanComponentGroupDetail {
     // some common pieces into a parent class or interface, it is likely not worth altering the libraries 
     // as this may be temporary code.
     public void addVulnerabilityMessages(DeveloperScansScanView resultView,
-            DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerabilityPolicyViolation) {
+            DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerabilityPolicyViolation, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         String baseMessage = getBaseMessage(resultView);
         
         List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView> violatingPolicies = vulnerabilityPolicyViolation.getViolatingPolicies();
@@ -174,7 +178,9 @@ public class RapidScanComponentGroupDetail {
         for (int i = 0; i < violatingPolicies.size(); i++) {
             DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView violation = violatingPolicies.get(i);
             
-            if (violation.getPolicySeverity().equals(POLICY_SEVERITY_CRITICAL) || violation.getPolicySeverity().equals(POLICY_SEVERITY_BLOCKER)) {
+            if (severitiesToFailPolicyCheck.stream()
+                    .map(PolicyRuleSeverityType::name)
+                    .anyMatch(severity -> severity.equals(violation.getPolicySeverity()))) {
                 errorMessage = constructVulnerabilityMessageSegment(baseMessage, errorMessage, violation);
             } else {
                 warningMessage = constructVulnerabilityMessageSegment(baseMessage, warningMessage, violation);
@@ -212,7 +218,7 @@ public class RapidScanComponentGroupDetail {
     // While it may be possible to reduce the overall message generation code in this class by pushing
     // some common pieces into a parent class or interface, it is likely not worth altering the libraries
     // as this may be temporary code.
-    public void addViolatingPoliciesMessages(DeveloperScansScanView resultView, List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies) {
+    public void addViolatingPoliciesMessages(DeveloperScansScanView resultView, List<DeveloperScansScanItemsViolatingPoliciesView> violatingPolicies, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         String baseMessage = getBaseMessage(resultView);
 
         String errorMessage = "", warningMessage = "";
@@ -220,7 +226,9 @@ public class RapidScanComponentGroupDetail {
         for (int i = 0; i < violatingPolicies.size(); i++) {
             DeveloperScansScanItemsViolatingPoliciesView violation = violatingPolicies.get(i);
 
-            if (violation.getPolicySeverity().equals(POLICY_SEVERITY_CRITICAL) || violation.getPolicySeverity().equals(POLICY_SEVERITY_BLOCKER)) {
+            if (severitiesToFailPolicyCheck.stream()
+                    .map(PolicyRuleSeverityType::name)
+                    .anyMatch(severity -> severity.equals(violation.getPolicySeverity()))) {
                 if (errorMessage.equals("")) {
                     errorMessage = baseMessage;
                 } else {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/aggregate/RapidScanResultAggregator.java
@@ -13,17 +13,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.blackduck.integration.blackduck.api.generated.component.*;
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
+import com.blackduck.integration.detect.workflow.blackduck.developer.RapidScanOptions;
 
 public class RapidScanResultAggregator {
     
     private final Map<String, Set<String>> directToTransitiveChildren = new HashMap<>();
     private final Map<String, String[]> directUpgradeGuidanceVersions = new HashMap<>();
     
-    public RapidScanAggregateResult aggregateData(List<DeveloperScansScanView> results) {
-        Collection<RapidScanComponentDetail> componentDetails = aggregateComponentData(results);
+    public RapidScanAggregateResult aggregateData(List<DeveloperScansScanView> results, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
+        Collection<RapidScanComponentDetail> componentDetails = aggregateComponentData(results, severitiesToFailPolicyCheck);
         List<RapidScanComponentDetail> sortedByComponent = componentDetails.stream()
                 .sorted(Comparator.comparing(RapidScanComponentDetail::getComponentIdentifier))
                 .collect(Collectors.toList());
@@ -62,7 +65,7 @@ public class RapidScanResultAggregator {
                 transitiveGuidance);
     }
 
-    private List<RapidScanComponentDetail> aggregateComponentData(List<DeveloperScansScanView> results) {
+    private List<RapidScanComponentDetail> aggregateComponentData(List<DeveloperScansScanView> results, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         // the key is the component identifier
         List<RapidScanComponentDetail> componentDetails = new LinkedList<>();
 
@@ -110,10 +113,10 @@ public class RapidScanResultAggregator {
             licenseGroupDetail.addPolicies(licensePolicyNames);
             violatingPoliciesDetail.addPolicies(allViolatedPolicyNames);
 
-            addComponentData(resultView, componentViolations, componentGroupDetail);
-            addVulnerabilityData(resultView, vulnerabilityViolations, securityGroupDetail);
-            addLicenseData(resultView, licenseViolations, licenseGroupDetail);
-            addViolatingPoliciesData(resultView, policyViolationsSuperset, violatingPoliciesDetail);
+            addComponentData(resultView, componentViolations, componentGroupDetail, severitiesToFailPolicyCheck);
+            addVulnerabilityData(resultView, vulnerabilityViolations, securityGroupDetail, severitiesToFailPolicyCheck);
+            addLicenseData(resultView, licenseViolations, licenseGroupDetail, severitiesToFailPolicyCheck);
+            addViolatingPoliciesData(resultView, policyViolationsSuperset, violatingPoliciesDetail, severitiesToFailPolicyCheck);
         }
         
         return componentDetails;
@@ -190,26 +193,26 @@ public class RapidScanResultAggregator {
                 securityGroupDetail, licenseGroupDetail, violatingPoliciesDetail);
     }
 
-    private void addVulnerabilityData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesView> vulnerabilities, RapidScanComponentGroupDetail securityDetail) {
+    private void addVulnerabilityData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationVulnerabilitiesView> vulnerabilities, RapidScanComponentGroupDetail securityDetail, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         for (DeveloperScansScanItemsPolicyViolationVulnerabilitiesView vulnerabilityPolicyViolation : vulnerabilities) {
-            securityDetail.addVulnerabilityMessages(resultView, vulnerabilityPolicyViolation);
+            securityDetail.addVulnerabilityMessages(resultView, vulnerabilityPolicyViolation, severitiesToFailPolicyCheck);
         }
     }
 
-    private void addLicenseData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationLicensesView> licenseViolations, RapidScanComponentGroupDetail licenseDetail) {
+    private void addLicenseData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsPolicyViolationLicensesView> licenseViolations, RapidScanComponentGroupDetail licenseDetail, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         for (DeveloperScansScanItemsPolicyViolationLicensesView licensePolicyViolation : licenseViolations) {
-            licenseDetail.addLicenseMessages(resultView, licensePolicyViolation);
+            licenseDetail.addLicenseMessages(resultView, licensePolicyViolation, severitiesToFailPolicyCheck);
         }
     }
     
-    private void addComponentData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsComponentViolatingPoliciesView> componentViolations, RapidScanComponentGroupDetail componentGroupDetail) {
+    private void addComponentData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsComponentViolatingPoliciesView> componentViolations, RapidScanComponentGroupDetail componentGroupDetail, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
         for (DeveloperScansScanItemsComponentViolatingPoliciesView componentPolicyViolation: componentViolations) {
-            componentGroupDetail.addComponentMessages(resultView, componentPolicyViolation);
+            componentGroupDetail.addComponentMessages(resultView, componentPolicyViolation, severitiesToFailPolicyCheck);
         }
     }
 
-    private void addViolatingPoliciesData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsViolatingPoliciesView> allPolicyViolations, RapidScanComponentGroupDetail violatingPoliciesDetail) {
-        violatingPoliciesDetail.addViolatingPoliciesMessages(resultView, allPolicyViolations);
+    private void addViolatingPoliciesData(DeveloperScansScanView resultView, List<DeveloperScansScanItemsViolatingPoliciesView> allPolicyViolations, RapidScanComponentGroupDetail violatingPoliciesDetail, List<PolicyRuleSeverityType> severitiesToFailPolicyCheck) {
+        violatingPoliciesDetail.addViolatingPoliciesMessages(resultView, allPolicyViolations, severitiesToFailPolicyCheck);
     }
 
     /**

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperationTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidModeLogReportOperationTest.java
@@ -2,6 +2,8 @@ package com.blackduck.integration.detect.workflow.blackduck.developer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -10,6 +12,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.blackduck.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.blackduck.integration.detect.configuration.DetectUserFriendlyException;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
@@ -31,8 +35,11 @@ public class RapidModeLogReportOperationTest {
         List<DeveloperScansScanView> results = new LinkedList<>();
         DeveloperScansScanView resultView = Mockito.mock(DeveloperScansScanView.class);
         results.add(resultView);
+        
         RapidScanAggregateResult aggregateResult = Mockito.mock(RapidScanAggregateResult.class);
-        Mockito.when(rapidScanResultAggregator.aggregateData(results)).thenReturn(aggregateResult);
+        List<PolicyRuleSeverityType> violatingPoicies = 
+                new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL));
+        Mockito.when(rapidScanResultAggregator.aggregateData(results, violatingPoicies)).thenReturn(aggregateResult);
 
         RapidScanResultSummary summary = Mockito.mock(RapidScanResultSummary.class);
         Mockito.when(summary.hasErrors()).thenReturn(true);
@@ -43,7 +50,7 @@ public class RapidModeLogReportOperationTest {
         policyViolationNames.add("testPolicy2");
         Mockito.when(summary.getPolicyViolationNames()).thenReturn(policyViolationNames);
 
-        RapidScanResultSummary returnedSummary = op.perform(results);
+        RapidScanResultSummary returnedSummary = op.perform(results, violatingPoicies);
 
         assertEquals(summary, returnedSummary);
         Mockito.verify(exitCodePublisher, Mockito.times(1))

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
@@ -52,7 +52,7 @@ public class RapidScanResultAggregatorTest {
         aggregateResult.logResult(logger);
         RapidScanResultSummary summary = aggregateResult.getSummary();
         assertEquals(1, summary.getPolicyErrorCount());
-        assertEquals(1, summary.getPolicyWarningCount());
+        assertEquals(2, summary.getPolicyWarningCount());
         assertEquals(1, summary.getSecurityErrorCount());
         assertEquals(1, summary.getSecurityWarningCount());
         assertEquals(1, summary.getLicenseErrorCount());
@@ -60,8 +60,29 @@ public class RapidScanResultAggregatorTest {
         assertEquals(1, summary.getAllOtherPolicyErrorCount());
         assertEquals(1, summary.getAllOtherPolicyWarningCount());
         assertTrue(summary.getPolicyViolationNames().contains("other_policy"));
-        assertEquals(7, summary.getPolicyViolationNames().size());
+        assertEquals(8, summary.getPolicyViolationNames().size());
         assertFalse(logger.getOutputList(LogLevel.INFO).isEmpty());
+    }
+    
+    @Test
+    public void testFlexibleResults() {
+        List<DeveloperScansScanView> results = createResultList();
+        RapidScanResultAggregator aggregator = new RapidScanResultAggregator();
+        List<PolicyRuleSeverityType> violatingPoicies = 
+                new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.MINOR));
+
+        RapidScanAggregateResult aggregateResult = aggregator.aggregateData(results, violatingPoicies);
+        RapidScanResultSummary summary = aggregateResult.getSummary();
+
+        assertEquals(2, summary.getPolicyErrorCount());
+        assertEquals(1, summary.getPolicyWarningCount());
+        assertEquals(1, summary.getSecurityErrorCount());
+        assertEquals(1, summary.getSecurityWarningCount());
+        assertEquals(1, summary.getLicenseErrorCount());
+        assertEquals(1, summary.getLicenseWarningCount());
+        assertEquals(1, summary.getAllOtherPolicyErrorCount());
+        assertEquals(1, summary.getAllOtherPolicyWarningCount());
+        assertEquals(8, summary.getPolicyViolationNames().size());
     }
 
     private List<DeveloperScansScanView> createResultList() {
@@ -100,8 +121,13 @@ public class RapidScanResultAggregatorTest {
                 componentViolatingPolicy2.setPolicyName("component_policy_warning");
                 componentViolatingPolicy2.setPolicySeverity("MINOR");
                 
+                DeveloperScansScanItemsComponentViolatingPoliciesView componentViolatingPolicy3 = new DeveloperScansScanItemsComponentViolatingPoliciesView();
+                componentViolatingPolicy3.setPolicyName("component_policy_warning2");
+                componentViolatingPolicy3.setPolicySeverity("MINOR");
+                
                 componentViolatingPolicies.add(componentViolatingPolicy);
                 componentViolatingPolicies.add(componentViolatingPolicy2);
+                componentViolatingPolicies.add(componentViolatingPolicy3);
                 return componentViolatingPolicies;
             }
 

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanResultAggregatorTest.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detect.workflow.blackduck.developer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,6 +13,7 @@ import com.blackduck.integration.blackduck.api.generated.component.DeveloperScan
 import com.blackduck.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesView;
 import com.blackduck.integration.blackduck.api.generated.component.DeveloperScansScanItemsPolicyViolationVulnerabilitiesViolatingPoliciesView;
 import com.blackduck.integration.blackduck.api.generated.component.DeveloperScansScanItemsViolatingPoliciesView;
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.blackduck.api.generated.view.DeveloperScansScanView;
 import com.blackduck.integration.detect.workflow.blackduck.developer.aggregate.RapidScanAggregateResult;
 import com.blackduck.integration.detect.workflow.blackduck.developer.aggregate.RapidScanResultAggregator;
@@ -26,7 +28,7 @@ public class RapidScanResultAggregatorTest {
     public void testEmptyResults() {
         List<DeveloperScansScanView> results = Collections.emptyList();
         RapidScanResultAggregator aggregator = new RapidScanResultAggregator();
-        RapidScanAggregateResult aggregateResult = aggregator.aggregateData(results);
+        RapidScanAggregateResult aggregateResult = aggregator.aggregateData(results, null);
         BufferedIntLogger logger = new BufferedIntLogger();
         aggregateResult.logResult(logger);
         RapidScanResultSummary summary = aggregateResult.getSummary();
@@ -43,7 +45,9 @@ public class RapidScanResultAggregatorTest {
     public void testResults() {
         List<DeveloperScansScanView> results = createResultList();
         RapidScanResultAggregator aggregator = new RapidScanResultAggregator();
-        RapidScanAggregateResult aggregateResult = aggregator.aggregateData(results);
+        List<PolicyRuleSeverityType> violatingPoicies = 
+                new ArrayList<>(Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL));
+        RapidScanAggregateResult aggregateResult = aggregator.aggregateData(results, violatingPoicies);
         BufferedIntLogger logger = new BufferedIntLogger();
         aggregateResult.logResult(logger);
         RapidScanResultSummary summary = aggregateResult.getSummary();


### PR DESCRIPTION
This provides similar functionality to what detect.policy.check.fail.on.severities does except it does so for rapid and stateless scans under the new detect.stateless.policy.check.fail.on.severities property.

Essentially we are no longer hardcoding critical and blocker policies as the only policies that can fail a Detect scan. That's still the default but users can override with the new property using any policy severity allowed by BlackDuck.

Note: This is in draft only because we have not yet set a release, it is ready for review. I'll push release note changes at that time.