### PR TITLE
Enhance error message for BOM_COMPARE mode failures in rapid scan

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -16,7 +16,7 @@ public enum ExitCodeType {
     ),
     FAILURE_BLACKDUCK_FEATURE_ERROR(
         11,
-        "Detect encountered an error while attempting an operation on Black Duck. Ensure that your Black Duck version is compatible with this version of Detect, and that your Black Duck user account has the required roles."
+        "Detect encountered an error while attempting an operation on Black Duck. Ensure that your Black Duck version is compatible with this version of Detect, and that your Black Duck user account has the required roles, and the project version exists in Black Duck when using BOM_COMPARE mode in a rapid scan."
     ),
     FAILURE_MINIMUM_INTERVAL_NOT_MET(13, "Detect did not wait the minimum required scan interval."),
     FAILURE_IAC(

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/ExitCodeType.java
@@ -16,7 +16,7 @@ public enum ExitCodeType {
     ),
     FAILURE_BLACKDUCK_FEATURE_ERROR(
         11,
-        "Detect encountered an error while attempting an operation on Black Duck. Ensure that your Black Duck version is compatible with this version of Detect, and that your Black Duck user account has the required roles, and the project version exists in Black Duck when using BOM_COMPARE mode in a rapid scan."
+        "Detect encountered an error while trying to perform an operation on Black Duck SCA. Ensure that your Black Duck SCA version is compatible with this version of Detect, your Black Duck user account has the required roles, and the project version exists in Black Duck when using BOM_COMPARE mode in a rapid scan."
     ),
     FAILURE_MINIMUM_INTERVAL_NOT_MET(13, "Detect did not wait the minimum required scan interval."),
     FAILURE_IAC(

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -753,7 +753,7 @@ public class OperationRunner {
 
     private String createBomCompareErrorMessage(String originalMessage) {
         return originalMessage + " BOM_COMPARE mode requires the target project version to exist in Black Duck Hub. " +
-                "Please ensure 'detect.project.version.name' match an existing project version. " +
+                "Please ensure 'detect.project.version.name' matches an existing project version. " +
                 "Consider running a full scan first if the version hasn't been uploaded yet.";
     }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -757,20 +757,6 @@ public class OperationRunner {
                 "Consider running a full scan first if the version hasn't been uploaded yet.";
     }
 
-    public static boolean shouldSkipResolvedPolicies(DeveloperScansScanView resultView, RapidCompareMode rapidCompareMode) {
-        if (resultView.getPolicyStatuses() == null || resultView.getPolicyStatuses().isEmpty()) {
-            return false;
-        }
-        return (RapidCompareMode.BOM_COMPARE.equals(rapidCompareMode) || RapidCompareMode.BOM_COMPARE_STRICT.equals(rapidCompareMode))
-                && resultView.getPolicyStatuses().stream().allMatch(POLICY_STATUS_RESOLVED::equalsIgnoreCase);
-    }
-
-    public static List<DeveloperScansScanView> filterUnresolvedPolicyResults(List<DeveloperScansScanView> scanResults, RapidCompareMode rapidCompareMode) {
-        return scanResults.stream()
-                .filter(resultView -> !shouldSkipResolvedPolicies(resultView, rapidCompareMode))
-                .collect(Collectors.toList());
-    }
-
     public final RapidScanResultSummary logRapidReport(List<DeveloperScansScanView> scanResults, BlackduckScanMode mode) throws OperationException {
         List<PolicyRuleSeverityType> severitiesToFailPolicyCheck = detectConfigurationFactory.createRapidScanOptions().getSeveritiesToFailPolicyCheck();
         return auditLog.namedInternal("Print Rapid Mode Results", () -> 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -71,7 +71,6 @@ import com.blackduck.integration.common.util.finder.FileFinder;
 import com.blackduck.integration.componentlocator.beans.Component;
 import com.blackduck.integration.detect.configuration.DetectConfigurationFactory;
 import com.blackduck.integration.detect.configuration.DetectInfo;
-import com.blackduck.integration.detect.configuration.DetectProperties;
 import com.blackduck.integration.detect.configuration.DetectUserFriendlyException;
 import com.blackduck.integration.detect.configuration.DetectorToolOptions;
 import com.blackduck.integration.detect.configuration.connection.ConnectionFactory;
@@ -92,7 +91,6 @@ import com.blackduck.integration.detect.lifecycle.run.singleton.UtilitySingleton
 import com.blackduck.integration.detect.lifecycle.run.step.utility.OperationAuditLog;
 import com.blackduck.integration.detect.lifecycle.run.step.utility.OperationWrapper;
 import com.blackduck.integration.detect.lifecycle.shutdown.ExitCodePublisher;
-import com.blackduck.integration.detect.lifecycle.shutdown.ExitCodeRequest;
 import com.blackduck.integration.detect.tool.DetectableTool;
 import com.blackduck.integration.detect.tool.DetectableToolResult;
 import com.blackduck.integration.detect.tool.binaryscanner.BinaryScanFindMultipleTargetsOperation;
@@ -185,7 +183,6 @@ import com.blackduck.integration.detect.workflow.codelocation.DetectCodeLocation
 import com.blackduck.integration.detect.workflow.componentlocationanalysis.BdioToComponentListTransformer;
 import com.blackduck.integration.detect.workflow.componentlocationanalysis.GenerateComponentLocationAnalysisOperation;
 import com.blackduck.integration.detect.workflow.componentlocationanalysis.ScanResultToComponentListTransformer;
-import com.blackduck.integration.detect.workflow.event.Event;
 import com.blackduck.integration.detect.workflow.event.EventSystem;
 import com.blackduck.integration.detect.workflow.file.DirectoryManager;
 import com.blackduck.integration.detect.workflow.phonehome.PhoneHomeManager;


### PR DESCRIPTION
**JIRA Ticket**
IDETECT-4728 

**Issue**
When running rapid scans with `BOM_COMPARE` or `BOM_COMPARE_STRICT` modes, users receive a generic "400 Bad Request" error message without clear guidance on how to resolve the issue. The root cause is typically that the target project version doesn't exist in Black Duck Hub, but this wasn't communicated effectively to users.

**Proposed Fix**
Enhanced error handling in the `waitForRapidResults` method to:
- Intercept when BAD_REQUEST errors occur during BOM_COMPARE operations
- Provide specific guidance to users about project version requirements
- Suggest running a full scan first if the version hasn't been uploaded yet
- Update the `FAILURE_BLACKDUCK_FEATURE_ERROR` exit code to reflect the `BOM_COMPARE` error

**Implementation Details**
- Added specific error handling for `IntegrationRestException` with HTTP 400 status code when `BOM_COMPARE` or `BOM_COMPARE_STRICT` modes are used
- Enhanced error message includes actionable guidance directing users to verify their `detect.project.version.name` matches an existing project version in Black Duck Hub
- Refactored error handling logic into separate methods (`handleRapidScanException`, `isBomCompareError`, `createBomCompareErrorMessage`) for better maintainability and testability

**Before/After Error Message**
_**Before:**_
```
There was a problem trying to `GET {baseHubUrl}/api/developer-scans/{scanId}`, response was 400 Bad Request.
```

_**After:**_
```
There was a problem trying to `GET {baseHubUrl}/api/developer-scans/{scanId}`, response was 400 Bad Request. BOM_COMPARE mode requires the target project version to exist in Black Duck Hub. Please ensure 'detect.project.version.name' match an existing project version. Consider running a full scan first if the version hasn't been uploaded yet.
```

<hr>

**_N.B:_** _This merge request is meant for detect release 10.7_