### PR TITLE
Add properties entries to ditamap

### DIFF
--- a/documentation/topics.ditamap
+++ b/documentation/topics.ditamap
@@ -167,6 +167,7 @@
 		<topicref href="properties/detectors/overview.md" format="markdown">
 			<topicref href="properties/detectors/bazel.md" format="markdown"/>
 			<topicref href="properties/detectors/bitbake.md" format="markdown"/>
+			<topicref href="properties/detectors/cargo.md" format="markdown"/>
 			<topicref href="properties/detectors/conan.md" format="markdown"/>
 			<topicref href="properties/detectors/conda.md" format="markdown"/>
 			<topicref href="properties/detectors/cpan.md" format="markdown"/>
@@ -179,12 +180,17 @@
 			<topicref href="properties/detectors/maven.md" format="markdown"/>
 			<topicref href="properties/detectors/npm.md" format="markdown"/>
 			<topicref href="properties/detectors/nuget.md" format="markdown"/>
+			<topicref href="properties/detectors/opam.md" format="markdown"/>
 			<topicref href="properties/detectors/packagist.md" format="markdown"/>
 			<topicref href="properties/detectors/pear.md" format="markdown"/>
 			<topicref href="properties/detectors/pip.md" format="markdown"/>
+			<topicref href="properties/detectors/pnpm.md" format="markdown"/>
+			<topicref href="properties/detectors/poetry.md" format="markdown"/>
 			<topicref href="properties/detectors/python.md" format="markdown"/>
 			<topicref href="properties/detectors/ruby.md" format="markdown"/>
 			<topicref href="properties/detectors/sbt.md" format="markdown"/>
+			<topicref href="properties/detectors/swift.md" format="markdown"/>
+			<topicref href="properties/detectors/uv.md" format="markdown"/>
 			<topicref href="properties/detectors/yarn.md" format="markdown"/>
 		</topicref>
 		<topicref href="properties/deprecated-properties.md" format="markdown"/>


### PR DESCRIPTION
Add properties entries to resolve orphaned topic. (Zoomin does not handle the case of a topic entry only appearing in the generated TOC. This should work around that.)

FYI Will need to deploy a doc build with this change to Dev Zoomin to test. (Once we have a new QA build that includes this change I will upload it.)
Thanks.
