### PR TITLE
Fix NumberFormatException in NPM Package Json Parse for Long Numeric Pre-release or Timestamp Tags

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -96,12 +96,20 @@ public class PackageJsonExtractor {
             // Remove npm version selection characters that the KB won't match on
             .map(part -> part.replaceAll("[>=<~^]", ""))
             // Filter out parts that don't match the version pattern
-            .filter(part -> part.matches("\\d+\\.\\d+\\.\\d+|\\d+\\.\\d+|\\d+"))
+            .filter(part -> isProbableVersion(part))
             // Use compareSemVerVersions method to find smallest version in each value
             .min(semVerComparator)
             // If no part matches the version pattern, return the original value.
             .orElse(value);
 
         return lowestVersion;
+    }
+
+    private boolean isProbableVersion(String part) {
+        // If purely numeric and very long, it's likely a timestamp/hash
+        if (part.matches("\\d{6,}")) return false;
+
+        // Accept X, X.Y, X.Y.Z format
+        return part.matches("\\d+(\\.\\d+){0,2}");
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -85,7 +85,7 @@ public class PackageJsonExtractor {
         return new Dependency(externalId);
     }
 
-    private String extractLowestVersion(String value) {
+    public String extractLowestVersion(String value) {
         SemVerComparator semVerComparator = new SemVerComparator();
         
         // Split the value into parts by spaces, "||", or "-".
@@ -96,7 +96,7 @@ public class PackageJsonExtractor {
             // Remove npm version selection characters that the KB won't match on
             .map(part -> part.replaceAll("[>=<~^]", ""))
             // Filter out parts that don't match the version pattern
-            .filter(part -> isProbableVersion(part))
+            .filter(this::isProbableVersion)
             // Use compareSemVerVersions method to find smallest version in each value
             .min(semVerComparator)
             // If no part matches the version pattern, return the original value.

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/packagejson/unit/PackageJsonExtractorTest.java
@@ -109,6 +109,27 @@ class PackageJsonExtractorTest {
         graphAssert.hasRootSize(7);
     }
 
+    @Test
+    void shouldExtractLowestSemVerCorrectly() {
+        PackageJsonExtractor extractor = createExtractor();
+
+        assertEquals("1.0.0", extractor.extractLowestVersion("1.0.0 - 2.9999.9999"));
+        assertEquals("1.0.2", extractor.extractLowestVersion( ">=1.0.2 <2.1.2"));
+        assertEquals("1.0.0", extractor.extractLowestVersion("<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0"));
+        assertEquals("1.2.0", extractor.extractLowestVersion("~1.2.0"));
+        assertEquals("3.3.0", extractor.extractLowestVersion("3.3.x"));
+        assertEquals("1.0.0", extractor.extractLowestVersion("1.0.0-SNAPSHOT"));
+        assertEquals("1.2.3", extractor.extractLowestVersion( "^1.2.3"));
+        assertEquals("1.2.3", extractor.extractLowestVersion("1.2.3-alpha"));
+        assertEquals("17.0.0", extractor.extractLowestVersion( "17.0.0-1551262265873"));
+        assertEquals("3.2.0", extractor.extractLowestVersion("^3.2.0 || 4.0.1"));
+        assertEquals("1.2.0", extractor.extractLowestVersion("~1.2.x"));
+        assertEquals("1.2.3", extractor.extractLowestVersion("1.2.3-beta.2"));
+        assertEquals("5.0.0", extractor.extractLowestVersion( "5.0.0-alpha+build.1"));
+        assertEquals("3.0.0", extractor.extractLowestVersion("3.0.0-abc123"));
+        assertEquals("10.0.0", extractor.extractLowestVersion("10.0.0-0000000000123"));
+    }
+
     private CombinedPackageJson createPackageJson() {
         CombinedPackageJson combinedPackageJson = new CombinedPackageJson();
 


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4721

**Description**

**_Issue_**

The NPM Package Json Parse failed with a `NumberFormatException` when parsing version strings like `^17.0.0-1551262265873`. The numeric suffix was mistakenly treated as a valid version.

**_Root Cause_**

Our version parsing logic splits the input string using spaces, ||, or -. This mistakenly accepted long numeric segments (e.g. 1551262265873), which are likely timestamps or hashes, as valid versions due to the regex match. And thus causing a NumberFormatException in the version comparator.

**_Fix_**

* Added a helper method `isProbableVersion` to validate version tokens:

  * Accepts standard semver formats: `X`, `X.Y`, `X.Y.Z`.
  * Rejects purely numeric strings longer than 5 digits based on the intuition that valid version components rarely exceed 5 digits, whereas timestamps or hashes typically do.