### PR TITLE
Fix regression for read only tokens feature error

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -210,10 +210,11 @@ public class IntelligentModeStepRunner {
             PackageManagerStepRunner packageManagerScanStepRunner = new PackageManagerStepRunner(operationRunner);
 
             CommonScanResult commonScanResult = packageManagerScanStepRunner.invokePackageManagerScanningWorkflow(projectNameVersion, blackDuckRunData, bdioResult);
-            String scanId = commonScanResult.getScanId() == null ? null : commonScanResult.getScanId().toString();
-            scanIdsToWaitFor.add(scanId);
-
-            if(!commonScanResult.isPackageManagerScassPossible()) {
+            String scanId = null;
+            if(commonScanResult != null && commonScanResult.isPackageManagerScassPossible()) {
+                scanId = commonScanResult.getScanId() == null ? null : commonScanResult.getScanId().toString();
+                scanIdsToWaitFor.add(scanId);
+            } else {
                 invokePreScassPackageManagerWorkflow(blackDuckRunData, bdioResult, scanIdsToWaitFor, codeLocationAccumulator, scanId);
             }
         } else {


### PR DESCRIPTION
This PR fixes a regression (IDETECT-4761) caused when common Scan result is null when scans are done with read only token. 
