### PR TITLE
Bump up component-locator version to support version range operators

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation "com.blackduck.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.blackduck.integration:blackduck-upload-common:4.1.5'
     implementation 'com.blackducksoftware:method-analyzer-core:1.0.7'
-    implementation "${locatorGroup}:${locatorModule}:2.4.0"
+    implementation "${locatorGroup}:${locatorModule}:2.4.1"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation "com.blackduck.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.blackduck.integration:blackduck-upload-common:4.1.5'
     implementation 'com.blackducksoftware:method-analyzer-core:1.0.7'
-    implementation "${locatorGroup}:${locatorModule}:2.3.4"
+    implementation "${locatorGroup}:${locatorModule}:2.4.0"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -35,4 +35,4 @@
 
 ### Dependency Updates
 
-* Released and upgraded Component Locator version 2.4.0
+* Released and upgraded Component Locator version 2.4.1

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,7 +24,7 @@
 * With the addition of the `detect.cargo.included.features` and `detect.cargo.disable.default.features` properties, [detect_product_short] now supports Cargo features and the inclusion or exclusion of dependencies as options. See [Cargo](properties/detectors/cargo.md) for details.
   <note type="note">This feature is supported for Cargo CLI Detector. Cargo Lockfile Detector will log a warning if these properties are provided.</note>
 * (IDETECT-4937) Add support for `environment.yaml` in [detect_product_short] Conda CLI Detector.
-* (IDETECT-4168) Component Location Analysis now supports locating dependency declarations that use version range operators for NPM, YARN, and PIP. See [Component Location Analysis](runningdetect/component-location-analysis.md) for details.
+* (IDETECT-4168) Component Location Analysis now supports locating dependency declarations that use version range operators for npm, Yarn, and PIP. See [Component Location Analysis](runningdetect/component-location-analysis.md) for details.
 
 ### Resolved issues
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -32,3 +32,7 @@
 * (IDETECT-4960) Added support for Cargo features and optional dependencies in Cargo CLI Detector, allowing precise control over which features are included in the SBOM through cargo tree command flags. See [Cargo](properties/detectors/cargo.md) for details.
 * (IDETECT-4847) Clarified that the value of `detect.container.scan.file.path` should be a local .tar file path or HTTP/HTTPS URL for a remote .tar file.
 * (IDETECT-4970) Fixed an issue where a `quack-patch` output directory was created despite the feature not being enabled.
+
+### Dependency Updates
+
+* Released and upgraded Component Locator version 2.4.0

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -24,6 +24,7 @@
 * With the addition of the `detect.cargo.included.features` and `detect.cargo.disable.default.features` properties, [detect_product_short] now supports Cargo features and the inclusion or exclusion of dependencies as options. See [Cargo](properties/detectors/cargo.md) for details.
   <note type="note">This feature is supported for Cargo CLI Detector. Cargo Lockfile Detector will log a warning if these properties are provided.</note>
 * (IDETECT-4937) Add support for `environment.yaml` in [detect_product_short] Conda CLI Detector.
+* (IDETECT-4168) Component Location Analysis now supports locating dependency declarations that use version range operators for NPM, YARN, and PIP. See [Component Location Analysis](runningdetect/component-location-analysis.md) for details.
 
 ### Resolved issues
 

--- a/documentation/src/main/markdown/runningdetect/component-location-analysis.md
+++ b/documentation/src/main/markdown/runningdetect/component-location-analysis.md
@@ -72,17 +72,16 @@ Component Location Analysis supports locating dependency declarations that use v
 
 ### Supported Package Managers
 
-* **NPM/YARN**: Fully supported with all semantic versioning operators (`=`, `!=`, `>`, `<`, `>=`, `<=`, `~`, `^`, `-`).
-* **PIP**: Partially supported with comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`). Note that Python's `~=` operator has different semantics than npm's `~` operator and is not currently supported.
+* **npm / yarn**: Fully supported with all semantic versioning operators (`=`, `>`, `<`, `>=`, `<=`, `~`, `^`, `-`).
+* **PIP**: Partially supported with comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`). <note type="note"> Python&apos;s <codeph>~=</codeph> operator has different semantics than npm <codeph>~</codeph> operator and is not currently supported. </note>
 
 ### Supported Operators
 
-The following version range operators are supported for NPM and YARN:
+The following version range operators are supported for npm and yarn:
 
 | Operator | Description | Example |
 |----------|-------------|---------|
 | `=` | Equal | `=1.2.3` |
