### PR TITLE
Fix Cargo CLI scan failures due to infinite loop in cargo tree command

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/cargo/CargoCliExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/cargo/CargoCliExtractor.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.EnumMap;
 
 public class CargoCliExtractor {
-    private static final List<String> CARGO_TREE_COMMAND = Arrays.asList("tree", "--no-dedupe", "--prefix", "depth");
+    private static final List<String> CARGO_TREE_COMMAND = Arrays.asList("tree", "--prefix", "depth");
     private final DetectableExecutableRunner executableRunner;
     private final CargoDependencyGraphTransformer cargoDependencyTransformer;
     private final CargoTomlParser cargoTomlParser;


### PR DESCRIPTION
**JIRA Ticket**
IDETECT-4801

**Problem**
When scanning Cargo projects using Detect >10.3, the Cargo CLI detector fails with an `OutOfMemoryError`.
This was caused by the `cargo tree --no-dedupe --prefix depth` command, which forces Cargo to include *every duplicate occurrence of dependencies and their entire subtrees*.

On large projects, this results in extremely large output, effectively sending Cargo into an infinite loop and exhausting JVM heap space.
As a result, clients were forced to downgrade to Detect 10.3 to avoid this issue.

**Solution**
This merge request removes the `--no-dedupe` option from the Cargo CLI command.

With this change:

* The Cargo CLI detector now runs with:

  ```bash
  cargo tree --prefix depth
  ```
* Duplicate dependencies are collapsed to a single entry, but their subtree and relationships are preserved in the output.
* The resulting dependency graph remains accurate for SBOM generation — structure and relationships are unaffected.
* Dependency exclusions (`build`, `dev`, or both) continue to work as before via the `--edges` flag.


The removal of `--no-dedupe` does not affect the correctness of the SBOM. Cargo ensures that each dependency subtree is preserved under one occurrence, keeping the dependency graph structurally valid while avoiding runaway duplication.



_*N.B:* To be shipped with Detect **11.0.0**._

