### PR TITLE
Fix Regressions and update minimum SCASS version for PM scans

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -31,6 +31,8 @@ import com.google.gson.Gson;
  */
 public class CommonScanStepRunner {
     private static final BlackDuckVersion MIN_SCASS_SCAN_VERSION = new BlackDuckVersion(2025, 1, 1);
+
+    private static final BlackDuckVersion MIN_PACKAGE_MANAGER_SCASS_VERSION = new BlackDuckVersion(2025, 7, 0);
     
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
@@ -41,8 +43,12 @@ public class CommonScanStepRunner {
 
     private boolean isPackageManagerScassPossible = true;
 
-    public static boolean areScassScansPossible(Optional<BlackDuckVersion> blackDuckVersion) {
-        return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_SCASS_SCAN_VERSION);
+    public static boolean areScassScansPossible(Optional<BlackDuckVersion> blackDuckVersion, String scanType) {
+        if(scanType.equals(PACKAGE_MANAGER)) {
+            return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_PACKAGE_MANAGER_SCASS_VERSION);
+        } else {
+            return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_SCASS_SCAN_VERSION);
+        }
     }
 
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -31,8 +31,6 @@ import com.google.gson.Gson;
  */
 public class CommonScanStepRunner {
     private static final BlackDuckVersion MIN_SCASS_SCAN_VERSION = new BlackDuckVersion(2025, 1, 1);
-
-    private static final BlackDuckVersion MIN_PACKAGE_MANAGER_SCASS_VERSION = new BlackDuckVersion(2025, 7, 0);
     
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     
@@ -43,12 +41,8 @@ public class CommonScanStepRunner {
 
     private boolean isPackageManagerScassPossible = true;
 
-    public static boolean areScassScansPossible(Optional<BlackDuckVersion> blackDuckVersion, String scanType) {
-        if(scanType.equals(PACKAGE_MANAGER)) {
-            return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_PACKAGE_MANAGER_SCASS_VERSION);
-        } else {
-            return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_SCASS_SCAN_VERSION);
-        }
+    public static boolean areScassScansPossible(Optional<BlackDuckVersion> blackDuckVersion) {
+        return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_SCASS_SCAN_VERSION);
     }
 
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -206,7 +206,7 @@ public class IntelligentModeStepRunner {
     }
 
     private void invokePackageManagerScanningWorkflow(NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData, Set<String> scanIdsToWaitFor, BdioResult bdioResult, CodeLocationAccumulator codeLocationAccumulator) throws OperationException {
-        if (CommonScanStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion(), CommonScanStepRunner.PACKAGE_MANAGER)) {
+        if (PackageManagerStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion())) {
             PackageManagerStepRunner packageManagerScanStepRunner = new PackageManagerStepRunner(operationRunner);
 
             CommonScanResult commonScanResult = packageManagerScanStepRunner.invokePackageManagerScanningWorkflow(projectNameVersion, blackDuckRunData, bdioResult);
@@ -246,7 +246,7 @@ public class IntelligentModeStepRunner {
         throws IntegrationException, OperationException {
         logger.debug("Invoking intelligent persistent binary scan.");
         
-        AbstractBinaryScanStepRunner binaryScanStepRunner = CommonScanStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion(), CommonScanStepRunner.BINARY) ?
+        AbstractBinaryScanStepRunner binaryScanStepRunner = CommonScanStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion()) ?
             new ScassOrBdbaBinaryScanStepRunner(operationRunner) :
             new PreScassBinaryScanStepRunner(operationRunner);
 
@@ -274,7 +274,7 @@ public class IntelligentModeStepRunner {
         logger.debug("Invoking intelligent persistent container scan.");
 
         AbstractContainerScanStepRunner containerScanStepRunner;
-        if (CommonScanStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion(), CommonScanStepRunner.CONTAINER)) {
+        if (CommonScanStepRunner.areScassScansPossible(blackDuckRunData.getBlackDuckServerVersion())) {
             containerScanStepRunner = new ScassOrBdbaContainerScanStepRunner(operationRunner, projectNameVersion, blackDuckRunData, gson);
         } else {
             containerScanStepRunner = new PreScassContainerScanStepRunner(operationRunner, projectNameVersion, blackDuckRunData, gson);

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/packagemanager/PackageManagerStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/packagemanager/PackageManagerStepRunner.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import com.blackduck.integration.blackduck.bdio2.model.BdioFileContent;
 import com.blackduck.integration.blackduck.exception.BlackDuckIntegrationException;
+import com.blackduck.integration.blackduck.version.BlackDuckVersion;
 import com.blackduck.integration.detect.lifecycle.OperationException;
 import com.blackduck.integration.detect.lifecycle.run.data.BlackDuckRunData;
 import com.blackduck.integration.detect.lifecycle.run.data.CommonScanResult;
@@ -27,10 +28,16 @@ public class PackageManagerStepRunner {
     private final Gson gson;
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    private static final BlackDuckVersion MIN_SCASS_SCAN_VERSION = new BlackDuckVersion(2025, 7, 0);
+
     public PackageManagerStepRunner(OperationRunner operationRunner) {
         this.operationRunner = operationRunner;
         commonScanStepRunner = new CommonScanStepRunner();
         this.gson = new Gson();
+    }
+
+    public static boolean areScassScansPossible(Optional<BlackDuckVersion> blackDuckVersion) {
+        return blackDuckVersion.isPresent() && blackDuckVersion.get().isAtLeast(MIN_SCASS_SCAN_VERSION);
     }
 
     public CommonScanResult invokePackageManagerScanningWorkflow(NameVersion projectNameVersion, BlackDuckRunData blackDuckRunData, BdioResult bdioResult) {

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/packagemanager/PackageManagerStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/packagemanager/PackageManagerStepRunner.java
@@ -51,7 +51,6 @@ public class PackageManagerStepRunner {
 
         } catch (OperationException | IntegrationException e) {
             logger.error("Error completing the package manager scan. {}", e.getMessage());
-            operationRunner.publishDetectorFailure();
             return null;
         }
 


### PR DESCRIPTION
This PR fixes the regressions, IDETECT-4761 and IDETECT-4767. It also updates the minimum version which is required for SCASS scans to 2025.7.0 as discussed. Also, removed the exit code from SCASS upload for package manager scans which was overwriting the exit code when old non-SCASS workflow was tried.