### PR TITLE
cpIDETECT-4743

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* 
+*  A new parameter [detect.stateless.policy.check.fail.on.severities](properties/basic-properties.html#detect.stateless.policy.check.fail.on.severities) has been added which will trigger [detect_product_short] to fail the scan and notify the user if a Stateless Scan policy violation exceeds the configured value.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -26,11 +26,13 @@
 
 ### Changed features
 
-* 
+* To improve processing time when both PNPM and NPM detectors apply to a directory, only PNPM detector will execute, producing the same quality of results.
 
 ### Resolved issues
 
-* 
+* (IDETECT-4657) - Additional logging has been added for occurances of [detect_product_short] erroring out when loading a malformed Spring Boot config file. 
+<note type="hint">A valid Spring Boot config file can be specified via the `--spring.config.location=""` parameter.</note>
+
 ### Dependency updates
 
 * 

--- a/documentation/src/main/markdown/runningdetect/detectorcascade.md
+++ b/documentation/src/main/markdown/runningdetect/detectorcascade.md
@@ -44,9 +44,12 @@ Detector type filtering honors your requests to exclude certain detector types (
 
 ## Yielding rules
 
-Yielding rules cause some detectors to have precedence over others for a given directory. For example, if both the
-YARN and NPM detector types apply to a directory, only the YARN detector will apply
-because NPM yields to YARN.
+Yielding rules cause some detectors to have precedence over others for a given directory.    
+
+Examples;    
+* If both the YARN and NPM detector types apply to a directory, only the YARN detector will apply
+because NPM yields to YARN.    
+* If PMPN and NPM detectors apply, NPM will yield to PNPM detector.    
 
 Yielding rules cannot be disabled.
 


### PR DESCRIPTION
Update docs/RN for NPM detectors yielding to PNPM
Additional logging for spring boot exceptions – RN
RN and parameter updates for detect.stateless.policy.check.fail.on.severities property