### PR TITLE
Bring back code black to prevent dita error

### DIFF
--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -37,8 +37,9 @@ bash <(curl -s -L https://detect.blackduck.com/detect10.sh) --blackduck.url={you
 
 
 On Windows:
-powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.blackduck.com/detect10.ps1?$(Get-Random) | iex; detect" --blackduck.url={your Black Duck SCA server URL} --blackduck.api.token={your Black Duck access token}
-
+````
+powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://detect.blackduck.com/detect.ps1?$(Get-Random) | iex; detect" --blackduck.url={your Black Duck SCA server URL} --blackduck.api.token={your Black Duck SCA access token}
+````
 
 The operations performed by [detect_product_short] depends on what it finds in your source directory.
 By default, [detect_product_short] considers the current working directory to be your source directory.

--- a/documentation/src/main/markdown/gettingstarted/quickstart.md
+++ b/documentation/src/main/markdown/gettingstarted/quickstart.md
@@ -33,8 +33,9 @@ server. One way to do that is to add the following arguments to the command line
 The command you run looks like this:
 
 On Linux or Mac:
-bash <(curl -s -L https://detect.blackduck.com/detect10.sh) --blackduck.url={your Black Duck SCA server URL} --blackduck.api.token={your Black Duck access token}
-
+````
+bash <(curl -s -L https://detect.blackduck.com/detect10.sh) --blackduck.url={your Black Duck SCA server URL} --blackduck.api.token={your Black Duck SCA access token}
+````
 
 On Windows:
 ````


### PR DESCRIPTION
Original MR: 
https://github.com/blackducksoftware/detect/commit/0da9251b1f7808b26cee9e845be47de0feba079f

I believe bringing back the code block will prevent the error we see:

Execution failed for task ':documentation:ditasite'.
> java.lang.Exception: dita found invalid key references. Square brackets around doc text must be escaped if not inside back quotes. To run dita by hand: cd documentation/build/generated; dita -format webhelp-responsive -input detect.ditamap -output ../ditasite -Dwebhelp.publishing.template==<PATH TO docs-dita-tools>/templates/bd-webhelp -Dwebhelp.publishing.template.descriptor=bd-tiles.opt -v
  ERROR:    [keyref] file:/home/quickstart.md:181:15: [DOTJ047I][INFO] Unable to find key definition for key reference "Net.ServicePointManager" in root scope. The href attribute may be used as fallback if it exists

