### PR TITLE
Fix for some dev and optional dependencies not getting filtered out when they should be

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -111,9 +111,11 @@ public class NpmLockfileGraphTransformer {
                 NpmDependency resolved = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
                 if (resolved == null) {
                     logger.debug("No resolved dependency found for required package: {}", required.getName());
-                } else if (shouldIncludeDependency(resolved)) {
+                } else {
                     logger.trace(String.format("Found package: %s with version: %s", resolved.getName(), resolved.getVersion()));
-                    dependencyGraph.addChildWithParent(resolved, npmDependency);
+                    if (shouldIncludeDependency(resolved)) {
+                        dependencyGraph.addChildWithParent(resolved, npmDependency);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Fix for some optional dependencies not getting filtered out when they should be.

Example structure in which this could happen when say OPTIONAL was set to be excluded:

```
project
  dependencyA
    optionalDependencyB
        optionalDependencyC
          optionalDependencyD
```

In such a case dependencies C and D would get filtered out but dependency B would erroneously be included in the result.