### PR TITLE
Upgrade tika

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,8 +185,8 @@ dependencies {
     implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 
     // autonomous
-    implementation 'org.apache.tika:tika-core:2.9.0'
-    implementation 'org.apache.tika:tika-parsers-standard-package:2.9.0'
+    implementation 'org.apache.tika:tika-core:3.2.2'
+    implementation 'org.apache.tika:tika-parsers-standard-package:3.2.2'
     implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.23.1'
 
     constraints {

--- a/src/test/java/com/blackduck/integration/detect/lifecycle/autonomous/ScanTypeDeciderTest.java
+++ b/src/test/java/com/blackduck/integration/detect/lifecycle/autonomous/ScanTypeDeciderTest.java
@@ -4,7 +4,6 @@ import com.blackduck.integration.configuration.property.types.enumallnone.list.A
 import com.blackduck.integration.detect.configuration.DetectProperties;
 import com.blackduck.integration.detect.configuration.DetectPropertyConfiguration;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
-import com.blackduck.integration.detect.lifecycle.autonomous.ScanTypeDecider;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;


### PR DESCRIPTION
# Description

The currently-used 2.9.0 version of Tika contains a vulnerability in a code path that Detect does not use.
Even though Detect isn't affected by the vulnerability it's still better to make this upgrade.