### PR TITLE
Clarify property and report when overriding failing severities

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* A new property, `detect.stateless.policy.check.fail.on.severities`, has been added that takes a comma-separated list of policy violation severities. Any policy violation with a severity in this list, and only in this list, will cause Detect to fail. This overrides the default behavior of blocker and critical being the only severities which cause a Detect exit failure. This property works for both rapid and stateless scans. Intelligent persistent scans should continue to use the existing `detect.policy.check.fail.on.severities` property.
+* A new property, [detect.stateless.policy.check.fail.on.severities](properties/basic-properties.html#ariaid-title34) has been added, which will trigger [detect_product_short] to fail the scan and notify the user if a policy violation matches the configured value. This property overrides the default "Blocker" and "Critical" severity settings that cause [detect_product_short] scans to exit. This property applies to both [Rapid](runningdetect/rapidscan.md) and [Stateless](runningdetect/statelessscan.md) scans. Intelligent persistent scans, (when scan mode is not set to RAPID, STATELESS, or [--detect.blackduck.scan.mode](properties/all-properties.html#ariaid-title5) is explicitly set to INTELLIGENT and scan data is persisted), should continue using the [detect.policy.check.fail.on.severities](properties/basic-properties.html#ariaid-title34), property.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* 
+* A new property, `detect.stateless.policy.check.fail.on.severities`, has been added that takes a comma-separated list of policy violation severities. Any policy violation with a severity in this list, and only in this list, will cause Detect to fail. This overrides the default behavior of blocker and critical being the only severities which cause a Detect exit failure. This property works for both rapid and stateless scans. Intelligent persistent scans should continue to use the existing `detect.policy.check.fail.on.severities` property.
 
 ### Changed features
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -241,10 +241,14 @@ public class DetectConfigurationFactory {
     public RapidScanOptions createRapidScanOptions() {
         RapidCompareMode rapidCompareMode = detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_RAPID_COMPARE_MODE);
         BlackduckScanMode scanMode= detectConfiguration.getValue(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE);
-        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
+        List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = getPoliciesToFailOn();
         
         long detectTimeout = findTimeoutInSeconds();
         return new RapidScanOptions(rapidCompareMode, scanMode, detectTimeout, severitiesToFailPolicyCheck);
+    }
+
+    public List<PolicyRuleSeverityType> getPoliciesToFailOn() {
+        return detectConfiguration.getValue(DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
     }
 
     public BlackduckScanMode createScanMode() {

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1396,9 +1396,9 @@ public class DetectProperties {
     
     public static final AllNoneEnumListProperty<PolicyRuleSeverityType> DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES =
         AllNoneEnumListProperty.newBuilder("detect.stateless.policy.check.fail.on.severities", Arrays.asList(PolicyRuleSeverityType.BLOCKER, PolicyRuleSeverityType.CRITICAL), PolicyRuleSeverityType.class)
-            .setInfo("Fail on Stateless Policy Violation Severities", DetectPropertyFromVersion.VERSION_10_5_0)
+            .setInfo("Fail on Stateless Policy Violation Severities", DetectPropertyFromVersion.VERSION_10_6_0)
             .setHelp(
-                "A comma-separated list of policy violation severities that will fail Detect. If this is set to NONE, Detect will not fail due to policy violations. A value of ALL is equivalent to all of the other possible values except NONE.")
+                "A comma-separated list of policy violation severities that will fail Detect. If this is set to NONE, Detect will not fail due to policy violations. A value of ALL is equivalent to all of the other possible values except NONE. This property works for both stateless and rapid scans.")
             .setGroups(DetectGroup.PROJECT, DetectGroup.GLOBAL, DetectGroup.PROJECT_SETTING, DetectGroup.POLICY)
             .build();
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectPropertyFromVersion.java
@@ -55,7 +55,8 @@ public enum DetectPropertyFromVersion implements PropertyVersion {
     VERSION_10_2_0("10.2.0"),
     VERSION_10_3_0("10.3.0"),
     VERSION_10_4_0("10.4.0"),
-    VERSION_10_5_0("10.5.0");
+    VERSION_10_5_0("10.5.0"),
+    VERSION_10_6_0("10.6.0");
 
     private final String version;
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -714,7 +714,6 @@ public class OperationRunner {
         );
     }
 
-    // TODO fix here
     public final void publishRapidResults(File jsonFile, RapidScanResultSummary summary, BlackduckScanMode mode) throws OperationException {        
         auditLog.namedInternal("Publish Rapid Results", () -> statusEventPublisher.publishDetectResult(new RapidScanDetectResult(jsonFile.getCanonicalPath(), summary, mode, detectConfigurationFactory.getPoliciesToFailOn())));
     }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -64,6 +64,7 @@ import com.blackduck.integration.common.util.finder.FileFinder;
 import com.blackduck.integration.componentlocator.beans.Component;
 import com.blackduck.integration.detect.configuration.DetectConfigurationFactory;
 import com.blackduck.integration.detect.configuration.DetectInfo;
+import com.blackduck.integration.detect.configuration.DetectProperties;
 import com.blackduck.integration.detect.configuration.DetectUserFriendlyException;
 import com.blackduck.integration.detect.configuration.DetectorToolOptions;
 import com.blackduck.integration.detect.configuration.connection.ConnectionFactory;
@@ -713,8 +714,9 @@ public class OperationRunner {
         );
     }
 
-    public final void publishRapidResults(File jsonFile, RapidScanResultSummary summary, BlackduckScanMode mode) throws OperationException {
-        auditLog.namedInternal("Publish Rapid Results", () -> statusEventPublisher.publishDetectResult(new RapidScanDetectResult(jsonFile.getCanonicalPath(), summary, mode)));
+    // TODO fix here
+    public final void publishRapidResults(File jsonFile, RapidScanResultSummary summary, BlackduckScanMode mode) throws OperationException {        
+        auditLog.namedInternal("Publish Rapid Results", () -> statusEventPublisher.publishDetectResult(new RapidScanDetectResult(jsonFile.getCanonicalPath(), summary, mode, detectConfigurationFactory.getPoliciesToFailOn())));
     }
     //End Rapid
 

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -1,9 +1,10 @@
 package com.blackduck.integration.detect.workflow.blackduck.developer;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
+import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.blackduck.integration.detect.workflow.blackduck.developer.aggregate.RapidScanDetailGroup;
 import com.blackduck.integration.detect.workflow.blackduck.developer.aggregate.RapidScanResultSummary;
@@ -17,9 +18,9 @@ public class RapidScanDetectResult implements DetectResult {
     private final List<String> transitiveGuidanceSubMessages;
     public static String scanMode;
 
-    public RapidScanDetectResult(String jsonFilePath, RapidScanResultSummary resultSummary, BlackduckScanMode mode) {
+    public RapidScanDetectResult(String jsonFilePath, RapidScanResultSummary resultSummary, BlackduckScanMode mode, List<PolicyRuleSeverityType> errorPolicies) {
         this.jsonFilePath = jsonFilePath;
-        this.subMessages = createResultMessages(resultSummary);
+        this.subMessages = createResultMessages(resultSummary, errorPolicies);
         this.transitiveGuidanceSubMessages = createTransitiveGuidanceMessages(resultSummary);
         scanMode = mode.displayName();
     }
@@ -51,7 +52,7 @@ public class RapidScanDetectResult implements DetectResult {
     }
     
 
-    private List<String> createResultMessages(RapidScanResultSummary summary) {
+    private List<String> createResultMessages(RapidScanResultSummary summary, List<PolicyRuleSeverityType> errorPolicies) {
         String policyGroupName = RapidScanDetailGroup.POLICY.getDisplayName();
         String securityGroupName = RapidScanDetailGroup.SECURITY.getDisplayName();
         String licenseGroupName = RapidScanDetailGroup.LICENSE.getDisplayName();
@@ -61,7 +62,7 @@ public class RapidScanDetectResult implements DetectResult {
 
         List<String> resultMessages = new LinkedList<>();
         resultMessages.add("");
-        resultMessages.add("\tCritical and blocking policy violations for");
+        addErrorViolationHeader(resultMessages, errorPolicies);
         resultMessages.add(String.format(countFormat, policyGroupName, summary.getPolicyErrorCount()));
         resultMessages.add(String.format(countFormat, securityGroupName, summary.getSecurityErrorCount()));
         resultMessages.add(String.format(countFormat, licenseGroupName, summary.getLicenseErrorCount()));
@@ -89,6 +90,24 @@ public class RapidScanDetectResult implements DetectResult {
             .forEach(component -> resultMessages.add(String.format(indentedMessageFormat, component)));
 
         return resultMessages;
+    }
+
+    private void addErrorViolationHeader(List<String> resultMessages, List<PolicyRuleSeverityType> errorPolicies) {
+        List<PolicyRuleSeverityType> defaultPolicies = Arrays.asList(PolicyRuleSeverityType.CRITICAL, PolicyRuleSeverityType.BLOCKER);
+
+        if (errorPolicies.containsAll(defaultPolicies)) {
+            resultMessages.add("\tCritical and blocking policy violations for");
+        } else {
+            String violationMessage;
+            if (errorPolicies.size() == 1) {
+                violationMessage = errorPolicies.get(0).name().toLowerCase();
+            } else {
+                violationMessage = String.join(", ", errorPolicies.subList(0, errorPolicies.size() - 1).stream()
+                        .map(policy -> policy.name().toLowerCase())
+                        .toArray(String[]::new)) + " and " + errorPolicies.get(errorPolicies.size() - 1).name().toLowerCase();
+            }
+            resultMessages.add("\tdetect.stateless.policy.check.fail.on.severities " + violationMessage);
+        }
     }
 
     @Override

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/developer/RapidScanDetectResult.java
@@ -1,8 +1,10 @@
 package com.blackduck.integration.detect.workflow.blackduck.developer;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
 import com.blackduck.integration.detect.configuration.DetectProperties;
@@ -14,7 +16,6 @@ import com.blackduck.integration.detect.workflow.result.DetectResult;
 public class RapidScanDetectResult implements DetectResult {
     public static final String NONPERSISTENT_SCAN_RESULT_HEADING = " Scan Result";
     public static final String NONPERSISTENT_SCAN_RESULT_DETAILS_HEADING = " Scan Result Details";
-    public static final String ALT_POLICY_VIOLATION_HEADER_PREFIX = "detect.stateless.policy.check.fail.on.severities";
     private final String jsonFilePath;
     private final List<String> subMessages;
     private final List<String> transitiveGuidanceSubMessages;
@@ -106,7 +107,7 @@ public class RapidScanDetectResult implements DetectResult {
                         .map(policy -> policy.name().toLowerCase())
                         .toArray(String[]::new)) + " and " + errorPolicies.get(errorPolicies.size() - 1).name().toLowerCase();
             }
-            resultMessages.add(String.format("\t%s %s policy violations for", ALT_POLICY_VIOLATION_HEADER_PREFIX, violationMessage));
+            resultMessages.add(String.format("\t%s %s policy violations for", DetectProperties.DETECT_STATELESS_POLICY_CHECK_FAIL_ON_SEVERITIES.getKey(), violationMessage));
         }
     }
 
@@ -116,7 +117,11 @@ public class RapidScanDetectResult implements DetectResult {
         if (errorPolicies == null) {
             return false;
         }
-        return errorPolicies.equals(defaultPolicies);
+        
+        Set<PolicyRuleSeverityType> errorSet = new HashSet<>(errorPolicies);
+        Set<PolicyRuleSeverityType> defaultSet = new HashSet<>(defaultPolicies);
+        
+        return errorSet.equals(defaultSet);
     }
 
     @Override


### PR DESCRIPTION
This work:

- adds additional messaging to indicate that the new property works for both rapid and stateless scans

- update the section that says critical and blocker, even in the status.json, if the user uses the new property.

- we will not change the policy violation section as technically those are violated even though we may no longer be failing on them