-| `!=` | Not equal | `!=1.2.3` |
 | `>` | Greater than | `>1.2.3` |
 | `<` | Less than | `<2.0.0` |
 | `>=` | Greater than or equal | `>=1.2.3` |
@@ -110,5 +109,5 @@ When a version range operator is detected, the `operator` field appears in the `
 }
 ```
 
-<note type="note">Version range operators are not supported for Maven, Gradle, and NuGet at this time. These package managers use bracket notation for version ranges, which requires different parsing logic.</note>
+<note type="note">Version range operators are not supported for Maven, Gradle, or NuGet at this time. These package managers use bracket notation for version ranges, which requires different parsing logic.</note>
 

--- a/documentation/src/main/markdown/runningdetect/component-location-analysis.md
+++ b/documentation/src/main/markdown/runningdetect/component-location-analysis.md
@@ -72,12 +72,12 @@ Component Location Analysis supports locating dependency declarations that use v
 
 ### Supported Package Managers
 
-* **npm / yarn**: Fully supported with all semantic versioning operators (`=`, `>`, `<`, `>=`, `<=`, `~`, `^`, `-`).
+* **npm / Yarn**: Fully supported with all semantic versioning operators (`=`, `>`, `<`, `>=`, `<=`, `~`, `^`, `-`).
 * **PIP**: Partially supported with comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`). <note type="note"> Python&apos;s <codeph>~=</codeph> operator has different semantics than npm <codeph>~</codeph> operator and is not currently supported. </note>
 
 ### Supported Operators
 
-The following version range operators are supported for npm and yarn:
+The following version range operators are supported for npm and Yarn:
 
 | Operator | Description | Example |
 |----------|-------------|---------|

--- a/documentation/src/main/markdown/runningdetect/component-location-analysis.md
+++ b/documentation/src/main/markdown/runningdetect/component-location-analysis.md
@@ -65,3 +65,50 @@ Each component is uniquely identified by a name and version. Components may opti
 ## Rapid or Stateless Scan Mode Results
 
 When [detect_product_short] runs a Rapid or Stateless scan, the output file includes policy violation vulnerabilities, component violating policies, dependency trees for individual components and remediation guidance (short term, long term and transitive upgrade guidance) when available. This information is contained within the metadata field of each component.
+
+## Version Range Operator Support
+
+Component Location Analysis supports locating dependency declarations that use version range operators. When a version declaration uses a supported operator, an optional `operator` field is included in the `columnLocations` entry to indicate the specific operator used in the declaration.
+
+### Supported Package Managers
+
+* **NPM/YARN**: Fully supported with all semantic versioning operators (`=`, `!=`, `>`, `<`, `>=`, `<=`, `~`, `^`, `-`).
+* **PIP**: Partially supported with comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`). Note that Python's `~=` operator has different semantics than npm's `~` operator and is not currently supported.
+
+### Supported Operators
+
+The following version range operators are supported for NPM and YARN:
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | Equal | `=1.2.3` |
+| `!=` | Not equal | `!=1.2.3` |
+| `>` | Greater than | `>1.2.3` |
+| `<` | Less than | `<2.0.0` |
+| `>=` | Greater than or equal | `>=1.2.3` |
+| `<=` | Less than or equal | `<=2.0.0` |
+| `~` | Tilde range (patch updates) | `~1.2.3` (≥1.2.3, <1.3.0) |
+| `^` | Caret range (minor updates) | `^1.2.3` (≥1.2.3, <2.0.0) |
+| `-` | Hyphen range | `1.2 - 1.4.5` (≥1.2.0, ≤1.4.5) |
+
+For PIP, the comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`) are supported.
+
+### Output Format
+
+When a version range operator is detected, the `operator` field appears in the `columnLocations` entry:
+
+```json
+{
+    "lineNumber": 3753,
+    "columnLocations": [
+        {
+            "colStart": 22,
+            "colEnd": 27,
+            "operator": "^"
+        }
+    ]
+}
+```
+
+<note type="note">Version range operators are not supported for Maven, Gradle, and NuGet at this time. These package managers use bracket notation for version ranges, which requires different parsing logic.</note>
+


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-4168

**Description:**

This pull request bumps up the component-locator version to latest release version 2.4.1

The component-locator 2.4.1 adds version range operator support for `npm`, `yarn` detectors and `pip` detector partially.

Updated documentation and release notes to reflect the new version range operator support feature.