### PR TITLE
Dev/shanty/idetect 4772 fix regression snippet policy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.6.0-SIGQA17-shanty.IDETECT-4772_fix_regression_snippet_policy-SNAPSHOT'
+version = '10.6.0-SIGQA16-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.6.0-SIGQA16-shanty.IDETECT-4772_fix_regression_snippet_policy'
+version = '10.6.0-SIGQA17-shanty.IDETECT-4772_fix_regression_snippet_policy-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.6.0-SIGQA16-SNAPSHOT'
+version = '10.6.0-SIGQA16-shanty.IDETECT-4772_fix_regression_snippet_policy'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/policy/PolicyChecker.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/policy/PolicyChecker.java
@@ -205,7 +205,7 @@ public class PolicyChecker {
          .anyMatch(count -> count > 0);
     }
 
-    // OLD METHOD
+    // Checking policy violations at the component level will miss violations by unconfirmed snippet matches so we check the project version's policy status to decide whether to fail the scan.
     private boolean areFatalPolicySeveritiesViolated(PolicyStatusDescription policyStatusDescription, List<PolicyRuleSeverityType> fatalPolicySeverities) {
         return fatalPolicySeverities.stream()
                 .map(policyStatusDescription::getCountOfSeverity)


### PR DESCRIPTION
Fixes IDETECT-4772 following the fix for IDETECT-3941. Please see comment under 4772 for what the log output looks like after this fix. 

There is a policy users can set which will be violated if there are any unconfirmed snippet matches as a result of their signature scan along with the following properties:

> 
> - detect.blackduck.signature.scanner.snippet.matching=SNIPPET_MATCHING
> - detect.blackduck.signature.scanner.reduced.persistence=RETAIN_UNMATCHED 
> 

This use case was overlooked as part of https://github.com/blackducksoftware/detect/pull/1425 where we determine whether to fail a scan based on if any components in violation of fatal policies were found. If the only violation found happens to be the unconfirmed snippets policy, then the APIs we check at the **_project version level_** will indicate the project has violations. However, at the **component level** it will indicate no violations. This is visually evident in the UI as well when navigating between project version, component and snippet matches pages. There is room to explore optimizing the number of APIs we call during policy checking to gather the data we need + open questions around how more information could be provided to the user when unconfirmed snippet policy is violated specifically, which is lacking today (ticket created: IDETECT-4776 for a different release due to QA capacity).


To reserve existing behaviour, this MR brings back how we used to check whether or not to fail the scan regardless of the improvements made in IDETECT-3941. 