### PR TITLE
deprecate detect docker properties

### DIFF
--- a/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/property/AllEnumListProperty.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/property/AllEnumListProperty.java
@@ -48,6 +48,11 @@ public class AllEnumListProperty<B extends Enum<B>> extends ExtendedEnumListProp
         ));
     }
 
+    public AllEnumListProperty<B> deprecateValue(B value, String reason) {
+        addDeprecatedBaseValue(value, reason);
+        return this;
+    }
+
     public AllEnumList<B> toList(List<ExtendedEnumValue<AllEnum, B>> values) {
         return new AllEnumList<>(values, bClass);
     }

--- a/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/property/NoneEnumListProperty.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumallnone/property/NoneEnumListProperty.java
@@ -40,6 +40,11 @@ public class NoneEnumListProperty<B extends Enum<B>> extends ExtendedEnumListPro
         ));
     }
 
+    public NoneEnumListProperty<B> deprecateValue(B value, String reason) {
+        addDeprecatedBaseValue(value, reason);
+        return this;
+    }
+
     public NoneEnumList<B> toList(List<ExtendedEnumValue<NoneEnum, B>> values) {
         return new NoneEnumList<>(values, bClass);
     }

--- a/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumextended/ExtendedEnumListPropertyBase.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enumextended/ExtendedEnumListPropertyBase.java
@@ -58,22 +58,38 @@ public abstract class ExtendedEnumListPropertyBase<E extends Enum<E>, B extends 
     }
 
     List<E> deprecatedExtendedValues = new ArrayList<>();
+    List<B> deprecatedBaseValues = new ArrayList<>();
 
     public void deprecateExtendedValue(E value, String reason) {
         deprecatedExtendedValues.add(value);
         addDeprecatedValueInfo(value.toString(), reason);
     }
 
+    protected void addDeprecatedBaseValue(B value, String reason) {
+        deprecatedBaseValues.add(value);
+        addDeprecatedValueInfo(value.toString(), reason);
+    }
+
     @Override
     @NotNull
     public List<DeprecatedValueUsage> checkForDeprecatedValues(List<ExtendedEnumValue<E, B>> value) {
-        return value.stream()
+        List<DeprecatedValueUsage> result = new ArrayList<>();
+        value.stream()
             .filter(element -> element.getExtendedValue().isPresent())
             .map(element -> element.getExtendedValue().get())
             .filter(deprecatedExtendedValues::contains)
             .map(element -> createDeprecatedValueUsageIfExists(element.toString()))
             .filter(Optional::isPresent)
             .map(Optional::get)
-            .collect(Collectors.toList());
+            .forEach(result::add);
+        value.stream()
+            .filter(element -> element.getBaseValue().isPresent())
+            .map(element -> element.getBaseValue().get())
+            .filter(deprecatedBaseValues::contains)
+            .map(element -> createDeprecatedValueUsageIfExists(element.toString()))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .forEach(result::add);
+        return result;
     }
 }

--- a/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enums/EnumListProperty.java
+++ b/configuration/src/main/java/com/blackduck/integration/configuration/property/types/enums/EnumListProperty.java
@@ -1,6 +1,9 @@
 package com.blackduck.integration.configuration.property.types.enums;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -8,16 +11,35 @@ import org.jetbrains.annotations.Nullable;
 import com.blackduck.integration.configuration.parse.ListValueParser;
 import com.blackduck.integration.configuration.property.PropertyBuilder;
 import com.blackduck.integration.configuration.property.base.ValuedAlikeListProperty;
