### PR TITLE
Fix: Gradle Native Inspection Adds Invalid Suffix to Version in BDIO Entry

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -69,7 +69,7 @@ public class GradleReportLineParser {
             } else {
                 String group = gav.get(0);
                 String name = gav.get(1);
-                String version = gav.get(2).split("\\s")[0];
+                String version = StringUtils.substringBefore(gav.get(2), " ");
                 return GradleTreeNode.newGav(level, group, name, version);
             }
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/gradle/inspection/parse/GradleReportLineParser.java
@@ -69,7 +69,7 @@ public class GradleReportLineParser {
             } else {
                 String group = gav.get(0);
                 String name = gav.get(1);
-                String version = gav.get(2);
+                String version = gav.get(2).split("\\s")[0];
                 return GradleTreeNode.newGav(level, group, name, version);
             }
         }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/unit/GradleReportParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/gradle/unit/GradleReportParserTest.java
@@ -73,4 +73,27 @@ compile
         assertEquals(0, gradleReportLineParser.parseLine(("\\--- org.apache.commons:commons-compress:1.13"), Collections.emptyMap()).getLevel());
     }
 
+    @Test
+    void failedSuffixIsStrippedFromVersion() {
+        GradleReportLineParser gradleReportLineParser = new GradleReportLineParser();
+        String line = "+--- org.apache.commons:commons-email:1.2 FAILED";
+        GradleTreeNode node = gradleReportLineParser.parseLine(line, Collections.emptyMap());
+
+        assertTrue(node.getGav().isPresent());
+
+        GradleGav gav = node.getGav().get();
+        assertEquals("org.apache.commons", gav.getGroup());
+        assertEquals("commons-email", gav.getName());
+        assertEquals("1.2", gav.getVersion(), "Expected version to exclude 'FAILED'");
+    }
+
+    @Test
+    void missingVersionHandledAsUnknownNode() {
+        GradleReportLineParser parser = new GradleReportLineParser();
+        String line = "+--- org.apache.commons:commons-lang3:";
+        GradleTreeNode node = parser.parseLine(line, Collections.emptyMap());
+
+        assertEquals(GradleTreeNode.NodeType.UNKNOWN, node.getNodeType());
+        assertFalse(node.getGav().isPresent());
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4736


**Description:**
This merge request aims to fix an issue where the Gradle Native Inspector adds a `+FAILED` suffix to the version field in BDIO entries. This was causing incorrect GAV parsing. The version is now split on whitespace to discard any trailing status indicators like `FAILED`, ensuring only the clean semantic version is captured.
