### PR TITLE
Define PNPM rule before NPM to that the latter gets a chance to yield

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -206,6 +206,11 @@ public class DetectorRuleFactory {
                 .search().defaultLock();
         }).yieldsTo(DetectorType.LERNA);
 
+        rules.addDetector(DetectorType.PNPM, detector -> {
+            detector.entryPoint(PnpmLockDetectable.class)
+                .search().defaultLock();
+        }).yieldsTo(DetectorType.LERNA);
+
         rules.addDetector(DetectorType.NPM, detector -> {
                 detector.entryPoint(NpmShrinkwrapDetectable.class)
                     .search().defaultLock();
@@ -217,11 +222,6 @@ public class DetectorRuleFactory {
                     .search().defaults(); //maybe this one should be defaultLock?
             }).allEntryPointsFallbackToNext()
             .yieldsTo(DetectorType.LERNA, DetectorType.YARN, DetectorType.PNPM);
-
-        rules.addDetector(DetectorType.PNPM, detector -> {
-            detector.entryPoint(PnpmLockDetectable.class)
-                .search().defaultLock();
-        }).yieldsTo(DetectorType.LERNA);
 
         rules.addDetector(DetectorType.NUGET, detector -> {
             //four different detectables, last one will be the project inspector

--- a/src/test/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactoryTest.java
+++ b/src/test/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactoryTest.java
@@ -7,11 +7,13 @@ import com.blackduck.integration.detector.base.DetectorType;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
 
 class DetectorRuleFactoryTest {
 

--- a/src/test/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactoryTest.java
+++ b/src/test/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactoryTest.java
@@ -1,0 +1,47 @@
+package com.blackduck.integration.detect.tool.detector;
+
+import com.blackduck.integration.detect.tool.detector.factory.DetectDetectableFactory;
+import com.blackduck.integration.detector.rule.DetectorRule;
+import com.blackduck.integration.detector.rule.DetectorRuleSet;
+import com.blackduck.integration.detector.base.DetectorType;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DetectorRuleFactoryTest {
+
+    @Test
+    void testCreateRules() {
+        // Arrange
+        DetectDetectableFactory mockDetectableFactory = Mockito.mock(DetectDetectableFactory.class);
+        DetectorRuleFactory detectorRuleFactory = new DetectorRuleFactory();
+
+        // Act
+        DetectorRuleSet detectorRuleSet = detectorRuleFactory.createRules(mockDetectableFactory);
+
+        // Assert
+        assertNotNull(detectorRuleSet, "DetectorRuleSet should not be null");
+
+        List<DetectorRule> detectorRules = detectorRuleSet.getDetectorRules();
+        assertNotNull(detectorRules, "DetectorRules should not be null");
+
+        Set<DetectorType> declaredTypes = new HashSet<>();
+        for (DetectorRule rule : detectorRules) {
+            DetectorType currentType = rule.getDetectorType();
+            assertNotNull(currentType, "DetectorType should not be null");
+
+            rule.getEntryPoints().forEach(entryPoint -> {
+                entryPoint.getSearchRule().getYieldsTo().forEach(yieldedType -> {
+                    assertTrue(declaredTypes.contains(yieldedType),
+                        String.format("DetectorType %s yields to %s, which is not declared earlier.", currentType, yieldedType));
+                });
+            });
+            declaredTypes.add(currentType);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Define PNPM rule before NPM to that the latter gets a chance to yield.
This can help avoid unnecessary NPM commands and parsing when Pnpm has already succeeded in a given directory.