### PR TITLE
Update UV Build exe method to check if it is successful 

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildExtractor.java
@@ -1,6 +1,5 @@
 package com.blackduck.integration.detectable.detectables.opam.buildexe;
 
-import com.blackduck.integration.detectable.detectable.executable.ExecutableFailedException;
 import com.blackduck.integration.detectable.detectables.opam.buildexe.parse.OpamTreeParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamFileParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamParsedResult;
@@ -82,11 +81,11 @@ public class OpamBuildExtractor {
 
     }
 
-    private String getOpamVersion(ExecutableTarget opamExe) throws ExecutableFailedException {
+    private String getOpamVersion(ExecutableTarget opamExe) throws ExecutableRunnerException {
         List<String> arguments = new ArrayList<>();
         arguments.add("--version");
 
-        ExecutableOutput executableOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(sourceDirectory, opamExe, arguments));
+        ExecutableOutput executableOutput = executableRunner.execute(ExecutableUtils.createFromTarget(sourceDirectory, opamExe, arguments));
 
         if(executableOutput.getReturnCode() == 0) {
             return executableOutput.getStandardOutputAsList().get(0);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/opam/buildexe/OpamBuildExtractor.java
@@ -1,5 +1,6 @@
 package com.blackduck.integration.detectable.detectables.opam.buildexe;
 
+import com.blackduck.integration.detectable.detectable.executable.ExecutableFailedException;
 import com.blackduck.integration.detectable.detectables.opam.buildexe.parse.OpamTreeParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamFileParser;
 import com.blackduck.integration.detectable.detectables.opam.parse.OpamParsedResult;
@@ -81,11 +82,11 @@ public class OpamBuildExtractor {
 
     }
 
-    private String getOpamVersion(ExecutableTarget opamExe) throws ExecutableRunnerException {
+    private String getOpamVersion(ExecutableTarget opamExe) throws ExecutableFailedException {
         List<String> arguments = new ArrayList<>();
         arguments.add("--version");
 
-        ExecutableOutput executableOutput = executableRunner.execute(ExecutableUtils.createFromTarget(sourceDirectory, opamExe, arguments));
+        ExecutableOutput executableOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(sourceDirectory, opamExe, arguments));
 
         if(executableOutput.getReturnCode() == 0) {
             return executableOutput.getStandardOutputAsList().get(0);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
@@ -47,7 +47,7 @@ public class UVBuildExtractor {
             }
 
             // run uv tree command
-            ExecutableOutput executableOutput = executableRunner.execute(ExecutableUtils.createFromTarget(sourceDirectory, uvExe, arguments));
+            ExecutableOutput executableOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(sourceDirectory, uvExe, arguments));
             List<String> uvTreeOutput = executableOutput.getStandardOutputAsList();
 
             List<CodeLocation> codeLocations = uvTreeDependencyGraphTransformer.transform(uvTreeOutput, uvDetectorOptions);


### PR DESCRIPTION
This PR handles current issue where if uv tree command fails then Detect is successful causing confusion. Changed the method executed to check for any failures while running uv tree command and fail Detect if there is any failure in command.
