### PR TITLE
Fix Go Mod File detector compatibility for java 8

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/GoModFileDetectableOptions.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/GoModFileDetectableOptions.java
@@ -2,10 +2,10 @@ package com.blackduck.integration.detectable.detectables.go.gomodfile;
 
 public class GoModFileDetectableOptions {
     private final String goProxyUrl;
-    private final long connectionTimeout;
-    private final long readTimeout;
+    private final int connectionTimeout;
+    private final int readTimeout;
 
-    public GoModFileDetectableOptions(String goProxyUrl, long connectionTimeout, long readTimeout) {
+    public GoModFileDetectableOptions(String goProxyUrl, int connectionTimeout, int readTimeout) {
         this.goProxyUrl = goProxyUrl;
         this.connectionTimeout = connectionTimeout;
         this.readTimeout = readTimeout;
@@ -15,11 +15,11 @@ public class GoModFileDetectableOptions {
         return goProxyUrl;
     }
 
-    public long getConnectionTimeout() {
+    public int getConnectionTimeout() {
         return connectionTimeout;
     }
 
-    public long getReadTimeout() {
+    public int getReadTimeout() {
         return readTimeout;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/GoModParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/GoModParser.java
@@ -10,6 +10,7 @@ import com.blackduck.integration.detectable.detectables.go.gomodfile.parse.model
 import com.blackduck.integration.detectable.detectables.go.gomodfile.parse.model.GoModFileHelpers;
 import com.blackduck.integration.detectable.detectables.go.gomodfile.parse.model.GoModuleInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ public class GoModParser {
     private static final String ORPHAN_PARENT_NAME = "Additional_Components";
     private static final String ORPHAN_PARENT_VERSION = "none";
 
-    private static final String DEPENDENCY_SEPARATOR = "-".repeat(60);
+    private static final String DEPENDENCY_SEPARATOR = StringUtils.repeat("-", 60 );
 
     public GoModParser(ExternalIdFactory externalIdFactory, GoModFileDetectableOptions options) {
         this.externalIdFactory = externalIdFactory;
@@ -76,7 +77,7 @@ public class GoModParser {
         logger.debug(DEPENDENCY_SEPARATOR);
         for(int idx=0; idx < path.size(); idx++) {
             GoDependencyNode pathEntry = path.get(idx);
-            logger.debug("> {} {} {}", (idx > 0 ? " ".repeat(idx) : ""), pathEntry.getDependency().getName(), pathEntry.getDependency().getVersion());
+            logger.debug("> {} {} {}", (idx > 0 ? StringUtils.repeat(" ", idx) : ""), pathEntry.getDependency().getName(), pathEntry.getDependency().getVersion());
         }
         logger.debug(DEPENDENCY_SEPARATOR);
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/model/GoProxyModuleResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/model/GoProxyModuleResolver.java
@@ -64,11 +64,10 @@ public class GoProxyModuleResolver {
             conn.setReadTimeout(options.getReadTimeout() * 1000);
             if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-                    // Read the response context as string
                     String inputLine;
                     StringBuilder content = new StringBuilder();
                     while ((inputLine = in.readLine()) != null) {
-                        content.append(inputLine);
+                        content.append(inputLine).append(System.lineSeparator());
                     }
                     logger.debug("Successfully fetched go.mod file for dependency {}", dependency);
                     return content.toString();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/model/GoProxyModuleResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/go/gomodfile/parse/model/GoProxyModuleResolver.java
@@ -1,13 +1,10 @@
 package com.blackduck.integration.detectable.detectables.go.gomodfile.parse.model;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.net.ConnectException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpClient.Redirect;
-import java.net.http.HttpResponse.BodyHandlers;
-import java.time.Duration;
-
+import java.net.HttpURLConnection;
+import java.net.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,16 +15,11 @@ public class GoProxyModuleResolver {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     public final GoModFileDetectableOptions options;
-    private final HttpClient client;
 
     public GoProxyModuleResolver(GoModFileDetectableOptions options) {
         this.options = options;
         // initialize the http client with a default connection timeout of 30s and configure it to follow redirects
         logger.debug("Initializing Go proxy HTTP client with connection timeout of {} seconds and read timeout of {} seconds", options.getConnectionTimeout(), options.getReadTimeout());
-        this.client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(options.getConnectionTimeout()))
-            .followRedirects(Redirect.ALWAYS)
-            .build();
     }
 
     private String getGoModFileURL(Dependency dependency) {
@@ -45,14 +37,13 @@ public class GoProxyModuleResolver {
     public Boolean checkConnectivity() {
         String testURL = String.format("%s/", options.getGoProxyUrl());
         try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(java.net.URI.create(testURL))
-                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
-                    .timeout(Duration.ofSeconds(options.getReadTimeout()))
-                    .build();
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-            logger.debug("Go proxy connectivity check to URL '{}' returned status code: {}", options.getGoProxyUrl(), response.statusCode());
-            return response.statusCode() == 200;
+            HttpURLConnection conn = (HttpURLConnection) new URL(testURL).openConnection();
+            conn.setRequestMethod("HEAD");
+            conn.setConnectTimeout(options.getConnectionTimeout() * 1000);
+            conn.setReadTimeout(options.getReadTimeout() * 1000);
+            int responseCode = conn.getResponseCode();
+            logger.debug("Go proxy connectivity check to URL '{}' returned status code: {}", options.getGoProxyUrl(), responseCode);
+            return responseCode == 200;
         } catch (ConnectException e) {
             logger.error("The Go proxy URL '{}' could not be resolved. Please check the URL and your network connection.", options.getGoProxyUrl());
             return false;
@@ -67,18 +58,24 @@ public class GoProxyModuleResolver {
         // Make a HTTP GET request to fetch the go.mod file content
         try {
             logger.debug("Fetching go.mod for dependency {} via URL {}: ", dependency, modFileURL);
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(java.net.URI.create(modFileURL))
-                    .GET()
-                    .timeout(Duration.ofSeconds(options.getReadTimeout()))
-                    .build();
-            HttpResponse<String> response  = client.send(request, BodyHandlers.ofString());
-            if (response.statusCode() == 200) {
-                logger.debug("Successfully fetched go.mod file for dependency {}", dependency);
-                return response.body();
+            HttpURLConnection conn = (HttpURLConnection) new URL(modFileURL).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(options.getConnectionTimeout() * 1000);
+            conn.setReadTimeout(options.getReadTimeout() * 1000);
+            if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                    // Read the response context as string
+                    String inputLine;
+                    StringBuilder content = new StringBuilder();
+                    while ((inputLine = in.readLine()) != null) {
+                        content.append(inputLine);
+                    }
+                    logger.debug("Successfully fetched go.mod file for dependency {}", dependency);
+                    return content.toString();
+                }
             } else {
-                String responseBody = response.body();
-                logger.error("Failed to fetch go.mod file for dependency {}. HTTP request status code: {}. Response text: {}", dependency, response.statusCode(), responseBody);
+                String responseMessage = conn.getResponseMessage();
+                logger.error("Failed to fetch go.mod file for dependency {}. HTTP request status code: {}. Response text: {}", dependency, conn.getResponseCode(), responseMessage);
                 return null;
             }
         } catch (Exception e) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/go/functional/GoModFileDetectableTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/go/functional/GoModFileDetectableTest.java
@@ -36,7 +36,7 @@ public class GoModFileDetectableTest {
         Assertions.assertTrue(testGoModExtraction.getCodeLocations().size() == 1);
         DependencyGraph dependencyGraph = testGoModExtraction.getCodeLocations().get(0).getDependencyGraph();
         Assertions.assertNotNull(dependencyGraph);
-        Assertions.assertEquals(dependencyGraph.getDirectDependencies().size(), 3);
+        Assertions.assertEquals(dependencyGraph.getDirectDependencies().size(), 2);
         // Check if graph contains github.com/fsnotify/fsnotify v1.90 as a direct dependency
         Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
                 .anyMatch(dependency -> "github.com/fsnotify/fsnotify".equals(dependency.getName())
@@ -45,9 +45,6 @@ public class GoModFileDetectableTest {
         Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
                 .anyMatch(dependency -> "github.com/gin-gonic/gin".equals(dependency.getName())
                         && "v1.10.1".equals(dependency.getVersion())));
-        // Check if graph contains "Additional_Components" as a direct dependency
-        Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
-                .anyMatch(dependency -> "Additional_Components".equals(dependency.getName())));
         // google.golang.org/protobuf v1.34.1 should not in the children of github.com/gin-gonic/gin
         Assertions.assertFalse(dependencyGraph.getChildrenForParent(dependencyGraph.getDirectDependencies().stream()
                 .filter(dependency -> "github.com/gin-gonic/gin".equals(dependency.getName())

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/go/functional/GoModFileDetectableTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/go/functional/GoModFileDetectableTest.java
@@ -36,7 +36,7 @@ public class GoModFileDetectableTest {
         Assertions.assertTrue(testGoModExtraction.getCodeLocations().size() == 1);
         DependencyGraph dependencyGraph = testGoModExtraction.getCodeLocations().get(0).getDependencyGraph();
         Assertions.assertNotNull(dependencyGraph);
-        Assertions.assertEquals(dependencyGraph.getDirectDependencies().size(), 2);
+        Assertions.assertEquals(dependencyGraph.getDirectDependencies().size(), 3);
         // Check if graph contains github.com/fsnotify/fsnotify v1.90 as a direct dependency
         Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
                 .anyMatch(dependency -> "github.com/fsnotify/fsnotify".equals(dependency.getName())
@@ -45,6 +45,9 @@ public class GoModFileDetectableTest {
         Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
                 .anyMatch(dependency -> "github.com/gin-gonic/gin".equals(dependency.getName())
                         && "v1.10.1".equals(dependency.getVersion())));
+        // Check if graph contains "Additional_Components" as a direct dependency
+        Assertions.assertTrue(dependencyGraph.getDirectDependencies().stream()
+                .anyMatch(dependency -> "Additional_Components".equals(dependency.getName())));
         // google.golang.org/protobuf v1.34.1 should not in the children of github.com/gin-gonic/gin
         Assertions.assertFalse(dependencyGraph.getChildrenForParent(dependencyGraph.getDirectDependencies().stream()
                 .filter(dependency -> "github.com/gin-gonic/gin".equals(dependency.getName())

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -863,9 +863,9 @@ public class DetectProperties {
             )
             .setGroups(DetectGroup.GO, DetectGroup.GLOBAL)
             .build();
-    
-    public static final LongProperty DETECT_GO_FORGE_CONNECTION_TIMEOUT =
-        LongProperty.newBuilder("detect.go.forge.connection.timeout", 30L)
+
+    public static final IntegerProperty DETECT_GO_FORGE_CONNECTION_TIMEOUT =
+        IntegerProperty.newBuilder("detect.go.forge.connection.timeout", 30)
             .setInfo("Go Forge Connection Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The connection timeout in seconds to use when connecting to the Go Forge. If not set, the default connection timeout of 30 seconds will be used."
@@ -873,8 +873,8 @@ public class DetectProperties {
             .setGroups(DetectGroup.GO, DetectGroup.GLOBAL)
             .build();
 
-    public static final LongProperty DETECT_GO_FORGE_READ_TIMEOUT =
-        LongProperty.newBuilder("detect.go.forge.read.timeout", 60L)
+    public static final IntegerProperty DETECT_GO_FORGE_READ_TIMEOUT =
+        IntegerProperty.newBuilder("detect.go.forge.read.timeout", 60)
             .setInfo("Go Forge Read Timeout", DetectPropertyFromVersion.VERSION_11_0_0)
             .setHelp(
                 "The read timeout in seconds to use when reading from the Go Forge. If not set, the default read timeout of 60 seconds will be used."

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectableOptionFactory.java
@@ -145,18 +145,18 @@ public class DetectableOptionFactory {
 
     public GoModFileDetectableOptions createGoModFileDetectableOptions() {
         String goForgeUrl = detectConfiguration.getNullableValue(DetectProperties.DETECT_GO_FORGE);
-        if (goForgeUrl == null || goForgeUrl.isBlank()) {
+        if (goForgeUrl == null || goForgeUrl.isEmpty()) {
             goForgeUrl = "https://proxy.golang.org";
         }
         // if the URL ends with a trailing slash, remove it
         if (goForgeUrl.endsWith("/")) {
             goForgeUrl = goForgeUrl.substring(0, goForgeUrl.length() - 1);
         }
-        long connectionTimeout = detectConfiguration.getValue(DetectProperties.DETECT_GO_FORGE_CONNECTION_TIMEOUT);
+        int connectionTimeout = detectConfiguration.getValue(DetectProperties.DETECT_GO_FORGE_CONNECTION_TIMEOUT);
         if (connectionTimeout <= 0) {
             connectionTimeout = 30; // default to 30 seconds if not set
         }
-        long readTimeout = detectConfiguration.getValue(DetectProperties.DETECT_GO_FORGE_READ_TIMEOUT);
+        int readTimeout = detectConfiguration.getValue(DetectProperties.DETECT_GO_FORGE_READ_TIMEOUT);
         if (readTimeout <= 0) {
             readTimeout = 60; // default to 60 seconds if not set
         }


### PR DESCRIPTION
# Description

Detect was failing with Java 8 due to recent Go Mod File detector changes. This PR updates the code to support Java 8, 11, 17, and 21.

Changes,
1. Use StringUtils helper class instead of String.repeat function
2. Use HttpURLConnection for Go forge interactions
3. Change the detect.go.forge.connection.timeout and detect.go.forge.read.timeout properties to int


IDETECT-4865