### PR TITLE
Provide Risk Report in JSON Format

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectConfigurationFactory.java
@@ -449,9 +449,11 @@ public class DetectConfigurationFactory {
 
     public BlackDuckPostOptions createBlackDuckPostOptions() {
         Boolean waitForResults = detectConfiguration.getValue(DetectProperties.DETECT_WAIT_FOR_RESULTS);
-        Boolean runRiskReport = detectConfiguration.getValue(DetectProperties.DETECT_RISK_REPORT_PDF);
+        Boolean runRiskReportPdf = detectConfiguration.getValue(DetectProperties.DETECT_RISK_REPORT_PDF);
+        Boolean runRiskReportJson = detectConfiguration.getValue(DetectProperties.DETECT_RISK_REPORT_JSON);
         Boolean runNoticesReport = detectConfiguration.getValue(DetectProperties.DETECT_NOTICES_REPORT);
         Path riskReportPdfPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_RISK_REPORT_PDF_PATH);
+        Path riskReportJsonPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_RISK_REPORT_JSON_PATH);
         Path noticesReportPath = detectConfiguration.getPathOrNull(DetectProperties.DETECT_NOTICES_REPORT_PATH);
         List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_SEVERITIES).representedValues();
         List<String> policyNamesToFailPolicyCheck = detectConfiguration.getValue(DetectProperties.DETECT_POLICY_CHECK_FAIL_ON_NAMES);
@@ -459,13 +461,15 @@ public class DetectConfigurationFactory {
 
         return new BlackDuckPostOptions(
             waitForResults,
-            runRiskReport,
+            runRiskReportPdf,
             runNoticesReport,
             riskReportPdfPath,
             noticesReportPath,
             severitiesToFailPolicyCheck,
             policyNamesToFailPolicyCheck,
-            correlatedScanningEnabled
+            correlatedScanningEnabled,
+            runRiskReportJson,
+            riskReportJsonPath
         );
     }
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -1639,12 +1639,26 @@ public class DetectProperties {
             .setGroups(DetectGroup.REPORT, DetectGroup.GLOBAL, DetectGroup.REPORT_SETTING)
             .build();
 
+    public static final BooleanProperty DETECT_RISK_REPORT_JSON =
+            BooleanProperty.newBuilder("detect.risk.report.json", false)
+                    .setInfo("Generate Risk Report (JSON)", DetectPropertyFromVersion.VERSION_10_6_0)
+                    .setHelp("When set to true, a Black Duck risk report in JSON form will be created.")
+                    .setGroups(DetectGroup.REPORT, DetectGroup.GLOBAL, DetectGroup.REPORT_SETTING)
+                    .build();
+
     public static final NullablePathProperty DETECT_RISK_REPORT_PDF_PATH =
         NullablePathProperty.newBuilder("detect.risk.report.pdf.path")
-            .setInfo("Risk Report Output Path", DetectPropertyFromVersion.VERSION_3_0_0)
+            .setInfo("Risk Report (PDF) Output Path", DetectPropertyFromVersion.VERSION_3_0_0)
             .setHelp("The output directory for risk report in PDF. Default is the source directory.")
             .setGroups(DetectGroup.REPORT, DetectGroup.GLOBAL)
             .build();
+
+    public static final NullablePathProperty DETECT_RISK_REPORT_JSON_PATH =
+            NullablePathProperty.newBuilder("detect.risk.report.json.path")
+                    .setInfo("Risk Report (JSON) Output Path", DetectPropertyFromVersion.VERSION_10_6_0)
+                    .setHelp("The output directory for risk report in JSON. Default is the source directory.")
+                    .setGroups(DetectGroup.REPORT, DetectGroup.GLOBAL)
+                    .build();
 
     public static final NoneEnumListProperty<GemspecDependencyType> DETECT_RUBY_DEPENDENCY_TYPES_EXCLUDED =
         NoneEnumListProperty.newBuilder("detect.ruby.dependency.types.excluded", NoneEnum.NONE, GemspecDependencyType.class)

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 
 import com.blackduck.integration.blackduck.bdio2.model.BdioFileContent;
 import com.blackduck.integration.detect.lifecycle.run.step.CommonScanStepRunner;
+import com.blackduck.integration.detect.workflow.blackduck.report.ReportData;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
@@ -957,23 +958,20 @@ public class OperationRunner {
         );
     }
 
