### PR TITLE
Add properties links and rename duplicates

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -27,8 +27,8 @@
 * The new [detect.excluded.detectors](properties/configuration/detector.md#detectors-excluded-advanced) property takes as input a comma-separated list of Detector names to exclude. This allows for greater control over selection of Detectors.
 * Added support for capturing dependencies from the `go.mod` file via a new buildless detector named "Go Mod File" for Go projects.
 	* Added a new property [detect.go.forge](properties/detectors/go.md#go-forge-url) to customize the Go registry URL used for fetching dependency information. Defaults to `https://proxy.golang.org`.
-	* Added a new property [detect.go.forge.connection.timeout](properties/detectors/go.md#go-connection-timeout) to customize the connection timeout limit while connecting to the Go registry. Defaults to 30 seconds.
-	* Added a new property [detect.go.forge.read.timeout](properties/detectors/go.md#go-read-timeout) to customize the read timeout limit while fetching go.mod file of a dependency from Go registry. Defaults to 60 seconds.
+	* Added a new property [detect.go.forge.connection.timeout](properties/detectors/go.md#go-forge-connection-timeout) to customize the connection timeout limit while connecting to the Go registry. Defaults to 30 seconds.
+	* Added a new property [detect.go.forge.read.timeout](properties/detectors/go.md#go-forge-read-timeout) to customize the read timeout limit while fetching go.mod file of a dependency from Go registry. Defaults to 60 seconds.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -26,9 +26,9 @@
 * The new [detect.project.settings](properties/configuration/project.md#project-settings-via-json) property takes as input a path to a JSON file. This file allows users to pass several existing `detect.project` properties as a single argument to Detect. Detect will parse the JSON file to obtain information relevant to creating or updating projects.
 * The new [detect.excluded.detectors](properties/configuration/detector.md#detectors-excluded-advanced) property takes as input a comma-separated list of Detector names to exclude. This allows for greater control over selection of Detectors.
 * Added support for capturing dependencies from the `go.mod` file via a new buildless detector named "Go Mod File" for Go projects.
-	* Added a new property `detect.go.forge` to customize the Go registry URL used for fetching dependency information. Defaults to `https://proxy.golang.org`.
-	* Added a new property `detect.go.forge.connection.timeout` to customize the connection timeout limit while connecting to the Go registry. Defaults to 30 seconds.
-	* Added a new property `detect.go.forge.read.timeout` to customize the read timeout limit while fetching go.mod file of a dependency from Go registry. Defaults to 60 seconds.
+	* Added a new property [detect.go.forge](properties/detectors/go.md#go-forge-url) to customize the Go registry URL used for fetching dependency information. Defaults to `https://proxy.golang.org`.
+	* Added a new property [detect.go.forge.connection.timeout](properties/detectors/go.md#go-connection-timeout) to customize the connection timeout limit while connecting to the Go registry. Defaults to 30 seconds.
+	* Added a new property [detect.go.forge.read.timeout](properties/detectors/go.md#go-read-timeout) to customize the read timeout limit while fetching go.mod file of a dependency from Go registry. Defaults to 60 seconds.
 
 ### Changed features
 

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -866,7 +866,7 @@ public class DetectProperties {
     
     public static final LongProperty DETECT_GO_FORGE_CONNECTION_TIMEOUT =
         LongProperty.newBuilder("detect.go.forge.connection.timeout", 30L)
-            .setInfo("Go Connection Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
+            .setInfo("Go Forge Connection Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The connection timeout in seconds to use when connecting to the Go Forge. If not set, the default connection timeout of 30 seconds will be used."
             ).setExample("30")
@@ -875,7 +875,7 @@ public class DetectProperties {
 
     public static final LongProperty DETECT_GO_FORGE_READ_TIMEOUT =
         LongProperty.newBuilder("detect.go.forge.read.timeout", 60L)
-            .setInfo("Go Read Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
+            .setInfo("Go Forge Read Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The read timeout in seconds to use when reading from the Go Forge. If not set, the default read timeout of 60 seconds will be used."
             ).setExample("60")

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -866,7 +866,7 @@ public class DetectProperties {
     
     public static final LongProperty DETECT_GO_FORGE_CONNECTION_TIMEOUT =
         LongProperty.newBuilder("detect.go.forge.connection.timeout", 30L)
-            .setInfo("Detect Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
+            .setInfo("Go Connection Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The connection timeout in seconds to use when connecting to the Go Forge. If not set, the default connection timeout of 30 seconds will be used."
             ).setExample("30")
@@ -875,7 +875,7 @@ public class DetectProperties {
 
     public static final LongProperty DETECT_GO_FORGE_READ_TIMEOUT =
         LongProperty.newBuilder("detect.go.forge.read.timeout", 60L)
-            .setInfo("Detect Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
+            .setInfo("Go Read Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The read timeout in seconds to use when reading from the Go Forge. If not set, the default read timeout of 60 seconds will be used."
             ).setExample("60")


### PR DESCRIPTION
Add links in the release notes to the new properties.
Rename duplicate property names (Detect Timeout)

