### PR TITLE
retry failed scass signature scan

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -1074,12 +1074,13 @@ public class OperationRunner {
         List<SignatureScanPath> scanPaths,
         NameVersion projectNameVersion,
         DockerTargetData dockerTargetData,
-        BlackDuckRunData blackDuckRunData
+        BlackDuckRunData blackDuckRunData, 
+        boolean isScassFallback
     )
         throws OperationException {
         return auditLog.namedPublic("Create Online Signature Scan Batch", "OnlineSigScan",
             () -> new CreateScanBatchOperation(detectConfigurationFactory.createBlackDuckSignatureScannerOptions(), directoryManager, codeLocationNameManager)
-                .createScanBatchWithBlackDuck(detectRunUuid, projectNameVersion, scanPaths, blackDuckRunData, dockerTargetData)
+                .createScanBatchWithBlackDuck(detectRunUuid, projectNameVersion, scanPaths, blackDuckRunData, dockerTargetData, isScassFallback)
         );
     }
 

--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchOperation.java
@@ -42,10 +42,11 @@ public class CreateScanBatchOperation {
         NameVersion projectNameVersion,
         List<SignatureScanPath> signatureScanPaths,
         BlackDuckRunData blackDuckRunData,
-        @Nullable DockerTargetData dockerTargetData
+        @Nullable DockerTargetData dockerTargetData, 
+        boolean isScassFallback
     )
         throws DetectUserFriendlyException {
-        return createScanBatch(detectRunUuid, projectNameVersion, signatureScanPaths, blackDuckRunData, dockerTargetData);
+        return createScanBatch(detectRunUuid, projectNameVersion, signatureScanPaths, blackDuckRunData, dockerTargetData, isScassFallback);
     }
 
     public ScanBatch createScanBatchWithoutBlackDuck(
@@ -56,7 +57,7 @@ public class CreateScanBatchOperation {
     )
         throws DetectUserFriendlyException {
         //when offline, we must still call this with 'null' as a workaround for library issues, so offline scanner must be created with this set to null.
-        return createScanBatch(detectRunUuid, projectNameVersion, signatureScanPaths, null, dockerTargetData);
+        return createScanBatch(detectRunUuid, projectNameVersion, signatureScanPaths, null, dockerTargetData, false);
     }
 
     private ScanBatch createScanBatch(
@@ -64,7 +65,8 @@ public class CreateScanBatchOperation {
         NameVersion projectNameVersion,
         List<SignatureScanPath> signatureScanPaths,
         @Nullable BlackDuckRunData blackDuckRunData,
-        @Nullable DockerTargetData dockerTargetData
+        @Nullable DockerTargetData dockerTargetData, 
+        boolean isScassFallback
     )
         throws DetectUserFriendlyException {
         ScanBatchBuilder scanJobBuilder = new ScanBatchBuilder();
@@ -91,7 +93,7 @@ public class CreateScanBatchOperation {
         
         attemptToSetCsvArchive(scanJobBuilder, blackDuckRunData);
         
-        attemptToSetScassScan(scanJobBuilder, blackDuckRunData);
+        attemptToSetScassScan(scanJobBuilder, blackDuckRunData, isScassFallback);
 
         String projectName = projectNameVersion.getName();
         String projectVersionName = projectNameVersion.getVersion();
@@ -150,12 +152,14 @@ public class CreateScanBatchOperation {
         }
     }
 
-    private void attemptToSetScassScan(ScanBatchBuilder scanJobBuilder, BlackDuckRunData blackDuckRunData) {
+    private void attemptToSetScassScan(ScanBatchBuilder scanJobBuilder, BlackDuckRunData blackDuckRunData, boolean isScassFallback) {
         try {
             SignatureScannerVersion signatureScannerVersion = 
                     SignatureScanVersionChecker.getSignatureScannerVersion(logger, signatureScannerOptions.getLocalScannerInstallPath(), directoryManager.getPermanentDirectory());
 
-            if (signatureScannerVersion != null && signatureScannerVersion.isAtLeast(MIN_SCASS_VERSION)) {
+            if (signatureScannerVersion != null 
+                    && signatureScannerVersion.isAtLeast(MIN_SCASS_VERSION)
+                    && !isScassFallback) {
                 scanJobBuilder.scassScan(true);
             }
         } catch (IOException e) {


### PR DESCRIPTION
If a user has not allowed the SCASS IPs we want to retry the SCASS scan using the previous approach. I originally tried pushing down a lot of data to do this but it's easier, and I think cleaner, to just bubble back up to the start and being a new scan without the --scass-scan argument.