### PR TITLE
Fix UV Bugs when no project version and managed key are found

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/parse/UVTomlParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/parse/UVTomlParser.java
@@ -61,7 +61,6 @@ public class UVTomlParser {
             if (uvToolTable.contains(MANAGED_KEY)) {
                 return uvToolTable.getBoolean(MANAGED_KEY);
             }
-            return false;
         }
         return false;
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/parse/UVTomlParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/parse/UVTomlParser.java
@@ -61,7 +61,7 @@ public class UVTomlParser {
             if (uvToolTable.contains(MANAGED_KEY)) {
                 return uvToolTable.getBoolean(MANAGED_KEY);
             }
-            return true;
+            return false;
         }
         return false;
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
@@ -81,10 +81,10 @@ public class UVTreeDependencyGraphTransformer {
         if(depth > 0 && dependency != null) {
             addDependencyToGraph(dependency, dependencyStack, previousDepth);
             dependencyStack.push(dependency);
-        } else if (dependency != null && depth == 0) {
+        } else if (depth == 0) {
             String[] parts = line.split(" "); // parse the project line
             if(parts.length < 2) {
-                logger.warn("Unable to parse workspace member from line: {}", line);
+                logger.warn("Unable to parse workspace member and version from line: {}", line);
                 initializeProject(parts[0] != null ? parts[0] : "uvProject", "defaultVersion"); // if version doesn't exist, then create a code location with just project name and default version
                 return;
             }

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -33,7 +33,7 @@
 
 * (IDETECT-3456) BOM components marked as "ignored" will no longer appear in [detect_product_short] risk reports.
 * (IDETECT-4781) Signature Scans will no longer fail if SCA Scan Service (SCASS) related IPs are blocked. A performance warning will be printed and a non-SCASS Signature Scan will be performed.
-* (IDETECT-4759) Updated [detect_product_short] UV Detector to ensure it does not execute when `[tool.uv]` is absent, and avoids returning a success status unless a BDIO file is generated.
+* (IDETECT-4759) Updated [detect_product_short] UV Detector to prevent execution when the `toml` file does not have a `[tool.uv]` section, and to not return a success status unless a BDIO file is generated.
 
 ### Dependency updates
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -33,6 +33,7 @@
 
 * (IDETECT-3456) BOM components marked as "ignored" will no longer appear in [detect_product_short] risk reports.
 * (IDETECT-4781) Signature Scans will no longer fail if SCA Scan Service (SCASS) related IPs are blocked. A performance warning will be printed and a non-SCASS Signature Scan will be performed.
+* (IDETECT-4759) Updated [detect_product_short] UV Detector to ensure it does not execute when `[tool.uv]` is absent, and avoids returning a success status unless a BDIO file is generated.
 
 ### Dependency updates
 


### PR DESCRIPTION
This PR fixes IDETECT-4759 for bugs in UV detector, the fix includes not running uv scan when [tool.uv] key is not present in the `pyproject.toml` file. Other than that, it also fixes code location creation when project version is not provided, it creates a project default version in HUB.
