### PR TITLE
Prep docs for 10.6.0 and update troubleshooting

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -18,30 +18,19 @@
 	* eu.store.scass.blackduck.com - 34.54.213.11
 	* eu.scass.blackduck.com - 34.54.38.252
 
-## Version 10.5.0
+## Version 10.6.0
 
 ### New features
 
-* Support for UV Package Manager has been added under [UV Detector](packagemgrs/python.md#uv-package-manager)
-* With the `detect.clone.project.version.name` parameter specified and `detect.project.version.update` set to true, [detect_product_short] will now clone, scan, and update the cloned project via parameters such as `detect.project.version.phase`.
-* Support for Java 21 has been added.
-* If feasible, the most probable keys are recommended in place of invalid property keys that contain misspellings or malformations.
+* 
 
 ### Changed features
 
-* Gradle inspector script no longer requires, or includes, Gradle dependencies. This applies to both non-air gap and air gap zip generation.
-* [detect_product_short] will now fail the scan if `detect.wait.for.results` is set to true and a scan is not properly included in the BOM.
+* 
 
 ### Resolved issues
 
-* (IDETECT-4177) - [detect_product_short] no longer requires that the X-Artifactory-Filename header is set when specifying an internally hosted version in [bd_product_long].
-* (IDETECT-3512) - To prevent issues when [bd_product_long] and [detect_product_short] disagree on the full list of categories, [detect_product_short] now sends an indicator specifying "all categories" when detect.project.clone.categories is set to ALL.
-* (IDETECT-4606) - Support for the exclusion of dependency types in [detect_product_short] Nuget Inspector now includes `project.assets.json` and `project.lock.json` files.
-* (IDETECT-4209) - [detect_product_short] no longer creates numerous access denied exceptions in [bd_product_long] logs when a user does not have system administrator access.
-* (IDETECT-4222) [detect_product_short] now reports a failure status (FAILURE_BOM_PREPARATION) when BOM preparation fails in [bd_product_long].
-
+* 
 ### Dependency updates
 
-* Upgraded and released Nuget Inspector version 2.2.0.
-* Upgraded and released Docker Inspector version 11.3.0.
-* Updated usage of Apache Commons BeanUtils to version 1.11.0.
+* 

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -1,6 +1,34 @@
 <!-- Check the support matrix to determine supported, non-current major version releases -->
 # Release notes for previous supported versions
 
+## Version 10.5.0
+
+### New features
+
+* Support for UV Package Manager has been added under [UV Detector](packagemgrs/python.md#uv-package-manager)
+* With the `detect.clone.project.version.name` parameter specified and `detect.project.version.update` set to true, [detect_product_short] will now clone, scan, and update the cloned project via parameters such as `detect.project.version.phase`.
+* Support for Java 21 has been added.
+* If feasible, the most probable keys are recommended in place of invalid property keys that contain misspellings or malformations.
+
+### Changed features
+
+* Gradle inspector script no longer requires, or includes, Gradle dependencies. This applies to both non-air gap and air gap zip generation.
+* [detect_product_short] will now fail the scan if `detect.wait.for.results` is set to true and a scan is not properly included in the BOM.
+
+### Resolved issues
+
+* (IDETECT-4177) - [detect_product_short] no longer requires that the X-Artifactory-Filename header is set when specifying an internally hosted version in [bd_product_long].
+* (IDETECT-3512) - To prevent issues when [bd_product_long] and [detect_product_short] disagree on the full list of categories, [detect_product_short] now sends an indicator specifying "all categories" when detect.project.clone.categories is set to ALL.
+* (IDETECT-4606) - Support for the exclusion of dependency types in [detect_product_short] Nuget Inspector now includes `project.assets.json` and `project.lock.json` files.
+* (IDETECT-4209) - [detect_product_short] no longer creates numerous access denied exceptions in [bd_product_long] logs when a user does not have system administrator access.
+* (IDETECT-4222) [detect_product_short] now reports a failure status (FAILURE_BOM_PREPARATION) when BOM preparation fails in [bd_product_long].
+
+### Dependency updates
+
+* Upgraded and released Nuget Inspector version 2.2.0.
+* Upgraded and released Docker Inspector version 11.3.0.
+* Updated usage of Apache Commons BeanUtils to version 1.11.0.
+
 ## Version 10.4.0
 
 ### New features

--- a/documentation/src/main/markdown/troubleshooting/solutions.md
+++ b/documentation/src/main/markdown/troubleshooting/solutions.md
@@ -136,23 +136,23 @@ you will get this (or a similar) error if you run with --detect.tools.BINARY_SCA
 
 Set --detect.project.name and --detect.project.version.name.
 
-## [blackduck_signature_scanner_name] fails on Alpine Linux
+## [blackduck_signature_scanner_name] fails on Alpine Linux or ARM64
 
 ### Symptom
 
-The [blackduck_signature_scanner_name] fails on Alpine Linux with an error similar to:
+The [blackduck_signature_scanner_name] fails on Alpine Linux or ARM64 with an error similar to:
 
 ````
-There was a problem scanning target '/opt/projects/myproject': Cannot run program "/home/me/blackduck/tools/Black_Duck_Scan_Installation/scan.cli-2020.6.0/jre/bin/java": error=2, No such file or directory
+There was a problem scanning target '/opt/projects/myproject': Cannot run program "/home/me/blackduck/tools/Black_Duck_Scan_Installation/scan.cli-2025.4.0/jre/bin/java": error=2, No such file or directory
 ````
 
 ### Possible cause
 
-The Java bundled with the [blackduck_signature_scanner_name] does not work on Alpine Linux (it relies on libraries not usually present on an Alpine system).
+The Java bundled with the [blackduck_signature_scanner_name] does not work on Alpine Linux or ARM64 (it relies on libraries not usually present on an Alpine or ARM64 system).
 
 ### Solution
 
-Install an appropriate version of Java and tell [detect_product_short] to invoke the [blackduck_signature_scanner_name] using that
+Install a supported version of Java and tell [detect_product_short] to invoke the [blackduck_signature_scanner_name] using that
 version of Java by setting environment variable BDS_JAVA_HOME to the JAVA_HOME value for that Java installation.
 
 For example:
@@ -164,7 +164,7 @@ export BDS_JAVA_HOME=$JAVA_HOME
 Or:
 
 ````
-export BDS_JAVA_HOME=/usr/lib/jvm/java-11-openjdk/jre
+export BDS_JAVA_HOME=/<path to supported>/jre
 ````
 
 ## Detector scan fails with Java compatibility issues

--- a/documentation/topics.ditamap
+++ b/documentation/topics.ditamap
@@ -7,7 +7,7 @@
 		<prodinfo>
 			<prodname>Black Duck Detect</prodname>
 			<vrmlist>
-				<vrm version="10.5.0"/>
+				<vrm version="10.6.0"/>
 			</vrmlist>
 		</prodinfo>
 		<!-- zoomin bundle name -->


### PR DESCRIPTION
Setting up release notes and doc version.
Sneaking in BS SCA requested addition to troubleshooting section re: Signature Scanner Java version issue on ARM64 (SCANCLI-16).