### PR TITLE
fix test file autonomousScanModeOFFLINETest

### DIFF
--- a/src/test/java/com/blackduck/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/AutonomousScanTests.java
@@ -19,10 +19,13 @@ public class AutonomousScanTests {
 
     public static String ARTIFACTORY_URL = System.getenv().get("SNPS_INTERNAL_ARTIFACTORY");
 
-//    @Test
+    @Test
     void autonomousScanModeOFFLINETest() throws Exception {
-        try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-1", "detect-9.8.0:1.0.1")) {
-            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("Detect-9.8.0.dockerfile"));
+        // Uses a small, self-contained Gradle project baked into the image (see
+        // AutonomousScanOffline.dockerfile). Previously scanned the entire Detect 9.8
+        // source tree, which caused CI timeouts. See ticket for details.
+        try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-1", "autonomous-scan-offline:1.0.0")) {
+            test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("AutonomousScanOffline.dockerfile"));
 
             DetectCommandBuilder commandBuilder = new DetectCommandBuilder().defaults().defaultDirectories(test);
             commandBuilder.waitForResults();

--- a/src/test/java/com/blackduck/integration/detect/battery/docker/AutonomousScanTests.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/docker/AutonomousScanTests.java
@@ -21,9 +21,8 @@ public class AutonomousScanTests {
 
     @Test
     void autonomousScanModeOFFLINETest() throws Exception {
-        // Uses a small, self-contained Gradle project baked into the image (see
-        // AutonomousScanOffline.dockerfile). Previously scanned the entire Detect 9.8
-        // source tree, which caused CI timeouts. See ticket for details.
+        // Fixture is a minimal Gradle project inlined into the image
+        // (see AutonomousScanOffline.dockerfile).
         try (DetectDockerTestRunner test = new DetectDockerTestRunner("autonomous-scan-mode-test-1", "autonomous-scan-offline:1.0.0")) {
             test.withImageProvider(BuildDockerImageProvider.forDockerfilResourceNamed("AutonomousScanOffline.dockerfile"));
 
@@ -34,6 +33,10 @@ public class AutonomousScanTests {
 
             commandBuilder.property(DetectProperties.DETECT_AUTONOMOUS_SCAN_ENABLED, String.valueOf(true));
             commandBuilder.property(DetectProperties.DETECT_BLACKDUCK_SCAN_MODE, scanMode);
+            // No blackduck.url and no blackduck.offline.mode is intentional: with RAPID,
+            // setting offline.mode makes ProductDecider skip Black Duck entirely.
+            // Autonomous mode instead elects to run offline on its own, which is the
+            // path this test exercises.
             DockerAssertions dockerAssertions = test.run(commandBuilder);
 
             dockerAssertions.bdioFiles(1);

--- a/src/test/resources/docker/AutonomousScanOffline.dockerfile
+++ b/src/test/resources/docker/AutonomousScanOffline.dockerfile
@@ -1,0 +1,32 @@
+# Small, self-contained fixture for AutonomousScanTests.autonomousScanModeOFFLINETest.
+#
+# The test only asserts that when autonomous scan mode is enabled under RAPID with
+# offline mode, Detect produces:
+#   - one BDIO file,
+#   - a scan-settings JSON, and
+#   - the scan-settings JSON contains a GRADLE detector entry that includes the
+#     `detect.gradle.configuration.types.excluded` property.
+#
+# Any trivial Gradle project where Detect's Gradle detector fires satisfies all
+# of the above. This dockerfile inlines a minimal single-module Gradle project
+# so image build takes seconds, replacing the previous full clone + `gradlew build`
+# of the Detect 9.8 repository which caused CI timeouts.
+FROM gradle:8.10.2-jdk17
+
+# Do not change SRC_DIR, value is expected by tests
+ENV SRC_DIR=/opt/project/src
+ENV JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2"
+
+USER root
+
+RUN mkdir -p ${SRC_DIR}
+WORKDIR ${SRC_DIR}
+
+# Inline the fixture Gradle project.
+RUN printf 'rootProject.name = "autonomous-scan-fixture"\n' > settings.gradle \
+ && printf 'plugins { id "java" }\nrepositories { mavenCentral() }\ndependencies { implementation "org.apache.commons:commons-lang3:3.14.0" }\n' > build.gradle
+
+# Warm the Gradle cache at image-build time so the scan itself does not pay
+# the plugin/dependency download cost and is less network-dependent at runtime.
+RUN gradle --no-daemon --quiet dependencies
+


### PR DESCRIPTION
**What the test did**

The test exercised Detect's autonomous scan feature in RAPID mode against a Gradle project inside a Docker container, asserting that a BDIO file and a scan-settings JSON were produced with the expected keys. The Docker image it used, however, first cloned the entire Black Duck Detect 9.8 repository from GitHub and ran a full ./gradlew build on it solely to have a Gradle project to scan — a setup that routinely timed out on CI and was the reason the test had been disabled.

**What we changed**

Replaced the old Dockerfile with a new one (AutonomousScanOffline.dockerfile) that uses gradle:8.10.2-jdk17 and inlines a minimal two-file Gradle project (one settings.gradle, one build.gradle with a single dependency), warming the Gradle cache once at image build time. The test was re-enabled and repointed to the new Dockerfile; no assertion logic was changed.

**Why**

The old fixture was significantly oversized relative to what the test actually verifies — the assertions require only a Gradle project where Detect's Gradle detector fires. The new minimal fixture provides exactly that — it’s fast, stable, and preserves the same test coverage.