-    public File createRiskReportFile(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersionWrapper, File reportDirectory, boolean isPdfFile) throws OperationException {
+    public File createRiskReportFile(File reportDirectory, boolean isPdfFile, ReportService reportService, ReportData reportData) throws OperationException {
         return auditLog.namedPublic("Create Risk Report File", "RiskReport", () -> {
-            ReportService reportService = creatReportService(blackDuckRunData);
             if(isPdfFile) {
                 DetectFontLoader detectFontLoader = detectFontLoaderFactory.detectFontLoader();
                 return reportService.createReportPdfFile(
                         reportDirectory,
-                        projectVersionWrapper.getProjectView(),
-                        projectVersionWrapper.getProjectVersionView(),
                         detectFontLoader::loadFont,
-                        detectFontLoader::loadBoldFont
+                        detectFontLoader::loadBoldFont,
+                        reportData
                 );
             } else {
                 return reportService.createReportJsonFile(
                         reportDirectory,
-                        projectVersionWrapper.getProjectView(),
-                        projectVersionWrapper.getProjectVersionView()
+                        reportData
                 );
             }
         });
@@ -994,7 +992,7 @@ public class OperationRunner {
         });
     }
 
-    private ReportService creatReportService(BlackDuckRunData blackDuckRunData) throws OperationException {
+    public ReportService creatReportService(BlackDuckRunData blackDuckRunData) throws OperationException {
         return auditLog.namedInternal("Create Report Service", () -> {
             BlackDuckServicesFactory blackDuckServicesFactory = blackDuckRunData.getBlackDuckServicesFactory();
             Gson gson = blackDuckServicesFactory.getGson();

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -958,9 +958,10 @@ public class OperationRunner {
         );
     }
 
-    public File createRiskReportFile(File reportDirectory, boolean isPdfFile, ReportService reportService, ReportData reportData) throws OperationException {
+    public File createRiskReportFile(File reportDirectory, String reportType, ReportService reportService, ReportData reportData) throws OperationException {
+        final String PDF_SUFFIX = "pdf";
         return auditLog.namedPublic("Create Risk Report File", "RiskReport", () -> {
-            if(isPdfFile) {
+            if(reportType.equals(PDF_SUFFIX)) {
                 DetectFontLoader detectFontLoader = detectFontLoaderFactory.detectFontLoader();
                 return reportService.createReportPdfFile(
                         reportDirectory,

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -957,17 +957,25 @@ public class OperationRunner {
         );
     }
 
-    public File createRiskReportFile(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersionWrapper, File reportDirectory) throws OperationException {
+    public File createRiskReportFile(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersionWrapper, File reportDirectory, boolean isPdfFile) throws OperationException {
         return auditLog.namedPublic("Create Risk Report File", "RiskReport", () -> {
-            DetectFontLoader detectFontLoader = detectFontLoaderFactory.detectFontLoader();
             ReportService reportService = creatReportService(blackDuckRunData);
-            return reportService.createReportPdfFile(
-                reportDirectory,
-                projectVersionWrapper.getProjectView(),
-                projectVersionWrapper.getProjectVersionView(),
-                detectFontLoader::loadFont,
-                detectFontLoader::loadBoldFont
-            );
+            if(isPdfFile) {
+                DetectFontLoader detectFontLoader = detectFontLoaderFactory.detectFontLoader();
+                return reportService.createReportPdfFile(
+                        reportDirectory,
+                        projectVersionWrapper.getProjectView(),
+                        projectVersionWrapper.getProjectVersionView(),
+                        detectFontLoader::loadFont,
+                        detectFontLoader::loadBoldFont
+                );
+            } else {
+                return reportService.createReportJsonFile(
+                        reportDirectory,
+                        projectVersionWrapper.getProjectView(),
+                        projectVersionWrapper.getProjectVersionView()
+                );
+            }
         });
     }
 
@@ -1209,12 +1217,23 @@ public class OperationRunner {
         });
     }
 
-    public Optional<File> calculateRiskReportFileLocation() throws OperationException { //TODO Should be a decision in boot
+    public Optional<File> calculateRiskReportPdfFileLocation() throws OperationException { //TODO Should be a decision in boot
         return auditLog.namedInternal("Decide Risk Report Path", () -> {
             BlackDuckPostOptions postOptions = detectConfigurationFactory.createBlackDuckPostOptions();
-            if (postOptions.shouldGenerateRiskReport()) {
+            if (postOptions.shouldGenerateRiskReportPdf()) {
                 return Optional.of(postOptions.getRiskReportPdfPath().map(Path::toFile)
                     .orElse(directoryManager.getSourceDirectory()));
+            }
+            return Optional.empty();
+        });
+    }
+
+    public Optional<File> calculateRiskReportJsonFileLocation() throws OperationException { //TODO Should be a decision in boot
+        return auditLog.namedInternal("Decide Risk Report Path", () -> {
+            BlackDuckPostOptions postOptions = detectConfigurationFactory.createBlackDuckPostOptions();
+            if (postOptions.shouldGenerateRiskReportJson()) {
+                return Optional.of(postOptions.getRiskReportJsonPath().map(Path::toFile)
+                        .orElse(directoryManager.getSourceDirectory()));
             }
             return Optional.empty();
         });

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -404,7 +404,7 @@ public class IntelligentModeStepRunner {
         ReportService reportService = null;
         ReportData reportData = null;
 
-        if(riskReportPdfFile.isPresent() || riskReportJsonFile.isPresent()) {
+        if (riskReportPdfFile.isPresent() || riskReportJsonFile.isPresent()) {
             reportService = operationRunner.creatReportService(blackDuckRunData);
             reportData = reportService.getRiskReportData(projectVersion.getProjectView(), projectVersion.getProjectVersionView());
         }

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -397,19 +397,34 @@ public class IntelligentModeStepRunner {
     }
 
     public void riskReport(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersion) throws IOException, OperationException {
-        Optional<File> riskReportFile = operationRunner.calculateRiskReportFileLocation();
-        if (riskReportFile.isPresent()) {
+        Optional<File> riskReportPdfFile = operationRunner.calculateRiskReportPdfFileLocation();
+        if (riskReportPdfFile.isPresent()) {
             logger.info("Creating risk report pdf");
-            File reportDirectory = riskReportFile.get();
+            File reportDirectory = riskReportPdfFile.get();
 
             if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
                 logger.warn(String.format("Failed to create risk report pdf directory: %s", reportDirectory));
             }
 
-            File createdPdf = operationRunner.createRiskReportFile(blackDuckRunData, projectVersion, reportDirectory);
+            File createdPdf = operationRunner.createRiskReportFile(blackDuckRunData, projectVersion, reportDirectory, true);
 
             logger.info(String.format("Created risk report pdf: %s", createdPdf.getCanonicalPath()));
             operationRunner.publishReport(new ReportDetectResult("Risk Report", createdPdf.getCanonicalPath()));
+        }
+
+        Optional<File> riskReportJsonFile = operationRunner.calculateRiskReportJsonFileLocation();
+        if (riskReportJsonFile.isPresent()) {
+            logger.info("Creating risk report json file");
+            File reportDirectory = riskReportJsonFile.get();
+
+            if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
+                logger.warn(String.format("Failed to create risk report json directory: %s", reportDirectory));
+            }
+
+            File createdJson = operationRunner.createRiskReportFile(blackDuckRunData, projectVersion, reportDirectory, false);
+
+            logger.info(String.format("Created risk report json: %s", createdJson.getCanonicalPath()));
+            operationRunner.publishReport(new ReportDetectResult("Risk Report", createdJson.getCanonicalPath()));
         }
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -410,33 +410,26 @@ public class IntelligentModeStepRunner {
         }
 
         if (riskReportPdfFile.isPresent()) {
-            logger.info("Creating risk report pdf");
-            File reportDirectory = riskReportPdfFile.get();
-
-            if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
-                logger.warn(String.format("Failed to create risk report pdf directory: %s", reportDirectory));
-            }
-
-            File createdPdf = operationRunner.createRiskReportFile(reportDirectory, true, reportService, reportData);
-
-            logger.info(String.format("Created risk report pdf: %s", createdPdf.getCanonicalPath()));
-            operationRunner.publishReport(new ReportDetectResult("Risk Report", createdPdf.getCanonicalPath()));
+            riskReportCreation(reportData, reportService, "pdf", riskReportPdfFile);
         }
-
 
         if (riskReportJsonFile.isPresent()) {
-            logger.info("Creating risk report json file");
-            File reportDirectory = riskReportJsonFile.get();
-
-            if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
-                logger.warn(String.format("Failed to create risk report json directory: %s", reportDirectory));
-            }
-
-            File createdJson = operationRunner.createRiskReportFile(reportDirectory, false, reportService, reportData);
-
-            logger.info(String.format("Created risk report json: %s", createdJson.getCanonicalPath()));
-            operationRunner.publishReport(new ReportDetectResult("Risk Report", createdJson.getCanonicalPath()));
+            riskReportCreation(reportData, reportService, "json", riskReportJsonFile);
         }
+    }
+
+    private void riskReportCreation(ReportData reportData, ReportService reportService, String reportType, Optional<File> riskReportFile) throws OperationException, IOException {
+        logger.info("Creating risk report {}", reportType);
+        File reportDirectory = riskReportFile.get();
+
+        if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
+            logger.warn(String.format("Failed to create risk report %s directory: %s", reportType, reportDirectory));
+        }
+
+        File createdReport = operationRunner.createRiskReportFile(reportDirectory, reportType, reportService, reportData);
+
+        logger.info(String.format("Created risk report %s: %s", reportType, createdReport.getCanonicalPath()));
+        operationRunner.publishReport(new ReportDetectResult("Risk Report", createdReport.getCanonicalPath()));
     }
 
     public void noticesReport(BlackDuckRunData blackDuckRunData, ProjectVersionWrapper projectVersion) throws OperationException, IOException {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/BlackDuckPostOptions.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/BlackDuckPostOptions.java
@@ -12,9 +12,11 @@ import com.blackduck.integration.blackduck.api.generated.enumeration.PolicyRuleS
 public class BlackDuckPostOptions {
     private final boolean waitForResults;
 
-    private final boolean generateRiskReport;
+    private final boolean generateRiskReportPdf;
+    private final boolean generateRiskReportJson;
     private final boolean generateNoticesReport;
     private final @Nullable Path riskReportPdfPath;
+    private final @Nullable Path riskReportJsonPath;
     private final @Nullable Path noticesReportPath;
     private final List<PolicyRuleSeverityType> severitiesToFailPolicyCheck;
     private final List<String> policyNamesToFailPolicyCheck;
@@ -22,30 +24,38 @@ public class BlackDuckPostOptions {
 
     public BlackDuckPostOptions(
         boolean waitForResults,
-        boolean generateRiskReport,
+        boolean generateRiskReportPdf,
         boolean generateNoticesReport,
         @Nullable Path riskReportPdfPath,
         @Nullable Path noticesReportPath,
         List<PolicyRuleSeverityType> severitiesToFailPolicyCheck,
         List<String> policyNamesToFailPolicyCheck,
-        boolean correlatedScanningEnabled
+        boolean correlatedScanningEnabled,
+        boolean generateRiskReportJson,
+        @Nullable Path riskReportJsonPath
     ) {
         this.waitForResults = waitForResults;
-        this.generateRiskReport = generateRiskReport;
+        this.generateRiskReportPdf = generateRiskReportPdf;
         this.generateNoticesReport = generateNoticesReport;
         this.riskReportPdfPath = riskReportPdfPath;
         this.noticesReportPath = noticesReportPath;
         this.severitiesToFailPolicyCheck = severitiesToFailPolicyCheck;
         this.policyNamesToFailPolicyCheck = policyNamesToFailPolicyCheck;
         this.correlatedScanningEnabled = correlatedScanningEnabled;
+        this.generateRiskReportJson = generateRiskReportJson;
+        this.riskReportJsonPath = riskReportJsonPath;
     }
 
     public boolean shouldWaitForResults() {
         return waitForResults || shouldGenerateAnyReport() || shouldPerformAnyPolicyCheck();
     }
 
-    public boolean shouldGenerateRiskReport() {
-        return generateRiskReport;
+    public boolean shouldGenerateRiskReportPdf() {
+        return generateRiskReportPdf;
+    }
+
+    public boolean shouldGenerateRiskReportJson() {
+        return generateRiskReportJson;
     }
 
     public boolean shouldGenerateNoticesReport() {
@@ -53,7 +63,7 @@ public class BlackDuckPostOptions {
     }
 
     public boolean shouldGenerateAnyReport() {
-        return shouldGenerateNoticesReport() || shouldGenerateRiskReport();
+        return shouldGenerateNoticesReport() || shouldGenerateRiskReportPdf() || shouldGenerateRiskReportJson();
     }
 
     public boolean shouldPerformSeverityPolicyCheck() {
@@ -70,6 +80,10 @@ public class BlackDuckPostOptions {
 
     public Optional<Path> getRiskReportPdfPath() {
         return Optional.ofNullable(riskReportPdfPath);
+    }
+
+    public Optional<Path> getRiskReportJsonPath() {
+        return Optional.ofNullable(riskReportJsonPath);
     }
 
     public Optional<Path> getNoticesReportPath() {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/BomRiskCounts.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/BomRiskCounts.java
@@ -6,11 +6,20 @@ import static com.blackduck.integration.blackduck.api.generated.enumeration.Risk
 import static com.blackduck.integration.blackduck.api.generated.enumeration.RiskPriorityType.MEDIUM;
 
 import com.blackduck.integration.blackduck.api.generated.component.RiskProfileCountsView;
+import com.google.gson.annotations.SerializedName;
 
 public class BomRiskCounts {
+
+    @SerializedName("critical")
     private int critical;
+
+    @SerializedName("high")
     private int high;
+
+    @SerializedName("medium")
     private int medium;
+
+    @SerializedName("low")
     private int low;
 
     public void add(RiskProfileCountsView countsView) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/ReportData.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/ReportData.java
@@ -4,26 +4,54 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 public class ReportData {
+    @SerializedName("projectName")
     private String projectName;
+
+    @SerializedName("projectURL")
     private String projectURL;
+
+    @SerializedName("projectVersion")
     private String projectVersion;
+
+    @SerializedName("projectVersionURL")
     private String projectVersionURL;
+
+    @SerializedName("phase")
     private String phase;
+
+    @SerializedName("distribution")
     private String distribution;
+
+    @SerializedName("components")
     private List<BomComponent> components;
+
+    @SerializedName("totalComponents")
     private int totalComponents;
+
+    @SerializedName("dateTimeOfLatestScan")
     private LocalDateTime dateTimeOfLatestScan;
 
+    @SerializedName("securityRiskCounts")
     private final BomRiskCounts securityRiskCounts = new BomRiskCounts();
+
+    @SerializedName("licenseRiskCounts")
     private final BomRiskCounts licenseRiskCounts = new BomRiskCounts();
+
+    @SerializedName("operationalRiskCounts")
     private final BomRiskCounts operationalRiskCounts = new BomRiskCounts();
 
+    @SerializedName("vulnerabilityRiskNoneCount")
     private int vulnerabilityRiskNoneCount;
+
+    @SerializedName("licenseRiskNoneCount")
     private int licenseRiskNoneCount;
+
+    @SerializedName("operationalRiskNoneCount")
     private int operationalRiskNoneCount;
 
     public String htmlEscape(String valueToEscape) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
@@ -2,15 +2,25 @@ package com.blackduck.integration.detect.workflow.blackduck.report.json;
 
 import com.blackduck.integration.detect.workflow.blackduck.report.ReportData;
 import com.blackduck.integration.util.IntegrationEscapeUtil;
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class RiskReportJsonWriter {
 
+    private static final Logger logger = LoggerFactory.getLogger(RiskReportJsonWriter.class);
 
     public static File createRiskReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {
         IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
@@ -18,6 +28,12 @@ public class RiskReportJsonWriter {
         String escapedProjectName = escapeUtil.replaceWithUnderscore(reportData.getProjectName());
         String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(reportData.getProjectVersion());
         File jsonFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport.json");
+        if (jsonFile.exists()) {
+            boolean deleted = jsonFile.delete();
+            if (!deleted) {
+                logger.warn(String.format("Unable to delete existing file %s before re-creating it", jsonFile.getAbsolutePath()));
+            }
+        }
 
         String serializedReportData = serializeRiskReport(reportData);
 
@@ -35,8 +51,16 @@ public class RiskReportJsonWriter {
         Gson gson = new GsonBuilder()
                 .setLenient()
                 .setPrettyPrinting()
+                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
                 .create();
         return gson.toJson(reportData);
+    }
+
+    public static class LocalDateTimeAdapter implements JsonSerializer<LocalDateTime> {
+        @Override
+        public JsonElement serialize(LocalDateTime dateTime, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        }
     }
 
 }

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detect.workflow.blackduck.report.json;
 
 import com.blackduck.integration.detect.workflow.blackduck.report.ReportData;
+import com.blackduck.integration.detect.workflow.blackduck.report.util.ReportFileUtil;
 import com.blackduck.integration.util.IntegrationEscapeUtil;
 import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
@@ -23,18 +24,7 @@ public class RiskReportJsonWriter {
     private static final Logger logger = LoggerFactory.getLogger(RiskReportJsonWriter.class);
 
     public static File createRiskReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {
-        IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
-
-        String escapedProjectName = escapeUtil.replaceWithUnderscore(reportData.getProjectName());
-        String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(reportData.getProjectVersion());
-        File jsonFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport.json");
-        if (jsonFile.exists()) {
-            boolean deleted = jsonFile.delete();
-            if (!deleted) {
-                logger.warn(String.format("Unable to delete existing file %s before re-creating it", jsonFile.getAbsolutePath()));
-            }
-        }
-
+        File jsonFile = ReportFileUtil.createReportFile(outputDirectory, reportData.getProjectName(), reportData.getProjectVersion(), "json");
         String serializedReportData = serializeRiskReport(reportData);
 
         try (FileWriter fw = new FileWriter(jsonFile)) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
@@ -24,7 +24,7 @@ public class RiskReportJsonWriter {
     private static final Logger logger = LoggerFactory.getLogger(RiskReportJsonWriter.class);
 
     public static File createRiskReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {
-        File jsonFile = ReportFileUtil.createReportFile(outputDirectory, reportData.getProjectName(), reportData.getProjectVersion(), "json");
+        File jsonFile = ReportFileUtil.createReportFile(outputDirectory, reportData.getProjectName(), reportData.getProjectVersion(), "json", "_BlackDuck_RiskReport");
         String serializedReportData = serializeRiskReport(reportData);
 
         try (FileWriter fw = new FileWriter(jsonFile)) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/json/RiskReportJsonWriter.java
@@ -1,0 +1,42 @@
+package com.blackduck.integration.detect.workflow.blackduck.report.json;
+
+import com.blackduck.integration.detect.workflow.blackduck.report.ReportData;
+import com.blackduck.integration.util.IntegrationEscapeUtil;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class RiskReportJsonWriter {
+
+
+    public static File createRiskReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {
+        IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
+
+        String escapedProjectName = escapeUtil.replaceWithUnderscore(reportData.getProjectName());
+        String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(reportData.getProjectVersion());
+        File jsonFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport.json");
+
+        String serializedReportData = serializeRiskReport(reportData);
+
+        try (FileWriter fw = new FileWriter(jsonFile)) {
+            fw.write(serializedReportData);
+            fw.flush();
+        } catch (IOException e) {
+            throw e;
+        }
+
+        return jsonFile;
+    }
+
+    private static String serializeRiskReport(ReportData reportData) {
+        Gson gson = new GsonBuilder()
+                .setLenient()
+                .setPrettyPrinting()
+                .create();
+        return gson.toJson(reportData);
+    }
+
+}

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/pdf/RiskReportPdfWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/pdf/RiskReportPdfWriter.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.blackduck.integration.detect.workflow.blackduck.report.util.ReportFileUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -58,16 +59,7 @@ public class RiskReportPdfWriter {
     }
 
     public File createPDFReportFile(File outputDirectory, ReportData report) throws RiskReportException {
-        IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
-        String escapedProjectName = escapeUtil.replaceWithUnderscore(report.getProjectName());
-        String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(report.getProjectVersion());
-        File pdfFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport.pdf");
-        if (pdfFile.exists()) {
-            boolean deleted = pdfFile.delete();
-            if (!deleted) {
-                logger.warn(String.format("Unable to delete existing file %s before re-creating it", pdfFile.getAbsolutePath()));
-            }
-        }
+        File pdfFile = ReportFileUtil.createReportFile(outputDirectory, report.getProjectName(), report.getProjectVersion(), "pdf");
         PDDocument document = new PDDocument();
 
         font = fontLoader.loadFont(document);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/pdf/RiskReportPdfWriter.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/pdf/RiskReportPdfWriter.java
@@ -59,7 +59,7 @@ public class RiskReportPdfWriter {
     }
 
     public File createPDFReportFile(File outputDirectory, ReportData report) throws RiskReportException {
-        File pdfFile = ReportFileUtil.createReportFile(outputDirectory, report.getProjectName(), report.getProjectVersion(), "pdf");
+        File pdfFile = ReportFileUtil.createReportFile(outputDirectory, report.getProjectName(), report.getProjectVersion(), "pdf","_BlackDuck_RiskReport");
         PDDocument document = new PDDocument();
 
         font = fontLoader.loadFont(document);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.blackduck.integration.detect.workflow.blackduck.report.json.RiskReportJsonWriter;
+import com.blackduck.integration.detect.workflow.blackduck.report.util.ReportFileUtil;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -97,15 +98,7 @@ public class ReportService extends DataService {
         if (noticesReportContent == null) {
             return null;
         }
-        String escapedProjectName = escapeUtil.replaceWithUnderscore(projectName);
-        String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(projectVersionName);
-        File noticesReportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_Black_Duck_Notices_Report.txt");
-        if (noticesReportFile.exists()) {
-            boolean deleted = noticesReportFile.delete();
-            if (!deleted) {
-                logger.warn(String.format("Unable to delete existing file %s before re-creating it", noticesReportFile.getAbsolutePath()));
-            }
-        }
+        File noticesReportFile = ReportFileUtil.createReportFile(outputDirectory, projectName, projectVersionName, "txt");
         try (FileWriter writer = new FileWriter(noticesReportFile)) {
             logger.trace("Creating Notices Report in : " + outputDirectory.getCanonicalPath());
             writer.write(noticesReportContent);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
@@ -4,7 +4,6 @@ import java.awt.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.lang.reflect.Modifier;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -17,7 +16,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.blackduck.integration.detect.workflow.blackduck.report.json.RiskReportJsonWriter;
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 
@@ -210,6 +212,11 @@ public class ReportService extends DataService {
         } catch (RiskReportException | IOException e) {
             throw new BlackDuckIntegrationException(e.getMessage(), e);
         }
+    }
+
+    public File createReportJsonFile(File outputDirectory, ProjectView project, ProjectVersionView version) throws IntegrationException, IOException {
+        ReportData reportData = getRiskReportData(project, version);
+        return createReportJsonFile(outputDirectory, reportData);
     }
 
     public File createReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
@@ -4,6 +4,7 @@ import java.awt.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -15,13 +16,11 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.blackduck.integration.detect.workflow.blackduck.report.json.RiskReportJsonWriter;
+import com.google.gson.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.blackduck.integration.blackduck.api.core.response.UrlMultipleResponses;
 import com.blackduck.integration.blackduck.api.generated.deprecated.view.PolicyStatusView;
 import com.blackduck.integration.blackduck.api.generated.discovery.ApiDiscovery;
@@ -197,6 +196,12 @@ public class ReportService extends DataService {
         return createReportPdfFile(outputDirectory, reportData, fontLoader, boldFontLoader);
     }
 
+    public File createReportJsonFile(File outputDirectory, ProjectView project, ProjectVersionView version)
+            throws IntegrationException, IOException {
+        ReportData reportData = getRiskReportData(project, version);
+        return createReportJsonFile(outputDirectory, reportData);
+    }
+
     public File createReportPdfFile(File outputDirectory, ReportData reportData) throws BlackDuckIntegrationException {
         return createReportPdfFile(outputDirectory, reportData, document -> PDType1Font.HELVETICA, document -> PDType1Font.HELVETICA_BOLD);
     }
@@ -211,6 +216,14 @@ public class ReportService extends DataService {
         } catch (RiskReportException | IOException e) {
             throw new BlackDuckIntegrationException(e.getMessage(), e);
         }
+    }
+
+    public File createReportJsonFile(File outputDirectory, ReportData reportData) throws IOException {
+        logger.trace("Creating Risk Report json in : " + outputDirectory.getCanonicalPath());
+        File jsonFile = RiskReportJsonWriter.createRiskReportJsonFile(outputDirectory, reportData);
+        logger.trace("Created Risk Report Json : " + jsonFile.getCanonicalPath());
+
+        return jsonFile;
     }
 
     private HttpUrl getComponentPolicyURL(HttpUrl versionURL, String componentURL) throws IntegrationException {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
@@ -98,7 +98,7 @@ public class ReportService extends DataService {
         if (noticesReportContent == null) {
             return null;
         }
-        File noticesReportFile = ReportFileUtil.createReportFile(outputDirectory, projectName, projectVersionName, "txt");
+        File noticesReportFile = ReportFileUtil.createReportFile(outputDirectory, projectName, projectVersionName, "txt","_Black_Duck_Notices_Report");
         try (FileWriter writer = new FileWriter(noticesReportFile)) {
             logger.trace("Creating Notices Report in : " + outputDirectory.getCanonicalPath());
             writer.write(noticesReportContent);

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/service/ReportService.java
@@ -187,19 +187,13 @@ public class ReportService extends DataService {
     }
 
     public File createReportPdfFile(File outputDirectory, ProjectView project, ProjectVersionView version) throws IntegrationException {
-        return createReportPdfFile(outputDirectory, project, version, document -> PDType1Font.HELVETICA, document -> PDType1Font.HELVETICA_BOLD);
+        ReportData reportData = getRiskReportData(project, version);
+        return createReportPdfFile(outputDirectory, document -> PDType1Font.HELVETICA, document -> PDType1Font.HELVETICA_BOLD, reportData);
     }
 
-    public File createReportPdfFile(File outputDirectory, ProjectView project, ProjectVersionView version, FontLoader fontLoader, FontLoader boldFontLoader)
+    public File createReportPdfFile(File outputDirectory, FontLoader fontLoader, FontLoader boldFontLoader, ReportData reportData)
         throws IntegrationException {
-        ReportData reportData = getRiskReportData(project, version);
         return createReportPdfFile(outputDirectory, reportData, fontLoader, boldFontLoader);
-    }
-
-    public File createReportJsonFile(File outputDirectory, ProjectView project, ProjectVersionView version)
-            throws IntegrationException, IOException {
-        ReportData reportData = getRiskReportData(project, version);
-        return createReportJsonFile(outputDirectory, reportData);
     }
 
     public File createReportPdfFile(File outputDirectory, ReportData reportData) throws BlackDuckIntegrationException {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
@@ -10,11 +10,11 @@ public class ReportFileUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(ReportFileUtil.class);
 
-    public static File createReportFile(File outputDirectory, String projectName, String projectVersion, String reportFileExtension) {
+    public static File createReportFile(File outputDirectory, String projectName, String projectVersion, String reportFileExtension, String reportName) {
         IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
         String escapedProjectName = escapeUtil.replaceWithUnderscore(projectName);
         String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(projectVersion);
-        File reportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport."+reportFileExtension);
+        File reportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + reportName + ".+" +reportFileExtension);
         if (reportFile.exists()) {
             boolean deleted = reportFile.delete();
             if (!deleted) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
@@ -14,7 +14,7 @@ public class ReportFileUtil {
         IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
         String escapedProjectName = escapeUtil.replaceWithUnderscore(projectName);
         String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(projectVersion);
-        File reportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + reportName + ".+" +reportFileExtension);
+        File reportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + reportName + "." + reportFileExtension);
         if (reportFile.exists()) {
             boolean deleted = reportFile.delete();
             if (!deleted) {

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/report/util/ReportFileUtil.java
@@ -1,0 +1,28 @@
+package com.blackduck.integration.detect.workflow.blackduck.report.util;
+
+import com.blackduck.integration.util.IntegrationEscapeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class ReportFileUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReportFileUtil.class);
+
+    public static File createReportFile(File outputDirectory, String projectName, String projectVersion, String reportFileExtension) {
+        IntegrationEscapeUtil escapeUtil = new IntegrationEscapeUtil();
+        String escapedProjectName = escapeUtil.replaceWithUnderscore(projectName);
+        String escapedProjectVersionName = escapeUtil.replaceWithUnderscore(projectVersion);
+        File reportFile = new File(outputDirectory, escapedProjectName + "_" + escapedProjectVersionName + "_BlackDuck_RiskReport."+reportFileExtension);
+        if (reportFile.exists()) {
+            boolean deleted = reportFile.delete();
+            if (!deleted) {
+                logger.warn(String.format("Unable to delete existing file %s before re-creating it", reportFile.getAbsolutePath()));
+            }
+        }
+
+        return reportFile;
+    }
+
+}

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/DetectOnDetectTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/DetectOnDetectTest.java
@@ -28,7 +28,7 @@ import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.workflow.blackduck.report.service.ReportService;
 import com.blackduck.integration.exception.IntegrationException;
 
-//@Tag("integration")
+@Tag("integration")
 public class DetectOnDetectTest {
     @Test
     void detectOnDetect() throws IOException, IntegrationException {

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/integration/DetectOnDetectTest.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/integration/DetectOnDetectTest.java
@@ -107,8 +107,8 @@ public class DetectOnDetectTest {
 
     @Test
     public void riskReportJsonProduced() throws Exception {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-on-detect-riskreport-default", "detect-7.1.0:1.0.1")) {
-            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Detect-7.1.0.dockerfile"));
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("detect-on-detect-riskreport-default", "detect-9.8.0:1.0.0")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Detect-9.8.0.dockerfile"));
 
             BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
             BlackDuckAssertions blackDuckAssertions = blackDuckTestConnection.projectVersionAssertions("detect-junit", "risk-report-default");

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/util/DockerAssertions.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/util/DockerAssertions.java
@@ -294,6 +294,14 @@ public class DockerAssertions {
         }
     }
 
+    public void resultNotPresentAtLocation(String location) {
+        try {
+            Assertions.assertFalse(locateStatusJson().results.stream().anyMatch(result -> result.location.equals(location)), "Found file at: " + location);
+        } catch (Throwable t) {
+            wrapAndThrowWithDetectLogs(t);
+        }
+    }
+
     private void checkBdioDirectory() {
         try {
             Assertions.assertNotNull(bdioDirectory, "Bdio directory did not exist!");

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
@@ -20,7 +20,7 @@ import com.blackduck.integration.detect.battery.docker.integration.BlackDuckTest
 import com.blackduck.integration.detect.workflow.blackduck.report.service.ReportService;
 import com.blackduck.integration.exception.IntegrationException;
 
-//@Tag("integration")
+@Tag("integration")
 public class RiskReportServiceTestIT {
     public static final String PROJECT_NAME = "detect risk report test";
     public static final String PROJECT_VERSION_NAME = "1.0.0";

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/report/RiskReportServiceTestIT.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detect.workflow.blackduck.report;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Assertions;
@@ -19,7 +20,7 @@ import com.blackduck.integration.detect.battery.docker.integration.BlackDuckTest
 import com.blackduck.integration.detect.workflow.blackduck.report.service.ReportService;
 import com.blackduck.integration.exception.IntegrationException;
 
-@Tag("integration")
+//@Tag("integration")
 public class RiskReportServiceTestIT {
     public static final String PROJECT_NAME = "detect risk report test";
     public static final String PROJECT_VERSION_NAME = "1.0.0";
@@ -50,6 +51,20 @@ public class RiskReportServiceTestIT {
         File pdfFile = reportService.createReportPdfFile(folder, projectVersionWrapper.getProjectView(), projectVersionWrapper.getProjectVersionView());
         Assertions.assertNotNull(pdfFile);
         Assertions.assertTrue(pdfFile.exists());
+    }
+
+    @Test
+    @ExtendWith(TempDirectory.class)
+    public void createReportJsonFileTest(@TempDirectory.TempDir Path folderForReport) throws IntegrationException, IOException {
+        BlackDuckTestConnection blackDuckTestConnection = BlackDuckTestConnection.fromEnvironment();
+        ReportService reportService = blackDuckTestConnection.createReportService();
+
+        ProjectVersionWrapper projectVersionWrapper = blackDuckTestConnection.projectVersionAssertions(PROJECT_NAME, PROJECT_VERSION_NAME).getProjectVersionWrapper();
+
+        File folder = folderForReport.toFile();
+        File jsonFile = reportService.createReportJsonFile(folder, projectVersionWrapper.getProjectView(), projectVersionWrapper.getProjectVersionView());
+        Assertions.assertNotNull(jsonFile);
+        Assertions.assertTrue(jsonFile.exists());
     }
 
     @Test


### PR DESCRIPTION
This PR handles IDETECT-2301 to support enhancement request for providing Risk Report in JSON format in addition with PDF. There are new properties `detect.risk.report.json` and `detect.risk.report.json.path` to support it. Also added some test cases for the same.
