### PR TITLE
Check HUB version before downloading arm scan-cli

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* Signature Scan now supports ARM architecture with correctly packaged ARM JRE for Windows, Mac, Linux, and Alpine operating systems.
+* Signature Scan now supports ARM architecture with correctly packaged ARM JRE for Windows, Mac, Linux, and Alpine operating systems for [bd_product_long] version 2025.7.0 or later.
 <note type="hint">To ensure [detect_product_short] correctly identifies the system architecture on ARM-based systems, please install an ARM-specific Java runtime. This is necessary for accurate detection and proper functionality on ARM platforms.</note>
 
 ### Changed features

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='67.0.16'
+gradle.ext.blackDuckCommonVersion='67.0.17'
 gradle.ext.springBootVersion='2.7.12'

--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='67.0.15'
+gradle.ext.blackDuckCommonVersion='67.0.16'
 gradle.ext.springBootVersion='2.7.12'

--- a/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
+++ b/src/main/java/com/blackduck/integration/detect/lifecycle/run/operation/OperationRunner.java
@@ -257,6 +257,9 @@ public class OperationRunner {
     private static final String INTELLIGENT_SCAN_ENDPOINT = ApiDiscovery.INTELLIGENT_PERSISTENCE_SCANS_PATH.getPath();
     private static final String INTELLIGENT_SCAN_CONTENT_TYPE = "application/vnd.blackducksoftware.intelligent-persistence-scan-3+protobuf";
     private static final String INTELLIGENT_SCAN_SCASS_CONTENT_TYPE = "application/vnd.blackducksoftware.intelligent-persistence-scan-4+protobuf-jsonld";
+    private static final String ALPINE_LINUX_OS = "ALPINE_LINUX";
+    private static final String ALPINE_LINUX_ENV_VARIABLE = "SCAN_CLI_OS";
+    private static final String OS_ARCHITECTURE_CONSTANT = "x64";
     public static final ImmutableList<Integer> RETRYABLE_AFTER_WAIT_HTTP_EXCEPTIONS = ImmutableList.of(408, 429, 502, 503, 504);
     public static final ImmutableList<Integer> RETRYABLE_WITH_BACKOFF_HTTP_EXCEPTIONS = ImmutableList.of(425, 500);
     private List<File> binaryUserTargets = new ArrayList<>();
@@ -1128,10 +1131,10 @@ public class OperationRunner {
             IntEnvironmentVariables intEnvironmentVariables = IntEnvironmentVariables.includeSystemEnv();
             Optional<BlackDuckVersion> blackDuckVersion = blackDuckRunData.getBlackDuckServerVersion();
 
-            String operatingSystemEnv = intEnvironmentVariables.getValue("SCAN_CLI_OS");
+            String operatingSystemEnv = intEnvironmentVariables.getValue(ALPINE_LINUX_ENV_VARIABLE);
             OperatingSystemType operatingSystemType;
 
-            if (operatingSystemEnv != null && shouldCheckforARMArchitecture(blackDuckVersion) && operatingSystemEnv.equals("ALPINE_LINUX")) {
+            if (operatingSystemEnv != null && shouldCheckforARMArchitecture(blackDuckVersion) && operatingSystemEnv.equals(ALPINE_LINUX_OS)) {
                 operatingSystemType = OperatingSystemType.ALPINE_LINUX;
             } else {
                 if (operatingSystemEnv != null) {
@@ -1140,7 +1143,7 @@ public class OperationRunner {
                 operatingSystemType = OperatingSystemType.determineFromSystem();
             }
 
-            String osArchitecture = "x64";
+            String osArchitecture = OS_ARCHITECTURE_CONSTANT;
 
             if(shouldCheckforARMArchitecture(blackDuckVersion)) {
                 osArchitecture = SystemUtils.OS_ARCH;

--- a/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/signaturescanner/operation/CreateScanBatchRunnerWithBlackDuck.java
@@ -36,7 +36,7 @@ public class CreateScanBatchRunnerWithBlackDuck {
         this.executorService = executorService;
     }
 
-    public ScanBatchRunner createScanBatchRunner(BlackDuckServerConfig blackDuckServerConfig, File installDirectory, Optional<BlackDuckVersion> blackDuckVersion) throws BlackDuckIntegrationException {
+    public ScanBatchRunner createScanBatchRunner(BlackDuckServerConfig blackDuckServerConfig, File installDirectory, Optional<BlackDuckVersion> blackDuckVersion, String osArchitecture) throws BlackDuckIntegrationException {
         logger.debug("Signature scanner will use the Black Duck server to download/update the scanner - this is the most likely situation.");
         SignatureScannerLogger slf4jIntLogger = new SignatureScannerLogger(logger);
         ScanPathsUtility scanPathsUtility = new ScanPathsUtility(slf4jIntLogger, intEnvironmentVariables, operatingSystemType);
@@ -59,7 +59,8 @@ public class CreateScanBatchRunnerWithBlackDuck {
                     keyStoreHelper,
                     blackDuckServerConfig.getBlackDuckUrl(),
                     operatingSystemType,
-                    installDirectory
+                    installDirectory,
+                    osArchitecture
             );
         } else {
             logger.debug("Using Zip Scan CLI download API (old).");


### PR DESCRIPTION
This PR fixes the bug where we do not want to append arm64 at the end of api for downloading scan-cli for HUB versions 2025.4.0 and below. So we pass os architecture from Detect to bd-common to make it simpler for us. Corresponding bd-common PR with changes is here: https://github.com/blackducksoftware/blackduck-common/pull/466
