### PR TITLE
Bump CLL Version for Column Location Bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation "com.blackduck.integration:blackduck-common:${blackDuckCommonVersion}"
     implementation 'com.blackduck.integration:blackduck-upload-common:4.1.5'
     implementation 'com.blackducksoftware:method-analyzer-core:1.0.7'
-    implementation "${locatorGroup}:${locatorModule}:2.4.1"
+    implementation "${locatorGroup}:${locatorModule}:2.4.2"
 
     implementation 'org.apache.maven.shared:maven-invoker:3.0.0'
 


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5036

**Description:**

This pull request bumps up the component-locator version to latest release version 2.4.2

The `component-locator:2.4.2` aims to fix a regression where `colStart` in `components-with-locations.json` incorrectly pointed to the version operator character instead of the version string itself.