### PR TITLE
Fix uv bugs for large monorepos

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -41,6 +41,7 @@ public class UVLockParser {
     private final List<CodeLocation> codeLocations = new ArrayList<>();
     private final Map<String, String> packageDependencyMap = new HashMap<>();
     private final Map<String, Set<String>> transitiveDependencyMap = new HashMap<>();
+    private final Set<String> visitedDependencies = new HashSet<>();
 
     public UVLockParser(ExternalIdFactory externalIdFactory) {
         this.externalIdFactory = externalIdFactory;
@@ -146,6 +147,13 @@ public class UVLockParser {
 
     // parse all dependencies which we had stored in the Map for transitive dependency for each dependency while parsing it the first time
     private void loopOverDependencies(String dependency, Dependency parentDependency, UVDetectorOptions uvDetectorOptions) {
+
+        if(visitedDependencies.contains(dependency)) {
+            return;
+        }
+
+        visitedDependencies.add(dependency);
+
         if(transitiveDependencyMap.containsKey(dependency)) {
             for(String transitiveDependency: transitiveDependencyMap.get(dependency)) {
                 if(!checkIfMemberExcluded(transitiveDependency, uvDetectorOptions)) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
@@ -158,6 +158,11 @@ public class UVTreeDependencyGraphTransformer {
             line = line.replace(parenthesis, "");
         }
 
+        if (line.contains("(")) {
+            String parenthesis = line.substring(line.indexOf("("), line.indexOf(")") + 1);
+            line = line.replace(parenthesis, "");
+        }
+
         // we keep the limit three to split it in three parts if we have extra information such as group or extra, as an example "pytest v8.3.4 (group: dev)"
         String[] parts = line.split(" ",3);
         String dependencyName = parts[0];

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVTreeDependencyGraphTransformer.java
@@ -160,13 +160,14 @@ public class UVTreeDependencyGraphTransformer {
 
         // we keep the limit three to split it in three parts if we have extra information such as group or extra, as an example "pytest v8.3.4 (group: dev)"
         String[] parts = line.split(" ",3);
-        if(parts.length < 2) {
-            logger.warn("Unable to parse dependency from line: {}", line);
-            return null;
-        }
-
         String dependencyName = parts[0];
-        String dependencyVersion = parts[1].replace("v", "");
+        String dependencyVersion;
+        if(parts.length < 2) {
+            logger.warn("Unable to parse version from line: {}, putting the package with default version in BOM", line);
+            dependencyVersion = "defaultVersion";
+        } else {
+            dependencyVersion = parts[1].replace("v", "");
+        }
 
         // check if the member is excluded and set flags for excluding transitives of that dependency
         if (checkIfMemberExcluded(dependencyName, detectorOptions)) {


### PR DESCRIPTION
This PR fixes the following bugs:

**UV Build Detector**

UV has concept of dynamic versions for projects and workspaces where it fetches version during building but not in tree and lockfile. We were not handling the case when multiple workspaces have dynamic versions resulting in empty BDIO. Now, we are creating the workspace dependency in BOM with defaultVersion (Let me know if you have any other suggestions).

**UV Lockfile Detector**

The project in IDETECT-4806 contains a cycle and current lockfile approach was not able to handle that so this PR also handles detection of cycles.