### PR TITLE
Support optional npm dependencies

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/NpmDependencyType.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/NpmDependencyType.java
@@ -2,5 +2,6 @@ package com.blackduck.integration.detectable.detectables.npm;
 
 public enum NpmDependencyType {
     DEV,
-    PEER
+    PEER,
+    OPTIONAL
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -86,7 +86,7 @@ public class NpmCliParser {
             .filter(elementEntry -> elementEntry.getValue().isJsonObject())
             .filter(elementEntry -> {
                 if (!isRootDependency) {
-                    // Transitives can be both application and dev/peer dependency graphs, but Detect shouldn't be walking a dev or peer dependency tree unless it passed the filter already.
+                    // Transitives can be both application and dev/peer/optional dependency graphs, but Detect shouldn't be walking a dev, peer, or optional dependency tree unless it passed the filter already.
                     return true;
                 }
                 boolean excludingBecauseDev = (npmDependencyTypeFilter.shouldExclude(NpmDependencyType.DEV, combinedPackageJson.getDevDependencies()) && combinedPackageJson.getDevDependencies().containsKey(
@@ -96,7 +96,6 @@ public class NpmCliParser {
                 boolean excludingBecauseOptional = (npmDependencyTypeFilter.shouldExclude(NpmDependencyType.OPTIONAL, combinedPackageJson.getOptionalDependencies())
                     && combinedPackageJson.getOptionalDependencies().containsKey(elementEntry.getKey()));
                 return !excludingBecauseDev && !excludingBecausePeer && !excludingBecauseOptional;
-                // TODO need changes here for optional
             })
             .forEach(elementEntry -> processChild(elementEntry, graph, parentDependency, isRootDependency, combinedPackageJson));
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -9,10 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
 import com.blackduck.integration.bdio.graph.BasicDependencyGraph;
 import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.bdio.model.Forge;
@@ -24,7 +20,10 @@ import com.blackduck.integration.detectable.detectable.util.EnumListFilter;
 import com.blackduck.integration.detectable.detectables.npm.NpmDependencyType;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.result.NpmPackagerResult;
 import com.blackduck.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
-import com.blackduck.integration.detectable.detectables.npm.packagejson.model.PackageJson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 public class NpmCliParser {
     private final Logger logger = LoggerFactory.getLogger(NpmCliParser.class);
@@ -94,7 +93,9 @@ public class NpmCliParser {
                     elementEntry.getKey()));
                 boolean excludingBecausePeer = (npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER, combinedPackageJson.getPeerDependencies())
                     && combinedPackageJson.getPeerDependencies().containsKey(elementEntry.getKey()));
-                return !excludingBecauseDev && !excludingBecausePeer;
+                boolean excludingBecauseOptional = (npmDependencyTypeFilter.shouldExclude(NpmDependencyType.OPTIONAL, combinedPackageJson.getOptionalDependencies())
+                    && combinedPackageJson.getOptionalDependencies().containsKey(elementEntry.getKey()));
+                return !excludingBecauseDev && !excludingBecausePeer && !excludingBecauseOptional;
                 // TODO need changes here for optional
             })
             .forEach(elementEntry -> processChild(elementEntry, graph, parentDependency, isRootDependency, combinedPackageJson));

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -95,6 +95,7 @@ public class NpmCliParser {
                 boolean excludingBecausePeer = (npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER, combinedPackageJson.getPeerDependencies())
                     && combinedPackageJson.getPeerDependencies().containsKey(elementEntry.getKey()));
                 return !excludingBecauseDev && !excludingBecausePeer;
+                // TODO need changes here for optional
             })
             .forEach(elementEntry -> processChild(elementEntry, graph, parentDependency, isRootDependency, combinedPackageJson));
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -121,9 +121,9 @@ public class NpmDependencyConverter {
     private NpmDependency createNpmDependency(String name, String version, Boolean isDev, Boolean isPeer, Boolean isOptional) {
         boolean dev = isDev != null && isDev;
         boolean peer = isPeer != null && isPeer;
-        // TODO code needed here for optional
+        boolean optional = isOptional != null && isOptional;
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, name, version);
-        return new NpmDependency(name, version, externalId, dev, peer, isOptional);
+        return new NpmDependency(name, version, externalId, dev, peer, optional);
     }
 
     public List<NpmRequires> convertNameVersionMapToRequires(MultiValuedMap<String, String> requires) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -31,6 +31,7 @@ public class NpmDependencyConverter {
     public NpmProject convertLockFile(PackageLock packageLock, @Nullable CombinedPackageJson combinedPackageJson) {
         List<NpmRequires> declaredDevDependencies = new ArrayList<>();
         List<NpmRequires> declaredPeerDependencies = new ArrayList<>();
+        List<NpmRequires> declaredOptionalDependencies = new ArrayList<>();
         List<NpmRequires> declaredDependencies = new ArrayList<>();
         List<NpmDependency> resolvedDependencies = new ArrayList<>();
 
@@ -57,9 +58,14 @@ public class NpmDependencyConverter {
                 List<NpmRequires> rootPeerRequires = convertNameVersionMapToRequires(combinedPackageJson.getPeerDependencies());
                 declaredPeerDependencies.addAll(rootPeerRequires);
             }
+            
+            if (!combinedPackageJson.getOptionalDependencies().isEmpty()) {
+                List<NpmRequires> rootOptionalRequires = convertNameVersionMapToRequires(combinedPackageJson.getOptionalDependencies());
+                declaredOptionalDependencies.addAll(rootOptionalRequires);
+            }
         }
 
-        return new NpmProject(packageLock.name, packageLock.version, declaredDevDependencies, declaredPeerDependencies, declaredDependencies, resolvedDependencies);
+        return new NpmProject(packageLock.name, packageLock.version, declaredDevDependencies, declaredPeerDependencies, declaredDependencies, declaredOptionalDependencies, resolvedDependencies);
     }
 
     public List<NpmDependency> convertLockPackagesToNpmDependencies(NpmDependency parent, Map<String, PackageLockPackage> packages) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -79,7 +79,8 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockPackage packageLockDependency = packageEntry.getValue();
 
