### PR TITLE
Limit Cargo Dependency Exclusion to DEV and BUILD

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/cargo/CargoCliExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/cargo/CargoCliExtractor.java
@@ -38,6 +38,8 @@ public class CargoCliExtractor {
     public Extraction extract(File directory, ExecutableTarget cargoExe, File cargoTomlFile, CargoDetectableOptions cargoDetectableOptions) throws ExecutableFailedException, IOException {
         List<String> cargoTreeCommand = new ArrayList<>(CARGO_TREE_COMMAND);
 
+        // Adding the --edges exclusion option based on the CargoDetectableOptions to the cargo tree command
+        // This excludes build, dev or both type of dependencies if specified
         addEdgeExclusions(cargoTreeCommand, cargoDetectableOptions);
 
         ExecutableOutput cargoOutput = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(directory, cargoExe, cargoTreeCommand));
@@ -61,10 +63,8 @@ public class CargoCliExtractor {
 
     private void addEdgeExclusions(List<String> cargoTreeCommand, CargoDetectableOptions options) {
         Map<CargoDependencyType, String> exclusionMap = new EnumMap<>(CargoDependencyType.class);
-        exclusionMap.put(CargoDependencyType.NORMAL, "no-normal");
         exclusionMap.put(CargoDependencyType.BUILD, "no-build");
         exclusionMap.put(CargoDependencyType.DEV, "no-dev");
-        exclusionMap.put(CargoDependencyType.PROC_MACRO, "no-proc-macro");
 
         List<String> exclusions = new ArrayList<>();
         for (Map.Entry<CargoDependencyType, String> entry : exclusionMap.entrySet()) {

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -32,6 +32,8 @@
 
 * Support for SBT is now extended to 1.11.3.
 
+* A new property, `detect.cargo.dependency.types.excluded` has been added to allow exclusion of specific Cargo dependency types (`DEV`, `BUILD`) from scans. By default, all dependency types are included (`NONE`). This provides finer control over the dependencies reported in the BOM.
+
 ### Changed features
 
 * To improve processing time when both PNPM and NPM detectors apply to a directory, only PNPM detector will execute, producing the same quality of results.


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4326

**Description**

This merge request aims to limit cargo dependency type exclusion to cargo `DEV` and `BUILD` dependency types,
With team's consensus it was decided that the exclusion of other types of dependencies such as `NORMAL` would be addressed in a separate ticket. 
So, the added new property `detect.cargo.dependency.types.excluded` would work for `DEV`, `BUILD` or a combination of both.

---

_**N.B:** This is meant to be shipped to the detect release 10.6_