### PR TITLE
Yield PIP to SetUptools Detector

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/tool/detector/DetectorRuleFactory.java
@@ -264,8 +264,7 @@ public class DetectorRuleFactory {
                     .search().defaults();
             })
             .allEntryPointsFallbackToNext()
-            .yieldsTo(DetectorType.POETRY)
-            .yieldsTo(DetectorType.UV);
+            .yieldsTo(DetectorType.POETRY, DetectorType.UV, DetectorType.SETUPTOOLS);
 
         rules.addDetector(DetectorType.RUBYGEMS, detector -> {
             detector.entryPoint(GemlockDetectable.class)


### PR DESCRIPTION
After we added support for pyproject.toml with PIP detector, it gets invoked erroneously since there is no special identifier for PIP in pyproject.toml unlike all other detectors. Yielding PIP to all of these detectors here will solve this problem.