-            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer);
+            // TODO confirm works
+            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);
 
@@ -103,7 +104,8 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockDependency packageLockDependency = packageEntry.getValue();
 
-            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer);
+            // TODO confirm works
+            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);
 
@@ -116,9 +118,10 @@ public class NpmDependencyConverter {
         return children;
     }
 
-    private NpmDependency createNpmDependency(String name, String version, Boolean isDev, Boolean isPeer) {
+    private NpmDependency createNpmDependency(String name, String version, Boolean isDev, Boolean isPeer, Boolean isOptional) {
         boolean dev = isDev != null && isDev;
         boolean peer = isPeer != null && isPeer;
+        // TODO code needed here for optional
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, name, version);
         return new NpmDependency(name, version, externalId, dev, peer);
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -79,7 +79,6 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockPackage packageLockDependency = packageEntry.getValue();
 
-            // TODO confirm works
             NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);
@@ -104,7 +103,6 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockDependency packageLockDependency = packageEntry.getValue();
 
-            // TODO confirm works
             NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -123,7 +123,7 @@ public class NpmDependencyConverter {
         boolean peer = isPeer != null && isPeer;
         // TODO code needed here for optional
         ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, name, version);
-        return new NpmDependency(name, version, externalId, dev, peer);
+        return new NpmDependency(name, version, externalId, dev, peer, isOptional);
     }
 
     public List<NpmRequires> convertNameVersionMapToRequires(MultiValuedMap<String, String> requires) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/NpmDependency.java
