### PR TITLE
Change SBT detector graph parser library to support newer versions

### DIFF
--- a/detectable/build.gradle
+++ b/detectable/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.tomlj:tomlj:1.0.0'
     implementation 'com.moandjiezana.toml:toml4j:0.7.2'
     implementation 'com.paypal.digraph:digraph-parser:1.0'
+    implementation 'guru.nidi:graphviz-java:0.18.1'
 
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtDotExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtDotExtractor.java
@@ -60,9 +60,9 @@ public class SbtDotExtractor {
                 Set<String> rootIDs = sbtRootNodeFinder.determineRootIDs(mutableGraph);
                 File projectFolder = dotGraph.getParentFile().getParentFile();//typically found in project-folder/target/<>.dot so .parent.parent == project folder
 
+                DependencyGraph graph = sbtGraphParserTransformer.transformDotToGraph(rootIDs, mutableGraph);
                 if (rootIDs.size() == 1) {
                     String projectId = rootIDs.stream().findFirst().get();
-                    DependencyGraph graph = sbtGraphParserTransformer.transformDotToGraph(projectId, mutableGraph);
                     Dependency projectDependency = graphNodeParser.nodeToDependency(projectId);
                     extraction.codeLocations(new CodeLocation(graph, projectDependency.getExternalId(), projectFolder));
                     if (projectFolder.equals(directory)) {
@@ -72,7 +72,6 @@ public class SbtDotExtractor {
                 } else {
                     logger.warn("Unable to determine which node was the project in an SBT graph: " + dotGraph.toString());
                     logger.warn("This may mean you have extraneous dependencies and should consider removing them. The dependencies are: " + String.join(",", rootIDs));
-                    DependencyGraph graph = sbtGraphParserTransformer.transformDotToGraph(rootIDs, mutableGraph);
                     extraction.codeLocations(new CodeLocation(graph, projectFolder));
                 }
             }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtDotOutputParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtDotOutputParser.java
@@ -30,8 +30,8 @@ public class SbtDotOutputParser {
 
     @Nullable
     private String parseDotGraphFromLine(String line) {
-        final String DOT_PREFIX = "[info] Wrote dependency graph to '";
-        if (line.startsWith(DOT_PREFIX)) {
+        final String DOT_PREFIX = "Wrote dependency graph to '";
+        if (line.contains(DOT_PREFIX)) {
             final String DOT_SUFFIX = "'";
             return StringUtils.substringBetween(line, DOT_PREFIX, DOT_SUFFIX);
         } else {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
@@ -35,6 +35,15 @@ public class SbtGraphParserTransformer {
                     }
                 }
             });
+            node.links().forEach(link -> {
+                link.attrs().forEach(attr -> {
+                    if(attr.getKey().equals("label")) {
+                        if(attr.getValue().toString().toLowerCase().contains("evicted")) {
+                            evictedIds.add(node.name().toString());
+                        }
+                    }
+                });
+            });
         });
 
         List<Link> links = mutableGraph.nodes().stream().map(MutableNode::links).flatMap(List::stream).collect(Collectors.toList());

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
@@ -82,24 +82,6 @@ public class SbtGraphParserTransformer {
         }
     }
 
