### PR TITLE
Fallback to Old workflow if upload Url is blocked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '10.6.0-SIGQA18-SNAPSHOT'
+version = '10.6.0-SIGQA19-devm.IDETECT-4779-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -105,15 +105,18 @@ public class CommonScanStepRunner {
             }
         }
 
-        return executeFallBack(scanType, operationRunner, blackDuckRunData, scanFile, scanId, projectNameVersion);
+        return executeFallBack(scanType, operationRunner, blackDuckRunData, scanFile, scanId, projectNameVersion, scanCreationResponse);
     }
 
-    private UUID executeFallBack(String scanType, OperationRunner operationRunner, BlackDuckRunData blackDuckRunData, Optional<File> scanFile, UUID scanId, NameVersion projectNameVersion) throws IntegrationException, OperationException {
+    private UUID executeFallBack(String scanType, OperationRunner operationRunner, BlackDuckRunData blackDuckRunData, Optional<File> scanFile, UUID scanId, NameVersion projectNameVersion, ScanCreationResponse scanCreationResponse) throws IntegrationException, OperationException {
         // This is a SCASS capable server but SCASS is not enabled or the GCP URL is inaccessible. If PACKAGE_MANGER scan, we use the same scanId
         if(!scanType.equals(PACKAGE_MANAGER)) {
             BdbaScanStepRunner bdbaScanStepRunner = createBdbaScanStepRunner(operationRunner);
             bdbaScanStepRunner.runBdbaScan(projectNameVersion, blackDuckRunData, scanFile, scanId.toString(), scanType);
         } else {
+            if(scanCreationResponse.getUploadUrl() != null) {
+                scanId = null;
+            }
             isPackageManagerScassPossible = false;
         }
 

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/CommonScanStepRunner.java
@@ -114,6 +114,7 @@ public class CommonScanStepRunner {
             BdbaScanStepRunner bdbaScanStepRunner = createBdbaScanStepRunner(operationRunner);
             bdbaScanStepRunner.runBdbaScan(projectNameVersion, blackDuckRunData, scanFile, scanId.toString(), scanType);
         } else {
+            // When HUB generated GCP upload url and returned it to Detect, it does not expect anything except /scans/{scanId}/scass-scan-processing call after that, so we reset the scan Id to try the full fallback approach
             if(scanCreationResponse.getUploadUrl() != null) {
                 scanId = null;
             }


### PR DESCRIPTION
This PR fixes issue IDETECT-4779 where scan fails to upload bdio since upload Url is blocked and HUB does not expect the old workflow for the same scanId. What Detect currently does is, if SCASS scans fail for some reason then it passes the same scanId that we got from first header call down to blackduck-common to continue the scan with that scanId but HUB does not expect Detect to do that if upload url has been created. Notes from HUB:

`When HUB generated GCP upload url and returned it to Detect, it does not expect anything except /scans/{scanId}/scass-scan-processing call after that`

So if we find that upload url was generated then in that case we set the scan Id to null which will make sure that we create a new scan in HUB in order for the scan to be successful. 

Blackduck-common changes: https://github.com/blackducksoftware/blackduck-common/pull/460/files