@@ -13,17 +13,20 @@ import com.blackduck.integration.detectable.util.ExternalIdCreator;
 public class NpmDependency extends Dependency {
     private final boolean devDependency;
     private final boolean peerDependency;
-
-    public NpmDependency(String name, String version, ExternalId externalId, boolean devDependency, boolean peerDependency) {
+    private final boolean optionalDependency;
+    
+    public NpmDependency(String name, String version, ExternalId externalId, boolean devDependency, boolean peerDependency, boolean optionalDependency) {
         super(name, version, externalId);
         this.devDependency = devDependency;
         this.peerDependency = peerDependency;
+        this.optionalDependency = optionalDependency;
     }
 
-    public NpmDependency(String name, String version, boolean devDependency, boolean peerDependency) {
+    public NpmDependency(String name, String version, boolean devDependency, boolean peerDependency, boolean optionalDependency) {
         super(name, version, ExternalIdCreator.nameVersion(Forge.NPMJS, name, version));
         this.devDependency = devDependency;
         this.peerDependency = peerDependency;
+        this.optionalDependency = optionalDependency;
     }
 
     private NpmDependency parent;
@@ -60,5 +63,9 @@ public class NpmDependency extends Dependency {
 
     public boolean isPeerDependency() {
         return peerDependency;
+    }
+    
+    public boolean isOptionalDependency() {
+        return optionalDependency;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/NpmProject.java
@@ -8,6 +8,7 @@ public class NpmProject { //TODO: I hate that this is a 'model' and it is mutabl
 
     private final List<NpmRequires> declaredDevDependencies;
     private final List<NpmRequires> declaredPeerDependencies;
+    private final List<NpmRequires> declaredOptionalDependencies;
     private final List<NpmRequires> declaredDependencies;
     private final List<NpmDependency> resolvedDependencies;
 
@@ -17,12 +18,14 @@ public class NpmProject { //TODO: I hate that this is a 'model' and it is mutabl
         List<NpmRequires> declaredDevDependencies,
         List<NpmRequires> declaredPeerDependencies,
         List<NpmRequires> declaredDependencies,
+        List<NpmRequires> declaredOptionalDependencies, 
         List<NpmDependency> resolvedDependencies
     ) {
         this.name = name;
         this.version = version;
         this.declaredDevDependencies = declaredDevDependencies;
         this.declaredPeerDependencies = declaredPeerDependencies;
+        this.declaredOptionalDependencies = declaredOptionalDependencies;
         this.declaredDependencies = declaredDependencies;
         this.resolvedDependencies = resolvedDependencies;
     }
@@ -45,6 +48,10 @@ public class NpmProject { //TODO: I hate that this is a 'model' and it is mutabl
 
     public List<NpmRequires> getDeclaredPeerDependencies() {
         return declaredPeerDependencies;
+    }
+    
+    public List<NpmRequires> getDeclaredOptionalDependencies() {
+        return declaredOptionalDependencies;
     }
 
     public List<NpmDependency> getResolvedDependencies() {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockDependency.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockDependency.java
@@ -13,6 +13,9 @@ public class PackageLockDependency {
 
     @SerializedName("peer")
     public Boolean peer;
+    
+    @SerializedName("optional")
+    public Boolean optional;
 
     @SerializedName("requires")
     public Map<String, String> requires;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/model/PackageLockPackage.java
@@ -35,6 +35,8 @@ public class PackageLockPackage {
     public Boolean dev;
 
     public Boolean peer;
+    
+    public Boolean optional;
 
     public Boolean extraneous;
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -177,6 +177,7 @@ public class NpmLockfileGraphTransformer {
         // TODO change here
         return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency()) // If the type is not dev or peer, we always want to include it.
             || (packageLockDependency.isDevDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV))
-            || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER));
+            || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER))
+            || (packageLockDependency.isOptionalDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.OPTIONAL));
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -50,6 +50,9 @@ public class NpmLockfileGraphTransformer {
                 if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER)) {
                     addRootDependencies(project.getResolvedDependencies(), project.getDeclaredPeerDependencies(), dependencyGraph, externalDependencies);
                 }
+                if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.OPTIONAL)) {
+                    addRootDependencies(project.getResolvedDependencies(), project.getDeclaredOptionalDependencies(), dependencyGraph, externalDependencies);
+                }
             } else {
                 project.getResolvedDependencies()
                     .stream()
@@ -125,6 +128,7 @@ public class NpmLockfileGraphTransformer {
             NpmDependency workspaceDependency = (NpmDependency) lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
             
             if (workspaceDependency != null) {
+                // TODO change here
                 if ((workspaceDependency.isDevDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.DEV))
                         || (workspaceDependency.isPeerDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER))) {
                     continue;
@@ -169,6 +173,7 @@ public class NpmLockfileGraphTransformer {
     }
 
     private boolean shouldIncludeDependency(NpmDependency packageLockDependency) {
+        // TODO change here
         return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency()) // If the type is not dev or peer, we always want to include it.
             || (packageLockDependency.isDevDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV))
             || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER));

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -128,7 +128,6 @@ public class NpmLockfileGraphTransformer {
             NpmDependency workspaceDependency = (NpmDependency) lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
             
             if (workspaceDependency != null) {
-                // TODO change here
                 if ((workspaceDependency.isDevDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.DEV))
                         || (workspaceDependency.isPeerDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER))
                         || (workspaceDependency.isOptionalDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.OPTIONAL))) {
@@ -174,7 +173,6 @@ public class NpmLockfileGraphTransformer {
     }
 
     private boolean shouldIncludeDependency(NpmDependency packageLockDependency) {
-        // TODO change here
         return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency() && !packageLockDependency.isOptionalDependency()) // If the type is not dev or peer, we always want to include it.
             || (packageLockDependency.isDevDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV))
             || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER))

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -175,7 +175,7 @@ public class NpmLockfileGraphTransformer {
 
     private boolean shouldIncludeDependency(NpmDependency packageLockDependency) {
         // TODO change here
-        return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency()) // If the type is not dev or peer, we always want to include it.
+        return (!packageLockDependency.isDevDependency() && !packageLockDependency.isPeerDependency() && !packageLockDependency.isOptionalDependency()) // If the type is not dev or peer, we always want to include it.
             || (packageLockDependency.isDevDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV))
             || (packageLockDependency.isPeerDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER))
             || (packageLockDependency.isOptionalDependency() && npmDependencyTypeFilter.shouldInclude(NpmDependencyType.OPTIONAL));

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -130,7 +130,8 @@ public class NpmLockfileGraphTransformer {
             if (workspaceDependency != null) {
                 // TODO change here
                 if ((workspaceDependency.isDevDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.DEV))
-                        || (workspaceDependency.isPeerDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER))) {
+                        || (workspaceDependency.isPeerDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.PEER))
+                        || (workspaceDependency.isOptionalDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.OPTIONAL))) {
                     continue;
                 }
                 dependencyGraph.addChildrenToRoot(workspaceDependency);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/CombinedPackageJson.java
