### PR TITLE
Deb/shanty/idetect 4656 further doc updates for *pom.xml support

### DIFF
--- a/documentation/src/main/markdown/components/detectors.dita
+++ b/documentation/src/main/markdown/components/detectors.dita
@@ -526,7 +526,7 @@
 							<entry>various</entry>
 							<entry>Maven Central</entry>
 							<entry>
-								<p>File: pom.xml</p>
+								<p>File: *pom.xml</p>
 								<p>Executable: mvnw or mvn</p>
 							</entry>
 							<entry>HIGH</entry>

--- a/documentation/src/main/markdown/packagemgrs/maven.md
+++ b/documentation/src/main/markdown/packagemgrs/maven.md
@@ -21,7 +21,7 @@
 
 * Discovers dependencies of Maven projects by executing mvn commands.
 
-* Will run on your project if it finds a pom.xml file in the top level source directory and requires either `mvnw` or `mvn`.
+* Will run on your project if it finds any file matching the pattern *pom.xml in the top-level source directory and requires either `mvnw` or `mvn`.
 
 1. [detect_product_short] looks for `mvnw` in the source directory (top level). You can override this by setting the Maven path property.  
 1.  If `mvnw` path is not overridden and `mvnw` is not found:[detect_product_short] looks for mvn on $PATH.


### PR DESCRIPTION

Updating relevant mentions of "pom.xml" in our docs. 

The release note was merged in a previous MR and says (under new features): 

Maven CLI Detector now accepts a custom pom.xml file name (matching the pattern *pom.xml) when provided via `detect.maven.build.command`. 