### PR TITLE
do not send zero correlated id data

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunner.java
@@ -320,7 +320,12 @@ public class IntelligentModeStepRunner {
     public void uploadCorrelatedScanCounts(BlackDuckRunData blackDuckRunData, CodeLocationAccumulator codeLocationAccumulator, String detectRunUuid) throws OperationException {
         logger.debug("Uploading correlated scan counts to Black Duck (correlation ID: {})", detectRunUuid);
         ScanCountsPayload scanCountsPayload = scanCountsPayloadCreator.create(codeLocationAccumulator.getWaitableCodeLocations(), codeLocationAccumulator.getAdditionalCountsByTool());
-        operationRunner.uploadCorrelatedScanCounts(blackDuckRunData, detectRunUuid, scanCountsPayload);        
+        
+        if (scanCountsPayload.isValid()) {
+            operationRunner.uploadCorrelatedScanCounts(blackDuckRunData, detectRunUuid, scanCountsPayload);
+        } else {
+            logger.debug("Upload skipped, there was no correlation data to send.");
+        }
     }
 
     public CodeLocationResults calculateCodeLocations(CodeLocationAccumulator codeLocationAccumulator) throws OperationException { //this is waiting....

--- a/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/model/ScanCountsPayload.java
+++ b/src/main/java/com/blackduck/integration/detect/workflow/blackduck/integratedmatching/model/ScanCountsPayload.java
@@ -12,4 +12,11 @@ public class ScanCountsPayload extends Stringable {
     public ScanCounts getScanCounts() {
         return scanCounts;
     }
+    
+    public boolean isValid() {
+        if (scanCounts.getBinary() > 0 || scanCounts.getPackageManager() > 0 || scanCounts.getSignature() > 0) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunnerTest.java
+++ b/src/test/java/com/blackduck/integration/detect/lifecycle/run/step/IntelligentModeStepRunnerTest.java
@@ -1,0 +1,42 @@
+package com.blackduck.integration.detect.lifecycle.run.step;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.detect.lifecycle.run.data.BlackDuckRunData;
+import com.blackduck.integration.detect.lifecycle.run.operation.OperationRunner;
+import com.blackduck.integration.detect.workflow.blackduck.codelocation.CodeLocationAccumulator;
+import com.blackduck.integration.detect.workflow.blackduck.integratedmatching.ScanCountsPayloadCreator;
+import com.blackduck.integration.detect.workflow.blackduck.integratedmatching.model.ScanCounts;
+import com.blackduck.integration.detect.workflow.blackduck.integratedmatching.model.ScanCountsPayload;
+
+public class IntelligentModeStepRunnerTest {
+
+    private OperationRunner operationRunner;
+    private ScanCountsPayloadCreator scanCountsPayloadCreator;
+    private IntelligentModeStepRunner intelligentModeStepRunner;
+
+    @BeforeEach
+    public void setUp() {
+        operationRunner = mock(OperationRunner.class);
+        scanCountsPayloadCreator = mock(ScanCountsPayloadCreator.class);
+        intelligentModeStepRunner = new IntelligentModeStepRunner(operationRunner, null, null, scanCountsPayloadCreator, "test-run-uuid");
+    }
+
+    @Test
+    public void testUploadCorrelatedScanCountsWhenNoScanCounts() throws Exception {
+        BlackDuckRunData blackDuckRunData = mock(BlackDuckRunData.class);
+        CodeLocationAccumulator codeLocationAccumulator = mock(CodeLocationAccumulator.class);
+        
+        ScanCounts scanCounts = new ScanCounts(0, 0, 0);
+        ScanCountsPayload scanCountsPayload = new ScanCountsPayload(scanCounts);
+
+        when(scanCountsPayloadCreator.create(any(), any())).thenReturn(scanCountsPayload);
+
+        intelligentModeStepRunner.uploadCorrelatedScanCounts(blackDuckRunData, codeLocationAccumulator, "test-run-uuid");
+
+        verify(operationRunner, never()).uploadCorrelatedScanCounts(any(), any(), any());
+    }
+}


### PR DESCRIPTION
This adds detection that executes when correlated scanning is enabled. It adds a simple additional check to confirm that any correlated ID took place before sending count information. This prevents errors downstream and provides for a slight optimization for Detect since we do not make a call that is useless.