### PR TITLE
Do not wait on NOT_INCLUDED status and log a warning

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1651,10 +1651,11 @@ public class OperationRunner {
         });
     }
 
-    private void checkBomStatusAndHandleFailure(BomStatusScanView bomStatusScanView) {
-        if (bomStatusScanView.getStatus() == BomStatusScanStatusType.FAILURE) {
+    void checkBomStatusAndHandleFailure(BomStatusScanView bomStatusScanView) {
+        BomStatusScanStatusType status = bomStatusScanView.getStatus();
+        if (status != BomStatusScanStatusType.SUCCESS) {
             String message = "Black Duck failed to prepare BOM for the scan";
-            logger.error("BOM Scan Status: {} - {}.", BomStatusScanStatusType.FAILURE, message);
+            logger.error("BOM Scan Status: {} - {}.", status, message);
             exitCodePublisher.publishExitCode(ExitCodeType.FAILURE_BOM_PREPARATION);
         }
     }

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/DetectBomScanWaitJob.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/DetectBomScanWaitJob.java
@@ -1,6 +1,10 @@
 package com.blackduck.integration.detect.workflow.blackduck;
 
 import com.blackduck.integration.blackduck.api.generated.view.BomStatusScanView;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
 import com.blackduck.integration.blackduck.service.BlackDuckApiClient;
 import com.blackduck.integration.exception.IntegrationException;
@@ -9,6 +13,8 @@ import com.blackduck.integration.rest.HttpUrl;
 import com.blackduck.integration.wait.ResilientJob;
 
 public class DetectBomScanWaitJob implements ResilientJob<BomStatusScanView> {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private final BlackDuckApiClient blackDuckApiClient;
     private final HttpUrl scanUrl;
     private BomStatusScanView scanResponse;
@@ -27,7 +33,11 @@ public class DetectBomScanWaitJob implements ResilientJob<BomStatusScanView> {
         BomStatusScanView initialResponse = 
                 blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class);
         
-        if (initialResponse.getStatus() != BomStatusScanStatusType.BUILDING && initialResponse.getStatus() != BomStatusScanStatusType.NOT_INCLUDED) {
+        BomStatusScanStatusType status = initialResponse.getStatus();
+        if (status != BomStatusScanStatusType.BUILDING) {
+            if (status == BomStatusScanStatusType.NOT_INCLUDED) {
+                logger.warn("Encountered unexpected scan status: {}", status);
+            }
             complete = true;
             scanResponse = initialResponse;
         }

--- a/src/test/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
+++ b/src/test/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunnerTest.java
@@ -7,28 +7,37 @@ import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
 import com.blackduck.integration.detect.lifecycle.run.DetectFontLoaderFactory;
-import com.blackduck.integration.detect.lifecycle.run.operation.OperationRunner;
 import com.blackduck.integration.detect.lifecycle.run.singleton.BootSingletons;
 import com.blackduck.integration.detect.lifecycle.run.singleton.EventSingletons;
 import com.blackduck.integration.detect.lifecycle.run.singleton.UtilitySingletons;
 import com.blackduck.integration.detect.tool.detector.factory.DetectDetectableFactory;
 import com.blackduck.integration.exception.IntegrationException;
+import com.blackduck.integration.blackduck.api.generated.view.BomStatusScanView;
+import com.blackduck.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
+import com.blackduck.integration.detect.configuration.enumeration.ExitCodeType;
+import com.blackduck.integration.detect.lifecycle.shutdown.ExitCodePublisher;
 
-public class OperationRunnerTest {
+class OperationRunnerTest {
     private static OperationRunner operationRunner;
+    private static ExitCodePublisher exitCodePublisher;
+    
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
+        exitCodePublisher = Mockito.mock(ExitCodePublisher.class);
+        EventSingletons eventSingletons = Mockito.mock(EventSingletons.class);
+        Mockito.when(eventSingletons.getExitCodePublisher()).thenReturn(exitCodePublisher);
+        
         operationRunner = new OperationRunner(
             Mockito.mock(DetectDetectableFactory.class),
             Mockito.mock(DetectFontLoaderFactory.class),
             Mockito.mock(BootSingletons.class),
             Mockito.mock(UtilitySingletons.class),
-            Mockito.mock(EventSingletons.class)
+            eventSingletons
         );
     }
 
     @Test
-    public void testCalculateMaxWaitInSeconds() throws IntegrationException {
+    void testCalculateMaxWaitInSeconds() throws IntegrationException {
         // Lower bound edge cases
         Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(0));
         Assertions.assertEquals(5, operationRunner.calculateMaxWaitInSeconds(-1));
@@ -47,5 +56,35 @@ public class OperationRunnerTest {
         // Upper bound edge cases
         Assertions.assertEquals(55, operationRunner.calculateMaxWaitInSeconds(11));
         Assertions.assertEquals(55, operationRunner.calculateMaxWaitInSeconds(100));
+    }
+
+    @Test
+    void testCheckBomStatusAndHandleFailure() {
+        // Test that SUCCESS status does not publish exit code
+        BomStatusScanView successView = Mockito.mock(BomStatusScanView.class);
+        Mockito.when(successView.getStatus()).thenReturn(BomStatusScanStatusType.SUCCESS);
+        
+        operationRunner.checkBomStatusAndHandleFailure(successView);
+        
+        Mockito.verify(exitCodePublisher, Mockito.never()).publishExitCode(Mockito.any(ExitCodeType.class));
+        
+        // Test that non-SUCCESS statuses publish failure exit code
+        BomStatusScanView[] failureViews = {
+            createMockBomStatusScanView(BomStatusScanStatusType.BUILDING),
+            createMockBomStatusScanView(BomStatusScanStatusType.FAILURE),
+            createMockBomStatusScanView(BomStatusScanStatusType.NOT_INCLUDED)
+        };
+        
+        for (BomStatusScanView failureView : failureViews) {
+            Mockito.reset(exitCodePublisher);
+            operationRunner.checkBomStatusAndHandleFailure(failureView);
+            Mockito.verify(exitCodePublisher, Mockito.times(1)).publishExitCode(ExitCodeType.FAILURE_BOM_PREPARATION);
+        }
+    }
+    
+    private BomStatusScanView createMockBomStatusScanView(BomStatusScanStatusType status) {
+        BomStatusScanView view = Mockito.mock(BomStatusScanView.class);
+        Mockito.when(view.getStatus()).thenReturn(status);
+        return view;
     }
 }

--- a/src/test/java/com/blackduck/integration/detect/workflow/blackduck/DetectBomScanWaitJobTest.java
+++ b/src/test/java/com/blackduck/integration/detect/workflow/blackduck/DetectBomScanWaitJobTest.java
@@ -1,0 +1,152 @@
+package com.blackduck.integration.detect.workflow.blackduck;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import com.blackduck.integration.blackduck.api.generated.enumeration.BomStatusScanStatusType;
+import com.blackduck.integration.blackduck.api.generated.view.BomStatusScanView;
+import com.blackduck.integration.blackduck.service.BlackDuckApiClient;
+import com.blackduck.integration.exception.IntegrationException;
+import com.blackduck.integration.exception.IntegrationTimeoutException;
+import com.blackduck.integration.rest.HttpUrl;
+
+import java.lang.reflect.Field;
+
+class DetectBomScanWaitJobTest {
+
+    @Test
+    void testAttemptJobWithBuildingStatus() throws Exception {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        BomStatusScanView mockResponse = mock(BomStatusScanView.class);
+        
+        when(blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class)).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(BomStatusScanStatusType.BUILDING);
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        job.attemptJob();
+        
+        assertFalse(job.wasJobCompleted());
+    }
+
+    @Test
+    void testAttemptJobWithNotIncludedStatusLogsWarning() throws Exception {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        BomStatusScanView mockResponse = mock(BomStatusScanView.class);
+        Logger mockLogger = mock(Logger.class);
+        
+        when(blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class)).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(BomStatusScanStatusType.NOT_INCLUDED);
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        // Replace logger using reflection
+        Field loggerField = DetectBomScanWaitJob.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(job, mockLogger);
+        
+        job.attemptJob();
+        
+        assertTrue(job.wasJobCompleted());
+        verify(mockLogger).warn("Encountered unexpected scan status: {}", BomStatusScanStatusType.NOT_INCLUDED);
+    }
+
+    @Test
+    void testAttemptJobWithFailureStatusNoWarning() throws Exception {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        BomStatusScanView mockResponse = mock(BomStatusScanView.class);
+        Logger mockLogger = mock(Logger.class);
+        
+        when(blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class)).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(BomStatusScanStatusType.FAILURE);
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        // Replace logger using reflection
+        Field loggerField = DetectBomScanWaitJob.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(job, mockLogger);
+        
+        job.attemptJob();
+        
+        assertTrue(job.wasJobCompleted());
+        // Verify no warning was logged for FAILURE status
+        verify(mockLogger, org.mockito.Mockito.never()).warn(org.mockito.Mockito.anyString(), (Object) org.mockito.Mockito.any());
+    }
+
+    @Test
+    void testAttemptJobWithSuccessfulStatusNoWarning() throws Exception {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        BomStatusScanView mockResponse = mock(BomStatusScanView.class);
+        Logger mockLogger = mock(Logger.class);
+        
+        when(blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class)).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(BomStatusScanStatusType.SUCCESS);
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        // Replace logger using reflection
+        Field loggerField = DetectBomScanWaitJob.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(job, mockLogger);
+        
+        job.attemptJob();
+        
+        assertTrue(job.wasJobCompleted());
+        // Verify no warning was logged for SUCCESS status
+        verify(mockLogger, org.mockito.Mockito.never()).warn(org.mockito.Mockito.anyString(), (Object) org.mockito.Mockito.any());
+    }
+
+    @Test
+    void testOnCompletionReturnsScanResponse() throws Exception {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        BomStatusScanView mockResponse = mock(BomStatusScanView.class);
+        
+        when(blackDuckApiClient.getResponse(scanUrl, BomStatusScanView.class)).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(BomStatusScanStatusType.FAILURE);
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        job.attemptJob();
+        
+        assertEquals(mockResponse, job.onCompletion());
+    }
+
+    @Test
+    void testGetNameIncludesScanUrl() throws IntegrationException {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        String name = job.getName();
+        
+        assertTrue(name.contains("BOM Scan Wait Job"));
+        assertTrue(name.contains("https://blackduck.com/scan"));
+    }
+
+    @Test
+    void testOnTimeoutThrowsIntegrationTimeoutException() throws IntegrationException {
+        BlackDuckApiClient blackDuckApiClient = mock(BlackDuckApiClient.class);
+        HttpUrl scanUrl = new HttpUrl("https://blackduck.com/scan");
+        
+        DetectBomScanWaitJob job = new DetectBomScanWaitJob(blackDuckApiClient, scanUrl);
+        
+        IntegrationTimeoutException exception = assertThrows(IntegrationTimeoutException.class, job::onTimeout);
+        
+        assertEquals("Error waiting for scan to be considered for including in BOM. Timeout may have occurred.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
# Description

Do not wait on NOT_INCLUDED status and log a warning.
Under normal conditions NOT_INCLUDED should not be encountered.
The warning will allow us to identify such situations so that we can dig into them further.

Additionally, Detect will report failure in the case of all statuses except SUCCESS.