-//    public DependencyGraph transformDotToGraph(Set<String> projectNodeIds, MutableGraph mutableGraph) {
-//        DependencyGraph graph = new BasicDependencyGraph();
-//
-//        List<Link> links = mutableGraph.nodes().stream().map(MutableNode::links).flatMap(List::stream).collect(Collectors.toList());
-//        for (Link link : links) {
-//            String parentNode = normalizeDependency(link.asLinkTarget().name().toString());
-//            String childNode = normalizeDependency(link.asLinkSource().name().toString());
-//
-//            Dependency parent = sbtDotGraphNodeParser.nodeToDependency(parentNode);
-//            Dependency child = sbtDotGraphNodeParser.nodeToDependency(childNode);
-//
-//
-//
-//        }
-//
-//        return graph;
-//    }
-
     private String normalizeDependency(String dependency) {
         if(dependency.startsWith("--")) {
             return dependency.substring(2);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtGraphParserTransformer.java
@@ -9,15 +9,12 @@ import java.util.stream.Collectors;
 import guru.nidi.graphviz.model.Link;
 import guru.nidi.graphviz.model.MutableGraph;
 import guru.nidi.graphviz.model.MutableNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.blackduck.integration.bdio.graph.BasicDependencyGraph;
 import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.bdio.model.dependency.Dependency;
 
 public class SbtGraphParserTransformer {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final SbtDotGraphNodeParser sbtDotGraphNodeParser;
 
     public SbtGraphParserTransformer(SbtDotGraphNodeParser sbtDotGraphNodeParser) {
@@ -61,24 +58,16 @@ public class SbtGraphParserTransformer {
     private Set<String> getEvictedIds(MutableGraph mutableGraph) {
         Set<String> evictedIds = new HashSet<>();
         mutableGraph.nodes().forEach(node -> {
-            node.attrs().forEach(attr -> {
-                addEvictedEntry(attr, node, evictedIds);
-            });
-            node.links().forEach(link -> {
-                link.attrs().forEach(attr -> {
-                    addEvictedEntry(attr, node, evictedIds);
-                });
-            });
+            node.attrs().forEach(attr -> addEvictedEntry(attr, node, evictedIds));
+            node.links().forEach(link -> link.attrs().forEach(attr -> addEvictedEntry(attr, node, evictedIds)));
         });
 
         return evictedIds;
     }
 
     private void addEvictedEntry(Map.Entry<String, Object> attr, MutableNode node, Set<String> evictedIds) {
-        if(attr.getKey().equals("label")) {
-            if(attr.getValue().toString().toLowerCase().contains("evicted")) {
-                evictedIds.add(node.name().toString());
-            }
+        if(attr.getKey().equals("label") && attr.getValue().toString().toLowerCase().contains("evicted")) {
+            evictedIds.add(node.name().toString());
         }
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtRootNodeFinder.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/sbt/dot/SbtRootNodeFinder.java
@@ -2,15 +2,18 @@ package com.blackduck.integration.detectable.detectables.sbt.dot;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
+import guru.nidi.graphviz.attribute.Label;
+import guru.nidi.graphviz.model.MutableNode;
+import guru.nidi.graphviz.model.MutableGraph;
+import guru.nidi.graphviz.model.LinkSource;
+import guru.nidi.graphviz.model.Link;
 import org.apache.commons.collections4.SetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.paypal.digraph.parser.GraphEdge;
-import com.paypal.digraph.parser.GraphElement;
-import com.paypal.digraph.parser.GraphParser;
 import com.blackduck.integration.detectable.detectable.exception.DetectableException;
 
 public class SbtRootNodeFinder {
@@ -21,12 +24,16 @@ public class SbtRootNodeFinder {
         this.sbtDotGraphNodeParser = sbtDotGraphNodeParser;
     }
 
-    public Set<String> determineRootIDs(GraphParser graphParser) throws DetectableException {
-        Set<String> nodeIdsUsedInDestination = graphParser.getEdges().values().stream()
-            .map(GraphEdge::getNode2)
-            .map(GraphElement::getId)
-            .collect(Collectors.toSet());
-        Set<String> allNodeIds = new HashSet<>(graphParser.getNodes().keySet());
+    public Set<String> determineRootIDs(MutableGraph mutableGraph) throws DetectableException {
+        Set<String> nodeIdsUsedInDestination = mutableGraph.nodes().stream()
+                .map(MutableNode::links)
+                .flatMap(List::stream)
+                .map(Link::asLinkSource)
+                .map(LinkSource::name)
+                .map(Label::value)
+                .collect(Collectors.toSet());
+
+        Set<String> allNodeIds = mutableGraph.nodes().stream().map(MutableNode::name).map(Label::value).collect(Collectors.toSet());
         return SetUtils.difference(allNodeIds, nodeIdsUsedInDestination);
     }
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/sbt/unit/SbtDotGraphNodeParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/sbt/unit/SbtDotGraphNodeParserTest.java
@@ -1,15 +1,16 @@
 package com.blackduck.integration.detectable.detectables.sbt.unit;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
+import guru.nidi.graphviz.model.MutableGraph;
+import guru.nidi.graphviz.model.MutableNode;
+import guru.nidi.graphviz.parse.Parser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.paypal.digraph.parser.GraphNode;
-import com.paypal.digraph.parser.GraphParser;
 import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
@@ -18,7 +19,7 @@ import com.blackduck.integration.detectable.detectables.sbt.dot.SbtDotGraphNodeP
 public class SbtDotGraphNodeParserTest {
 
     @Test
-    public void canParseSimpleGraph() {
+    public void canParseSimpleGraph() throws IOException {
         String simpleGraph = "digraph \"dependency-graph\" {\n"
             + "    graph[rankdir=\"LR\"]\n"
             + "    edge [\n"
@@ -28,15 +29,13 @@ public class SbtDotGraphNodeParserTest {
             + "\n"
             + "}";
         InputStream stream = new ByteArrayInputStream(simpleGraph.getBytes(StandardCharsets.UTF_8));
-        GraphParser graphParser = new GraphParser(stream);
+        MutableGraph mutableGraph = new Parser().read(stream);
 
-        Map.Entry<String, GraphNode> node = graphParser.getNodes().entrySet().stream().findFirst().get();
+        MutableNode node = mutableGraph.nodes().stream().findFirst().get();
         SbtDotGraphNodeParser nodeParser = new SbtDotGraphNodeParser(new ExternalIdFactory());
-        Dependency dependencyFromKey = nodeParser.nodeToDependency(node.getKey());
-        Dependency dependencyFromId = nodeParser.nodeToDependency(node.getValue().getId());
+        Dependency dependency = nodeParser.nodeToDependency(node.name().toString());
 
-        assertDependency(dependencyFromId, "org.scalameta", "scalafmtroot_2.13", "2.7.5-SNAPSHOT");
-        assertDependency(dependencyFromKey, "org.scalameta", "scalafmtroot_2.13", "2.7.5-SNAPSHOT");
+        assertDependency(dependency, "org.scalameta", "scalafmtroot_2.13", "2.7.5-SNAPSHOT");
     }
 
     @Test

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/sbt/unit/SbtRootNodeFinderTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/sbt/unit/SbtRootNodeFinderTest.java
@@ -1,14 +1,16 @@
 package com.blackduck.integration.detectable.detectables.sbt.unit;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import guru.nidi.graphviz.model.MutableGraph;
+import guru.nidi.graphviz.parse.Parser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.paypal.digraph.parser.GraphParser;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectable.exception.DetectableException;
 import com.blackduck.integration.detectable.detectables.sbt.dot.SbtDotGraphNodeParser;
@@ -16,17 +18,17 @@ import com.blackduck.integration.detectable.detectables.sbt.dot.SbtRootNodeFinde
 
 public class SbtRootNodeFinderTest {
 
-    private GraphParser createGraphParser(String actualGraph) {
+    private MutableGraph createMutableGraph(String actualGraph) throws IOException {
         String simpleGraph = "digraph \"dependency-graph\" {\n"
-            + "    graph[rankdir=\"LR\"]\n"
-            + "    edge [\n"
-            + "        arrowtail=\"none\"\n"
-            + "    ]\n"
-            + actualGraph + "\n"
-            + "\n"
-            + "}";
+                + "    graph[rankdir=\"LR\"]\n"
+                + "    edge [\n"
+                + "        arrowtail=\"none\"\n"
+                + "    ]\n"
+                + actualGraph + "\n"
+                + "\n"
+                + "}";
         InputStream stream = new ByteArrayInputStream(simpleGraph.getBytes(StandardCharsets.UTF_8));
-        return new GraphParser(stream);
+        return new Parser().read(stream);
     }
 
     private String node(String org, String name, String version) {
@@ -38,47 +40,47 @@ public class SbtRootNodeFinderTest {
     }
 
     @Test
-    public void projectFoundFromSingleNode() throws DetectableException {
-        GraphParser graphParser = createGraphParser(node("one-org", "one-name", "one-version"));
+    public void projectFoundFromSingleNode() throws DetectableException, IOException {
+        MutableGraph mutableGraph = createMutableGraph(node("one-org", "one-name", "one-version"));
         SbtRootNodeFinder projectMatcher = new SbtRootNodeFinder(new SbtDotGraphNodeParser(new ExternalIdFactory()));
-        Set<String> projectId = projectMatcher.determineRootIDs(graphParser);
+        Set<String> projectId = projectMatcher.determineRootIDs(mutableGraph);
         Assertions.assertEquals(1, projectId.size());
-        Assertions.assertEquals("\"one-org:one-name:one-version\"", projectId.stream().findFirst().get());
+        Assertions.assertEquals("one-org:one-name:one-version", projectId.stream().findFirst().get());
     }
 
     @Test
-    public void projectFoundFromTwoNodesWhereProjectIsSecond() throws DetectableException {
-        GraphParser graphParser = createGraphParser(node("two-org", "two-name", "two-version") +
+    public void projectFoundFromTwoNodesWhereProjectIsSecond() throws DetectableException, IOException {
+        MutableGraph mutableGraph = createMutableGraph(node("two-org", "two-name", "two-version") +
             node("one-org", "one-name", "one-version") +
             edge("one-org", "one-name", "one-version", "two-org", "two-name", "two-version"));
         SbtRootNodeFinder projectMatcher = new SbtRootNodeFinder(new SbtDotGraphNodeParser(new ExternalIdFactory()));
-        Set<String> projectId = projectMatcher.determineRootIDs(graphParser);
+        Set<String> projectId = projectMatcher.determineRootIDs(mutableGraph);
         Assertions.assertEquals(1, projectId.size());
-        Assertions.assertEquals("\"one-org:one-name:one-version\"", projectId.stream().findFirst().get());
+        Assertions.assertEquals("one-org:one-name:one-version", projectId.stream().findFirst().get());
     }
 
     @Test
-    public void multipleFoundWithNoEdges() throws DetectableException {
-        GraphParser graphParser = createGraphParser(node("one-org", "one-name", "one-version") +
+    public void multipleFoundWithNoEdges() throws DetectableException, IOException {
+        MutableGraph mutableGraph = createMutableGraph(node("one-org", "one-name", "one-version") +
             node("one-org", "one-name", "two-version"));
         SbtRootNodeFinder projectMatcher = new SbtRootNodeFinder(new SbtDotGraphNodeParser(new ExternalIdFactory()));
-        Set<String> projectId = projectMatcher.determineRootIDs(graphParser);
+        Set<String> projectId = projectMatcher.determineRootIDs(mutableGraph);
         Assertions.assertEquals(2, projectId.size());
-        Assertions.assertTrue(projectId.contains("\"one-org:one-name:one-version\""));
-        Assertions.assertTrue(projectId.contains("\"one-org:one-name:two-version\""));
+        Assertions.assertTrue(projectId.contains("one-org:one-name:one-version"));
+        Assertions.assertTrue(projectId.contains("one-org:one-name:two-version"));
     }
 
     @Test
-    public void multipleFoundWithEdge() throws DetectableException {
-        GraphParser graphParser = createGraphParser(node("one-org", "one-name", "one-version") +
+    public void multipleFoundWithEdge() throws DetectableException, IOException {
+        MutableGraph mutableGraph = createMutableGraph(node("one-org", "one-name", "one-version") +
             node("one-org", "one-name", "two-version") +
             node("one-org", "one-name", "three-version") + //should not be reported
             edge("one-org", "one-name", "one-version", "one-org", "one-name", "three-version"));
         SbtRootNodeFinder projectMatcher = new SbtRootNodeFinder(new SbtDotGraphNodeParser(new ExternalIdFactory()));
-        Set<String> projectId = projectMatcher.determineRootIDs(graphParser);
+        Set<String> projectId = projectMatcher.determineRootIDs(mutableGraph);
         Assertions.assertEquals(2, projectId.size());
-        Assertions.assertTrue(projectId.contains("\"one-org:one-name:one-version\""));
-        Assertions.assertTrue(projectId.contains("\"one-org:one-name:two-version\""));
+        Assertions.assertTrue(projectId.contains("one-org:one-name:one-version"));
+        Assertions.assertTrue(projectId.contains("one-org:one-name:two-version"));
     }
 
 }

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/SbtEncodingTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/SbtEncodingTest.java
@@ -1,7 +1,13 @@
 package com.blackduck.integration.detect.battery.docker;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.blackduck.integration.detect.battery.docker.integration.BlackDuckAssertions;
+import com.blackduck.integration.detect.battery.docker.integration.BlackDuckTestConnection;
+import com.blackduck.integration.detector.base.DetectorType;
+import com.blackduck.integration.exception.IntegrationException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +20,9 @@ import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 
 @Tag("integration")
 public class SbtEncodingTest {
+
+    public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
+
     @Test
     void sbtEncoding() throws IOException {
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-sbt-encoding", "detect-sbt-encoding:1.0.3")) {
@@ -26,6 +35,38 @@ public class SbtEncodingTest {
 
             dockerAssertions.atLeastOneBdioFile();
             dockerAssertions.projectVersion("sbt-simple-project_2.12", "1.0.0-SNAPSHOT");
+        }
+    }
+
+    @Test
+    void sbtDetectorTest() throws IOException, IntegrationException {
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-sbt-detector", "detect-sbt-detector:1.0.1")) {
+            Map<String, String> artifactoryArgs = new HashMap<>();
+            artifactoryArgs.put("ARTIFACTORY_URL", ARTIFACTORY_URL);
+
+            BuildDockerImageProvider buildDockerImageProvider = BuildDockerImageProvider.forDockerfilResourceNamed("Sbt_Detector.dockerfile");
+            buildDockerImageProvider.setBuildArgs(artifactoryArgs);
+            test.withImageProvider(buildDockerImageProvider);
+
+            String projectVersion = "sbt-detector:1.0.1";
+            BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+            BlackDuckAssertions blackduckAssertions = blackDuckTestConnection.projectVersionAssertions("sbt-detector", projectVersion);
+            blackduckAssertions.emptyOnBlackDuck();
+
+            DetectCommandBuilder commandBuilder =  new DetectCommandBuilder().defaults().defaultDirectories(test);
+            commandBuilder.connectToBlackDuck(blackDuckTestConnection);
+            commandBuilder.projectNameVersion(blackduckAssertions);
+            commandBuilder.waitForResults();
+
+            commandBuilder.property(DetectProperties.DETECT_TOOLS, DetectTool.DETECTOR.toString());
+            DockerAssertions dockerAssertions = test.run(commandBuilder);
+
+            dockerAssertions.atLeastOneBdioFile();
+            dockerAssertions.logContains("SBT: SUCCESS");
+
+            blackduckAssertions.checkComponentVersionExists("scala-compiler", "2.12.18");
+            blackduckAssertions.checkComponentVersionExists("Apache Log4J API", "2.24.3");
+            blackduckAssertions.checkComponentVersionExists("scopt", "3.7.1");
         }
     }
 }

--- a/src/test/resources/docker/Sbt_Detector.dockerfile
+++ b/src/test/resources/docker/Sbt_Detector.dockerfile
@@ -1,0 +1,25 @@
+FROM maven:3-jdk-8-alpine
+
+ENV SRC_DIR=/opt/project/src
+
+ARG ARTIFACTORY_URL
+
+# Install git: https://github.com/nodejs/docker-node/issues/586
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+#Install SBT
+WORKDIR /home/app
+RUN wget -q "https://github.com/sbt/sbt/releases/download/v1.10.11/sbt-1.10.11.tgz"
+RUN tar -xzf sbt-1.10.11.tgz
+RUN rm sbt-1.10.11.tgz
+ENV PATH="/home/app/sbt/bin:${PATH}"
+
+# Set up the test project
+RUN mkdir -p ${SRC_DIR}
+
+RUN wget ${ARTIFACTORY_URL}/artifactory/detect-generic-qa-local/sbt_graphviz_java.zip
+RUN unzip sbt_graphviz_java.zip -d /opt/project/src/
+RUN rm sbt_graphviz_java.zip
+
+RUN cd ${SRC_DIR}


### PR DESCRIPTION
The old library we were using for parsing `.dot` files was archived and not able to parse graph parsers from sbt package manager version 1.5.4 and above. This PR aims to substitute the library, to use a new third party library which behaves in the same way the old library does and is updated regularly for new changes in SBT package manager. The new library creates a linked list for each node in the library and its dependencies. We parse linked list to get dependency and node label information. The old library dependency cannot be removed since Bitbake detector also uses it.