### PR TITLE
Add 11.5.1 and update deprecation note for RPM-based linux

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -41,10 +41,11 @@
   * Poetry: 2.4.1
 
 ### Changed features
+
 * Added `detect.uv.dependency.groups.only` property for the UV CLI detector. To restrict scanning to specific dependency groups while excluding standard dependencies and optional extras, use this property. When set, Detect limits analysis to the explicitly listed dependency groups defined in the project's pyproject.toml. Multiple groups can be specified as a comma-separated list (e.g., `detect.uv.dependency.groups.only='dev,lint'`). This applies exclusively to groups under the `[dependency-groups]` section; extras under `[project.optional-dependencies]` are not included. If both this property and `detect.uv.dependency.groups.excluded` are configured, the exclusion setting takes precedence for any overlapping groups and Detect will log a warning.
 
-
 ### Dependency Updates
+
 * Update ANTLR library to version 4.13.2.
 * Update Jackson libraries to version 2.22.0.
 * Update Java minimum version to 11.

--- a/documentation/src/main/markdown/previousreleasenotes.md
+++ b/documentation/src/main/markdown/previousreleasenotes.md
@@ -1,15 +1,28 @@
 <!-- Check the support matrix to determine supported, non-current major version releases -->
 # Release notes for previous [detect_product_short] versions
 
+## Version 11.5.1
+
+### Resolved issues
+
+* (IDETECT-5207) Fixed an IndexOutOfBoundsException in component location analysis that was due to space characters within a version string.
+* (IDETECT-5247) Fixed a regression in the Gradle init script where phantom subprojects (modules without a build.gradle file) with dependencies declared in the root build.gradle were incorrectly assigned an empty configuration set, resulting in 0 components being detected.
+
+### Dependency Updates
+
+* Updated Component Locator Library to version 2.4.4
+
 ## Version 11.5.0
 
 ### Changed features
 
 * The default output directory of the Quack Patch feature has been updated to use [detect_product_short] scan output directory. For more information, see [Quack Patch Documentation](runningdetect/quack-patch.md).
-* CentOS support in Detect Docker Inspector has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](packagemgrs/docker/releasenotes.md).
+* Detect Docker Inspector support for RPM-based Linux platforms such as CentOS, and RedHat has been deprecated and will be removed in 12.0.0. For more details, please see [Docker Inspector Release Notes](packagemgrs/docker/releasenotes.md).
     * imageinspector.service.port.centos has been deprecated and will be removed in 12.0.0.
 * Clarified documentation for `--detect.uv.dependency.groups.excluded`. Optional is not a dependency group in uv but a section defining extras, therefor supplying `optional` as a value has no effect and exclusions must reference the extra name directly (e.g., postgres, redis).
+
 ### Resolved issues
+
 * (IDETECT-5125) Fixed failure during Python scans when the `requirements.txt` file contains Python extras syntax using square brackets, e.g.: `kopf[dev]>=1.3`
 * (IDETECT-5090) Fixed PIP Native Inspector failure to parse `requirements.txt` lines that contain [PEP 508 environment markers](https://peps.python.org/pep-0508/).
 * (IDETECT-5056) Fixed a Cargo Lock detector failure to parse the caret symbol '^' used in `Cargo.toml` dependency declarations.
@@ -39,6 +52,7 @@
 ## Version 11.4.1
 
 ### Dependency Updates
+
 * Upgraded and released Nuget Inspector version 2.6.0
 
 ## Version 11.4.0
@@ -70,6 +84,7 @@
 * (IDETECT-4993) Fixed an issue where the Go Module Detector entered an infinite loop while scanning `go.mod` files containing circular dependencies.
 
 ### Dependency Updates
+
 * Update tomlj library to version 1.1.1.
 
 ## Version 11.3.0


### PR DESCRIPTION
Add 11.5.1 and update deprecation note for RPM-based Linux