### PR TITLE
Update blackduck-common Version to Fix 412 Retry Error

### DIFF
--- a/shared-version.properties
+++ b/shared-version.properties
@@ -1,2 +1,2 @@
-gradle.ext.blackDuckCommonVersion='67.0.19'
+gradle.ext.blackDuckCommonVersion='67.0.20'
 gradle.ext.springBootVersion='2.7.12'


### PR DESCRIPTION
**JIRA Ticket**
IDETECT-4786

**Description**
This update bumps the `blackduck-common` version to `67.0.20` to include the recent fix that prevents retrying BDIO uploads when the Black Duck server responds with **HTTP 412 (Precondition Failed)**.
  
Previously, Detect retried BDIO uploads for up to 5 minutes after receiving a 412 response. This was inefficient because:
- **HTTP 412 is a client-side error**, indicating unmet preconditions.
- Retrying without changing the request logic will always fail.

**Fix Details**  
- The `blackduck-common` library now treats HTTP 412 as **non-retryable**.
- Detect will immediately stop retrying BDIO uploads when a 412 response is received, improving scan performance and clarity.

Pull request merged in **blackduck-common** end: [Stop Retrying BDIO Uploads on HTTP 412 Precondition Failed Response](https://github.com/blackducksoftware/blackduck-common/pull/472)