### PR TITLE
Fix Cargo Cli Dependency Exclusion Test Failure

### DIFF
--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/cargo/functional/CargoCliDependencyExclusionTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/cargo/functional/CargoCliDependencyExclusionTest.java
@@ -59,7 +59,7 @@ public class CargoCliDependencyExclusionTest extends DetectableFunctionalTest {
             "1openssl v0.10.73",
             "1regex-lite v0.1.6 (https://github.com/rust-lang/regex.git#1a069b92)"
         );
-        addExecutableOutput(cargoTreeOutput, "cargo", "tree", "--no-dedupe", "--prefix", "depth", "--edges", "no-normal");
+        addExecutableOutput(cargoTreeOutput, "cargo", "tree", "--prefix", "depth", "--edges", "no-normal");
     }
 
     @NotNull


### PR DESCRIPTION
**Description**

This merge request aims to fix the cargo cli dependency exclusion test after the merge of IDETECT-4801
