### PR TITLE
Update Release Notes for Go Version Support

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -33,6 +33,7 @@
   * Pnpm: 11.8.0
   * NPM: 11.13.0
   * Node.js: 24.17.0
+  * Go: 1.26.5
 
 ### Changed features
 * Added `detect.uv.dependency.groups.only` property for the UV CLI detector. To restrict scanning to specific dependency groups while excluding standard dependencies and optional extras, use this property. When set, Detect limits analysis to the explicitly listed dependency groups defined in the project's pyproject.toml. Multiple groups can be specified as a comma-separated list (e.g., `detect.uv.dependency.groups.only='dev,lint'`). This applies exclusively to groups under the `[dependency-groups]` section; extras under `[project.optional-dependencies]` are not included. If both this property and `detect.uv.dependency.groups.excluded` are configured, the exclusion setting takes precedence for any overlapping groups and Detect will log a warning.


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5205

**Description**

Go version support has been extended for the detect release 12.0
This pull request updates the `currentreleasenotes.md` with that support claim declaration.