+import com.blackduck.integration.configuration.property.deprecation.DeprecatedValueUsage;
 import com.blackduck.integration.configuration.util.EnumPropertyUtils;
 import com.blackduck.integration.configuration.util.PropertyUtils;
 
 public class EnumListProperty<E extends Enum<E>> extends ValuedAlikeListProperty<E> {
     @NotNull
     private final Class<E> enumClass;
+    private final List<E> deprecatedValues = new ArrayList<>();
 
     public EnumListProperty(@NotNull String key, @NotNull List<E> defaultValue, @NotNull Class<E> enumClass) {
         super(key, new ListValueParser<>(new EnumValueParser<>(enumClass)), defaultValue);
         this.enumClass = enumClass;
+    }
+
+    public EnumListProperty<E> deprecateValue(E value, String reason) {
+        deprecatedValues.add(value);
+        addDeprecatedValueInfo(value.toString(), reason);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public List<DeprecatedValueUsage> checkForDeprecatedValues(List<E> value) {
+        return value.stream()
+            .filter(deprecatedValues::contains)
+            .map(element -> createDeprecatedValueUsageIfExists(element.toString()))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
     }
 
     public static <E extends Enum<E>> PropertyBuilder<EnumListProperty<E>> newBuilder(@NotNull String key, @NotNull List<E> defaultValue, @NotNull Class<E> enumClass) {

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -46,6 +46,7 @@ import com.blackduck.integration.configuration.property.types.string.StringPrope
 import com.blackduck.integration.detect.configuration.enumeration.BlackduckScanMode;
 import com.blackduck.integration.detect.configuration.enumeration.DetectCategory;
 import com.blackduck.integration.detect.configuration.enumeration.DetectGroup;
+import com.blackduck.integration.detect.configuration.enumeration.DetectMajorVersion;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTargetType;
 import com.blackduck.integration.detect.configuration.enumeration.DetectTool;
 import com.blackduck.integration.detect.configuration.enumeration.RapidCompareMode;
@@ -786,7 +787,6 @@ public class DetectProperties {
             .setCategory(DetectCategory.Advanced)
             .build();
 
-    // TODO: This could go away if we more tightly integrated Docker Inspector code within Detect. Yuuuge effort
     public static final PassthroughProperty DOCKER_PASSTHROUGH =
         PassthroughProperty.newBuilder("detect.docker.passthrough")
             .setInfo("Docker Passthrough", DetectPropertyFromVersion.VERSION_6_0_0)
@@ -795,6 +795,7 @@ public class DetectProperties {
             .setGroups(DetectGroup.DOCKER, DetectGroup.DEFAULT)
             .setCategory(DetectCategory.Advanced)
             .setExample("(This example is unusual in that it shows a complete propertyname=value) detect.docker.passthrough.imageinspector.service.log.length=1000")
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullableStringProperty DETECT_DOCKER_IMAGE =
@@ -806,6 +807,7 @@ public class DetectProperties {
             )
             .setExample("ubuntu:22.04")
             .setGroups(DetectGroup.DOCKER, DetectGroup.SOURCE_PATH)
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullableStringProperty DETECT_DOCKER_IMAGE_ID =
@@ -818,6 +820,7 @@ public class DetectProperties {
             .setExample("0d120b6ccaa8")
             .setGroups(DetectGroup.DOCKER, DetectGroup.SOURCE_PATH)
             .setExample("fe1cc5b91830")
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullablePathProperty DETECT_DOCKER_INSPECTOR_PATH =
@@ -828,6 +831,7 @@ public class DetectProperties {
             )
             .setGroups(DetectGroup.DOCKER, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced)
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullableStringProperty DETECT_DOCKER_INSPECTOR_VERSION =
@@ -837,15 +841,16 @@ public class DetectProperties {
             .setGroups(DetectGroup.DOCKER, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced)
             .setExample("9.1.1")
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
-    // The docker exe is only used in air gap mode to load image tarfiles (from the air gap files) for docker inspector
     public static final NullablePathProperty DETECT_DOCKER_PATH =
         NullablePathProperty.newBuilder("detect.docker.path")
             .setInfo("Docker Executable", DetectPropertyFromVersion.VERSION_3_0_0)
             .setHelp("Path to the docker executable (used to load image inspector Docker images in order to run the Docker Inspector in air gap mode).")
             .setExample("/usr/local/bin/docker")
             .setGroups(DetectGroup.DOCKER, DetectGroup.GLOBAL)
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullableStringProperty DETECT_DOCKER_PLATFORM_TOP_LAYER_ID =
@@ -858,6 +863,7 @@ public class DetectProperties {
             .setGroups(DetectGroup.DOCKER, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced)
             .setExample("sha256:f6253634dc78da2f2e3bee9c8063593f880dc35d701307f30f65553e0f50c18c")
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NullableStringProperty DETECT_DOCKER_TAR =
@@ -871,6 +877,7 @@ public class DetectProperties {
             )
             .setExample("./ubuntu21_04.tar")
             .setGroups(DetectGroup.DOCKER, DetectGroup.SOURCE_PATH)
+            .setDeprecated("Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final NoneEnumListProperty<DetectorType> DETECT_EXCLUDED_DETECTOR_TYPES =
@@ -1212,6 +1219,7 @@ public class DetectProperties {
             .setHelp("Path to the Java executable used by Docker Inspector.", "If set, Detect will use the given Java executable instead of searching for one.")
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .setExample("/usr/lib/jvm/jdk-17/bin/java")
+            .setDeprecated("This property is only used by Docker Inspector. Docker Inspector support is deprecated.", DetectMajorVersion.THIRTEEN)
             .build();
 
     public static final CaseSensitiveStringListProperty DETECT_LERNA_EXCLUDED_PACKAGES =
@@ -1801,7 +1809,8 @@ public class DetectProperties {
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
             .setCategory(DetectCategory.Advanced)
-            .build();
+            .build()
+            .deprecateValue(DetectTool.DOCKER, "Docker Inspector support is deprecated. The DOCKER tool value will be removed in a future release.");
 
     public static final EnumProperty<ProjectVersionDistributionType> DETECT_PROJECT_VERSION_DISTRIBUTION =
         EnumProperty.newBuilder("detect.project.version.distribution", ProjectVersionDistributionType.EXTERNAL, ProjectVersionDistributionType.class)
@@ -2059,7 +2068,8 @@ public class DetectProperties {
                     "If neither detect.tools nor detect.tools.excluded are set, Detect will allow (run if applicable, based on the values of other properties) all Detect tools. If detect.tools is set, and detect.tools.excluded is not set, Detect will only allow to run those tools that are specified in the detect.tools list. If detect.tools.excluded is set, Detect will only allow those tools that are not specified in the detect.tools.excluded list."
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
-            .build();
+            .build()
+            .deprecateValue(DetectTool.DOCKER, "Docker Inspector support is deprecated. The DOCKER tool value will be removed in a future release.");
 
     public static final AllEnumListProperty<DetectTool> DETECT_TOOLS =
         AllEnumListProperty.newBuilder("detect.tools", emptyList(), DetectTool.class)
@@ -2070,7 +2080,8 @@ public class DetectProperties {
                     "If neither detect.tools nor detect.tools.excluded are set, Detect will allow (run if applicable, based on the values of other properties) all non-exclusive Detect tools. If detect.tools is set, and detect.tools.excluded is not set, Detect will run those tools that are specified in the detect.tools list. If detect.tools.excluded is set, Detect will only allow those tools that are not specified in the detect.tools.excluded list."
             )
             .setGroups(DetectGroup.PATHS, DetectGroup.GLOBAL)
-            .build();
+            .build()
+            .deprecateValue(DetectTool.DOCKER, "Docker Inspector support is deprecated. The DOCKER tool value will be removed in a future release.");
 
     public static final NullablePathProperty DETECT_UV_PATH =
             NullablePathProperty.newBuilder("detect.uv.path")

--- a/src/main/java/com/blackduck/integration/detect/configuration/enumeration/DetectMajorVersion.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/enumeration/DetectMajorVersion.java
@@ -14,6 +14,8 @@ public class DetectMajorVersion extends ProductMajorVersion {
     public static final DetectMajorVersion NINE = new DetectMajorVersion(9);
     public static final DetectMajorVersion TEN = new DetectMajorVersion(10);
     public static final DetectMajorVersion ELEVEN = new DetectMajorVersion(11);
+    public static final DetectMajorVersion TWELVE = new DetectMajorVersion(12);
+    public static final DetectMajorVersion THIRTEEN = new DetectMajorVersion(13);
 
     public DetectMajorVersion(Integer intValue) {
         super(intValue);

--- a/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import com.blackduck.integration.configuration.config.PropertyConfiguration;
 import com.blackduck.integration.configuration.help.PropertyConfigurationHelpContext;
+import com.blackduck.integration.configuration.property.Property;
+import com.blackduck.integration.configuration.property.base.PassthroughProperty;
 import com.blackduck.integration.configuration.property.base.TypedProperty;
 import com.blackduck.integration.configuration.property.deprecation.DeprecatedValueUsage;
 import com.blackduck.integration.detect.configuration.DetectProperties;
@@ -39,10 +41,17 @@ public class DetectConfigurationBootManager {
     public List<RemovalDeprecation> checkForUsedRemovalDeprecations(PropertyConfiguration detectConfiguration) {
         return DetectProperties.allProperties().getProperties()
             .stream()
-            .filter(property -> detectConfiguration.wasKeyProvided(property.getKey()))
+            .filter(property -> wasProvided(property, detectConfiguration))
             .filter(property -> property.getPropertyDeprecationInfo().getRemovalInfo().isPresent())
             .map(property -> new RemovalDeprecation(property.getKey(), property.getPropertyDeprecationInfo().getRemovalInfo().get().getDeprecationText()))
             .collect(Collectors.toList());
+    }
+
+    private boolean wasProvided(Property property, PropertyConfiguration detectConfiguration) {
+        if (property instanceof PassthroughProperty) {
+            return !detectConfiguration.getRaw((PassthroughProperty) property).isEmpty();
+        }
+        return detectConfiguration.wasKeyProvided(property.getKey());
     }
 
     public List<ValueDeprecation> checkForUsedValueDeprecations(PropertyConfiguration detectConfiguration) {

--- a/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
@@ -39,19 +39,20 @@ public class DetectConfigurationBootManager {
     }
 
     public List<RemovalDeprecation> checkForUsedRemovalDeprecations(PropertyConfiguration detectConfiguration) {
-        return DetectProperties.allProperties().getProperties()
-            .stream()
-            .filter(property -> wasProvided(property, detectConfiguration))
-            .filter(property -> property.getPropertyDeprecationInfo().getRemovalInfo().isPresent())
-            .map(property -> new RemovalDeprecation(property.getKey(), property.getPropertyDeprecationInfo().getRemovalInfo().get().getDeprecationText()))
-            .collect(Collectors.toList());
-    }
-
-    private boolean wasProvided(Property property, PropertyConfiguration detectConfiguration) {
-        if (property instanceof PassthroughProperty) {
-            return !detectConfiguration.getRaw((PassthroughProperty) property).isEmpty();
+        List<RemovalDeprecation> result = new ArrayList<>();
+        for (Property property : DetectProperties.allProperties().getProperties()) {
+            if (!property.getPropertyDeprecationInfo().getRemovalInfo().isPresent()) continue;
+            String deprecationText = property.getPropertyDeprecationInfo().getRemovalInfo().get().getDeprecationText();
+            if (property instanceof PassthroughProperty) {
+                PassthroughProperty passthrough = (PassthroughProperty) property;
+                detectConfiguration.getRaw(passthrough).keySet().stream()
+                    .map(subKey -> new RemovalDeprecation(passthrough.getKey() + "." + subKey, deprecationText))
+                    .forEach(result::add);
+            } else if (detectConfiguration.wasKeyProvided(property.getKey())) {
+                result.add(new RemovalDeprecation(property.getKey(), deprecationText));
+            }
         }
-        return detectConfiguration.wasKeyProvided(property.getKey());
+        return result;
     }
 
     public List<ValueDeprecation> checkForUsedValueDeprecations(PropertyConfiguration detectConfiguration) {

--- a/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/validation/DetectConfigurationBootManager.java
@@ -44,6 +44,8 @@ public class DetectConfigurationBootManager {
             if (!property.getPropertyDeprecationInfo().getRemovalInfo().isPresent()) continue;
             String deprecationText = property.getPropertyDeprecationInfo().getRemovalInfo().get().getDeprecationText();
             if (property instanceof PassthroughProperty) {
+                // Passthrough sub-keys (e.g. detect.docker.passthrough.service.timeout) are never provided
+                // under the bare prefix key, so emit one entry per sub-key to match the printed log key.
                 PassthroughProperty passthrough = (PassthroughProperty) property;
                 detectConfiguration.getRaw(passthrough).keySet().stream()
                     .map(subKey -> new RemovalDeprecation(passthrough.getKey() + "." + subKey, deprecationText))


### PR DESCRIPTION
Deprecates all Docker Inspector support in preparation for removal in 13.0.0.

Properties deprecated: all detect.docker.* properties, detect.java.path (exclusively used by Docker Inspector), and the DOCKER value on detect.tools, detect.tools.excluded, and detect.project.tool.

Extended value deprecation runtime checking to list property types (EnumListProperty, AllEnumListProperty, NoneEnumListProperty) so specifying a deprecated enum value in a list property triggers *** DEPRECATED VALUE ***, matching the behavior already present on single-value EnumProperty.

Passthrough deprecation fix done for detect.docker.passthrough.* sub-keys. For example, detect.docker.passthrough.service.timeout now correctly show *** DEPRECATED *** in the property log. Previously the check used an exact key match against the passthrough prefix, which users never set directly.