@@ -15,11 +15,13 @@ public class CombinedPackageJson {
     private MultiValuedMap<String, String> dependencies;
     private MultiValuedMap<String, String> devDependencies;
     private MultiValuedMap<String, String> peerDependencies;
+    private MultiValuedMap<String, String> optionalDependencies;
     
     public CombinedPackageJson() {
         dependencies = new HashSetValuedHashMap<>();
         devDependencies = new HashSetValuedHashMap<>();
         peerDependencies = new HashSetValuedHashMap<>();
+        optionalDependencies = new HashSetValuedHashMap<>();
     }
 
     public MultiValuedMap<String, String> getDependencies() {
@@ -32,6 +34,10 @@ public class CombinedPackageJson {
 
     public MultiValuedMap<String, String> getPeerDependencies() {
         return peerDependencies;
+    }
+    
+    public MultiValuedMap<String, String> getOptionalDependencies() {
+        return optionalDependencies;
     }
     
     public List<String> getRelativeWorkspaces() {        

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/CombinedPackageJsonExtractor.java
@@ -50,6 +50,7 @@ public class CombinedPackageJsonExtractor {
         combinedPackageJson.getDependencies().putAll(packageJson.dependencies);
         combinedPackageJson.getDevDependencies().putAll(packageJson.devDependencies);
         combinedPackageJson.getPeerDependencies().putAll(packageJson.peerDependencies);
+        combinedPackageJson.getOptionalDependencies().putAll(packageJson.optionalDependencies);
         
         if (packageJson.workspaces != null && rootJsonPath != null) {
             // If there are workspaces there are additional package.json's we need to parse
@@ -81,6 +82,7 @@ public class CombinedPackageJsonExtractor {
                     combinedPackageJson.getDependencies().putAll(workspacePackageJson.dependencies);
                     combinedPackageJson.getDevDependencies().putAll(workspacePackageJson.devDependencies);
                     combinedPackageJson.getPeerDependencies().putAll(workspacePackageJson.peerDependencies);
+                    combinedPackageJson.getOptionalDependencies().putAll(workspacePackageJson.optionalDependencies);
                 }
             }
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/PackageJsonExtractor.java
@@ -54,7 +54,8 @@ public class PackageJsonExtractor {
         List<Dependency> dependencies = transformDependencies(combinedPackageJson.getDependencies());
         npmDependencyTypeFilter.ifShouldInclude(NpmDependencyType.DEV, transformDependencies(combinedPackageJson.getDevDependencies()), dependencies::addAll);
         npmDependencyTypeFilter.ifShouldInclude(NpmDependencyType.PEER, transformDependencies(combinedPackageJson.getPeerDependencies()), dependencies::addAll);
-
+        npmDependencyTypeFilter.ifShouldInclude(NpmDependencyType.OPTIONAL, transformDependencies(combinedPackageJson.getOptionalDependencies()), dependencies::addAll);
+        
         DependencyGraph dependencyGraph = new BasicDependencyGraph();
         dependencyGraph.addChildrenToRoot(dependencies);
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/model/PackageJson.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/packagejson/model/PackageJson.java
@@ -23,6 +23,9 @@ public class PackageJson {
     @SerializedName("peerDependencies")
     public Map<String, String> peerDependencies = new HashMap<>();
     
+    @SerializedName("optionalDependencies")
+    public Map<String, String> optionalDependencies = new HashMap<>();
+    
     @SerializedName("workspaces")
     public List<String> workspaces = new ArrayList<>();
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
@@ -4,13 +4,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.gson.Gson;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLockPackage;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.parse.NpmLockfilePackager;
 import com.blackduck.integration.detectable.util.FunctionalTestFiles;
+import com.google.gson.Gson;
 
 public class NpmDependencyConverterTest {
     
@@ -72,6 +72,7 @@ public class NpmDependencyConverterTest {
         Assertions.assertTrue(testPackage.dependencies.containsKey("dep1"));
         Assertions.assertTrue(testPackage.dependencies.containsKey("dev1"));
         Assertions.assertTrue(testPackage.dependencies.containsKey("peer1"));
+        Assertions.assertTrue(testPackage.dependencies.containsKey("optional1"));
     }
     
     private void validatePackageLinkage(String lockFileText) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
@@ -92,6 +92,7 @@ public class NpmLockfileGraphTransformerTest {
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),
+            Collections.emptyList(),
             resolvedDependencies
         );
         

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
@@ -73,9 +73,9 @@ public class NpmLockfileGraphTransformerTest {
         // as normally the requires would be in one area of the structure and the dependencies
         // in another but this is a unit test and we are only concerned about workspace dependencies becoming
         // direct dependencies in the final graph.
-        NpmDependency workspaceDependency = new NpmDependency("packages/a", "1.0.0", false, false);
-        NpmDependency simpleDependency1 = new NpmDependency("abbrev", "^2.0.0", false, false);
-        NpmDependency simpleDependency2 = new NpmDependency("send", "0.17.2", false, false);
+        NpmDependency workspaceDependency = new NpmDependency("packages/a", "1.0.0", false, false, false);
+        NpmDependency simpleDependency1 = new NpmDependency("abbrev", "^2.0.0", false, false, false);
+        NpmDependency simpleDependency2 = new NpmDependency("send", "0.17.2", false, false, false);
         NpmRequires workspaceRequires1 = new NpmRequires("abbrev", "^2.0.0");
         NpmRequires workspaceRequires2 = new NpmRequires("send", "0.17.2");
         requires.add(workspaceRequires1);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
@@ -36,7 +36,7 @@ public class NpmWithoutRequiresExcludesTest {
         );
 
         NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(
-            EnumListFilter.fromExcluded(NpmDependencyType.DEV, NpmDependencyType.PEER)
+            EnumListFilter.fromExcluded(NpmDependencyType.DEV, NpmDependencyType.PEER, NpmDependencyType.OPTIONAL)
         );
         
         // Test with packages for v2/v3 lockfile

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
@@ -24,7 +24,7 @@ public class NpmWithoutRequiresExcludesTest {
         PackageLock packageLock = new PackageLock();
 
         List<NpmDependency> resolvedDependencies = new ArrayList<>();
-        resolvedDependencies.add(new NpmDependency("example", "1.0.0", true, true));
+        resolvedDependencies.add(new NpmDependency("example", "1.0.0", true, true, true));
         NpmProject npmProject = new NpmProject(
             StringUtils.EMPTY,
             StringUtils.EMPTY,

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
@@ -31,6 +31,7 @@ public class NpmWithoutRequiresExcludesTest {
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),
+            Collections.emptyList(),
             resolvedDependencies
         );
 

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
@@ -54,4 +54,47 @@ public class NpmWithoutRequiresExcludesTest {
         graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(0);
     }
+    
+    @Test
+    public void testOptionalDependencyExcluded() {
+        PackageLock packageLock = new PackageLock();
+
+        List<NpmDependency> resolvedDependencies = new ArrayList<>();
+        resolvedDependencies.add(new NpmDependency("example", "1.0.0", false, false, true));
+        NpmProject npmProject = new NpmProject(
+            StringUtils.EMPTY,
+            StringUtils.EMPTY,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            resolvedDependencies
+        );
+
+        NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(
+            EnumListFilter.fromExcluded(NpmDependencyType.OPTIONAL)
+        );
+        
+        // Test with packages for v2/v3 lockfile
+        packageLock.packages = new HashMap<>();
+        
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
+
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
+        graphAssert.hasRootSize(0);
+        
+        // Test with dependencies for v1 lockfile
+        packageLock.dependencies = new HashMap<>();
+        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
+
+        graphAssert = new GraphAssert(Forge.NPMJS, graph);
+        graphAssert.hasRootSize(0);
+        
+        // Clear filtering and check we get a dependency
+        graphTransformer = new NpmLockfileGraphTransformer(EnumListFilter.fromExcluded());
+        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
+        
+        graphAssert = new GraphAssert(Forge.NPMJS, graph);
+        graphAssert.hasRootSize(1);
+    }
 }

--- a/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-multiple-deps.json
+++ b/detectable/src/test/resources/detectables/functional/npm/packages-linkage-test/package-lock-multiple-deps.json
@@ -16,6 +16,9 @@
       },
       "peerDependencies": {
         "peer1": "1.0.0"
+      },
+      "optionalDependencies": {
+        "optional1": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
This adds support for optional npm dependencies as well as for filtering out optional dependencies using --detect.npm.dependency.types.excluded=OPTIONAL.

This works for all lockfiles and all npm detectors.