### PR TITLE
rework JSON reading to support Java 8

### DIFF
--- a/src/main/java/com/blackduck/integration/detect/configuration/ProjectSettingsJsonFileReader.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/ProjectSettingsJsonFileReader.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detect.configuration;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -45,7 +46,7 @@ public class ProjectSettingsJsonFileReader {
         }
 
         try {
-            String jsonContent = Files.readString(filePath);
+            String jsonContent = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
             if (jsonContent == null || jsonContent.trim().isEmpty()) {
                 logger.warn("Project settings file is empty: {}", filePath);
                 return null;


### PR DESCRIPTION
Was using a call that only worked on Java 11 and later. Rewriting to support Java 8 as well as later versions.