### PR TITLE
IDETECT-5220 - feat(PNPM): Improve workspace discovery INFO/DEBUG log messages for better scan visibility

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -23,7 +22,6 @@ import com.blackduck.integration.util.NameVersion;
 public class PnpmLockYamlParser {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final Predicate<String> isNodeRoot = "."::equals;
 
     private PnpmYamlTransformer pnpmTransformer;
 
@@ -98,7 +96,7 @@ public class PnpmLockYamlParser {
                     projectNameVersion);
 
             String reportingProjectPackagePath = null;
-            if (!isNodeRoot.evaluate(projectKey)) {
+            if (!PnpmWorkspaceDependencySummary.IS_NODE_ROOT.evaluate(projectKey)) {
                 reportingProjectPackagePath = projectKey;
             }
             File generatedSourcePath = generateCodeLocationSourcePath(sourcePath, reportingProjectPackagePath);
@@ -114,7 +112,7 @@ public class PnpmLockYamlParser {
 
     private NameVersion extractProjectInfo(Map.Entry<String, PnpmProjectPackage> projectPackageInfo,
             PnpmLinkedPackageResolver linkedPackageResolver, @Nullable NameVersion projectNameVersion) {
-        if (isNodeRoot.evaluate(projectPackageInfo.getKey()) && projectNameVersion != null
+        if (PnpmWorkspaceDependencySummary.IS_NODE_ROOT.evaluate(projectPackageInfo.getKey()) && projectNameVersion != null
                 && projectNameVersion.getName() != null) {
             // resolve "." package to project root
             return projectNameVersion;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
@@ -2,13 +2,9 @@ package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.Predicate;
@@ -17,8 +13,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.blackduck.integration.bdio.graph.DependencyGraph;
-import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYaml;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmProjectPackage;
@@ -66,8 +60,9 @@ public class PnpmLockYamlParser {
             return Collections.emptyList();
         }
 
-        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s): {}",
-            pnpmLockYaml.importers.size(), pnpmLockYaml.importers.keySet());
+        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s).",
+            pnpmLockYaml.importers.size());
+        logger.debug("PNPM workspace module paths: {}", pnpmLockYaml.importers.keySet());
         logger.info("Subdirectory package.json files in workspace modules do not need to be processed separately; "
             + "all dependency information is already contained in the root pnpm-lock.yaml.");
 
@@ -110,7 +105,7 @@ public class PnpmLockYamlParser {
 
             CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(generatedSourcePath, projectPackage,
                     reportingProjectPackagePath, extractedNameVersion, pnpmLockYaml.packages, linkedPackageResolver, pnpmLockYaml.snapshots);
-            logWorkspaceModuleSummary(projectKey, codeLocation.getDependencyGraph());
+            PnpmWorkspaceDependencySummary.logModuleSummary(logger, projectKey, codeLocation.getDependencyGraph());
             codeLocations.add(codeLocation);
         }
 
@@ -135,33 +130,5 @@ public class PnpmLockYamlParser {
             return new File(sourcePath, reportingProjectPackagePath);
         }
         return sourcePath;
-    }
-
-    private void logWorkspaceModuleSummary(String projectKey, DependencyGraph graph) {
-        String moduleLabel = isNodeRoot.evaluate(projectKey) ? "(root)" : projectKey;
-        Set<Dependency> allDeps = collectAllDependencies(graph);
-        int directCount = graph.getRootDependencies().size();
-        int transitiveCount = allDeps.size() - directCount;
-        logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
-            moduleLabel, directCount, transitiveCount);
-        if (logger.isDebugEnabled()) {
-            List<String> depNames = allDeps.stream()
-                .map(dep -> dep.getName() + "@" + dep.getVersion())
-                .sorted()
-                .collect(Collectors.toList());
-            logger.debug("Workspace module '{}' full dependency list: {}", moduleLabel, depNames);
-        }
-    }
-
-    private Set<Dependency> collectAllDependencies(DependencyGraph graph) {
-        Set<Dependency> visited = new HashSet<>();
-        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
-        while (!queue.isEmpty()) {
-            Dependency dep = queue.poll();
-            if (visited.add(dep)) {
-                queue.addAll(graph.getChildrenForParent(dep));
-            }
-        }
-        return visited;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParser.java
@@ -2,9 +2,13 @@ package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.Predicate;
@@ -13,6 +17,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYaml;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmProjectPackage;
@@ -60,6 +66,11 @@ public class PnpmLockYamlParser {
             return Collections.emptyList();
         }
 
+        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s): {}",
+            pnpmLockYaml.importers.size(), pnpmLockYaml.importers.keySet());
+        logger.info("Subdirectory package.json files in workspace modules do not need to be processed separately; "
+            + "all dependency information is already contained in the root pnpm-lock.yaml.");
+
         if (pnpmLockYaml.packages == null) {
             logger.warn("The pnpm-lock.yaml file contains {} importer(s) {} but has no 'packages' section. "
                 + "No resolved dependencies are available. All workspaces will have empty dependency graphs.",
@@ -82,7 +93,7 @@ public class PnpmLockYamlParser {
                 // skip as the user specified filters and this projectKey is not something they want
                 continue;
             }
-            
+
             PnpmProjectPackage projectPackage = projectPackageInfo.getValue();
             if (projectPackage == null) {
                 logger.warn("Importer '{}' has no content (null). Treating as empty (no dependencies).", projectKey);
@@ -97,8 +108,10 @@ public class PnpmLockYamlParser {
             }
             File generatedSourcePath = generateCodeLocationSourcePath(sourcePath, reportingProjectPackagePath);
 
-            codeLocations.add(pnpmTransformer.generateCodeLocation(generatedSourcePath, projectPackage,
-                    reportingProjectPackagePath, extractedNameVersion, pnpmLockYaml.packages, linkedPackageResolver, pnpmLockYaml.snapshots));
+            CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(generatedSourcePath, projectPackage,
+                    reportingProjectPackagePath, extractedNameVersion, pnpmLockYaml.packages, linkedPackageResolver, pnpmLockYaml.snapshots);
+            logWorkspaceModuleSummary(projectKey, codeLocation.getDependencyGraph());
+            codeLocations.add(codeLocation);
         }
 
         return codeLocations;
@@ -122,5 +135,33 @@ public class PnpmLockYamlParser {
             return new File(sourcePath, reportingProjectPackagePath);
         }
         return sourcePath;
+    }
+
+    private void logWorkspaceModuleSummary(String projectKey, DependencyGraph graph) {
+        String moduleLabel = isNodeRoot.evaluate(projectKey) ? "(root)" : projectKey;
+        Set<Dependency> allDeps = collectAllDependencies(graph);
+        int directCount = graph.getRootDependencies().size();
+        int transitiveCount = allDeps.size() - directCount;
+        logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
+            moduleLabel, directCount, transitiveCount);
+        if (logger.isDebugEnabled()) {
+            List<String> depNames = allDeps.stream()
+                .map(dep -> dep.getName() + "@" + dep.getVersion())
+                .sorted()
+                .collect(Collectors.toList());
+            logger.debug("Workspace module '{}' full dependency list: {}", moduleLabel, depNames);
+        }
+    }
+
+    private Set<Dependency> collectAllDependencies(DependencyGraph graph) {
+        Set<Dependency> visited = new HashSet<>();
+        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
+        while (!queue.isEmpty()) {
+            Dependency dep = queue.poll();
+            if (visited.add(dep)) {
+                queue.addAll(graph.getChildrenForParent(dep));
+            }
+        }
+        return visited;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -22,7 +21,6 @@ import com.blackduck.integration.util.NameVersion;
 public class PnpmLockYamlParserv5 {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final Predicate<String> isNodeRoot = "."::equals;
 
     private PnpmYamlTransformerv5 pnpmTransformer;
 
@@ -83,7 +81,7 @@ public class PnpmLockYamlParserv5 {
             NameVersion extractedNameVersion = extractProjectInfo(projectPackageInfo, linkedPackageResolver, projectNameVersion);
 
             String reportingProjectPackagePath = null;
-            if (!isNodeRoot.evaluate(projectKey)) {
+            if (!PnpmWorkspaceDependencySummary.IS_NODE_ROOT.evaluate(projectKey)) {
                 reportingProjectPackagePath = projectKey;
             }
             File generatedSourcePath = generateCodeLocationSourcePath(sourcePath, reportingProjectPackagePath);
@@ -108,7 +106,7 @@ public class PnpmLockYamlParserv5 {
         PnpmLinkedPackageResolver linkedPackageResolver,
         @Nullable NameVersion projectNameVersion
     ) {
-        if (isNodeRoot.evaluate(projectPackageInfo.getKey()) && projectNameVersion != null && projectNameVersion.getName() != null) {
+        if (PnpmWorkspaceDependencySummary.IS_NODE_ROOT.evaluate(projectPackageInfo.getKey()) && projectNameVersion != null && projectNameVersion.getName() != null) {
             // resolve "." package to project root
             return projectNameVersion;
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
@@ -2,13 +2,9 @@ package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.Predicate;
@@ -17,8 +13,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.blackduck.integration.bdio.graph.DependencyGraph;
-import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYamlv5;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmProjectPackagev5;
@@ -27,7 +21,7 @@ import com.blackduck.integration.util.NameVersion;
 
 public class PnpmLockYamlParserv5 {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    
+
     private static final Predicate<String> isNodeRoot = "."::equals;
 
     private PnpmYamlTransformerv5 pnpmTransformer;
@@ -45,7 +39,6 @@ public class PnpmLockYamlParserv5 {
         }
         return codeLocationsFromImports;
     }
-    
 
     private List<CodeLocation> createCodeLocationsFromRoot(
         File sourcePath,
@@ -70,8 +63,9 @@ public class PnpmLockYamlParserv5 {
             return Collections.emptyList();
         }
 
-        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s): {}",
-            pnpmLockYaml.importers.size(), pnpmLockYaml.importers.keySet());
+        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s).",
+            pnpmLockYaml.importers.size());
+        logger.debug("PNPM workspace module paths: {}", pnpmLockYaml.importers.keySet());
         logger.info("Subdirectory package.json files in workspace modules do not need to be processed separately; "
             + "all dependency information is already contained in the root pnpm-lock.yaml.");
 
@@ -102,7 +96,7 @@ public class PnpmLockYamlParserv5 {
                 pnpmLockYaml.packages,
                 linkedPackageResolver
             );
-            logWorkspaceModuleSummary(projectKey, codeLocation.getDependencyGraph());
+            PnpmWorkspaceDependencySummary.logModuleSummary(logger, projectKey, codeLocation.getDependencyGraph());
             codeLocations.add(codeLocation);
         }
 
@@ -129,33 +123,5 @@ public class PnpmLockYamlParserv5 {
             return new File(sourcePath, reportingProjectPackagePath);
         }
         return sourcePath;
-    }
-
-    private void logWorkspaceModuleSummary(String projectKey, DependencyGraph graph) {
-        String moduleLabel = isNodeRoot.evaluate(projectKey) ? "(root)" : projectKey;
-        Set<Dependency> allDeps = collectAllDependencies(graph);
-        int directCount = graph.getRootDependencies().size();
-        int transitiveCount = allDeps.size() - directCount;
-        logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
-            moduleLabel, directCount, transitiveCount);
-        if (logger.isDebugEnabled()) {
-            List<String> depNames = allDeps.stream()
-                .map(dep -> dep.getName() + "@" + dep.getVersion())
-                .sorted()
-                .collect(Collectors.toList());
-            logger.debug("Workspace module '{}' full dependency list: {}", moduleLabel, depNames);
-        }
-    }
-
-    private Set<Dependency> collectAllDependencies(DependencyGraph graph) {
-        Set<Dependency> visited = new HashSet<>();
-        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
-        while (!queue.isEmpty()) {
-            Dependency dep = queue.poll();
-            if (visited.add(dep)) {
-                queue.addAll(graph.getChildrenForParent(dep));
-            }
-        }
-        return visited;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmLockYamlParserv5.java
@@ -2,9 +2,13 @@ package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.Predicate;
@@ -13,6 +17,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmLockYamlv5;
 import com.blackduck.integration.detectable.detectables.pnpm.lockfile.model.PnpmProjectPackagev5;
@@ -64,6 +70,11 @@ public class PnpmLockYamlParserv5 {
             return Collections.emptyList();
         }
 
+        logger.info("PNPM workspace detected in pnpm-lock.yaml. Found {} workspace module(s): {}",
+            pnpmLockYaml.importers.size(), pnpmLockYaml.importers.keySet());
+        logger.info("Subdirectory package.json files in workspace modules do not need to be processed separately; "
+            + "all dependency information is already contained in the root pnpm-lock.yaml.");
+
         if (pnpmLockYaml.packages == null) {
             logger.warn("The pnpm-lock.yaml file contains {} importer(s) {} but has no 'packages' section. "
                 + "No resolved dependencies are available. All workspaces will have empty dependency graphs.",
@@ -83,14 +94,16 @@ public class PnpmLockYamlParserv5 {
             }
             File generatedSourcePath = generateCodeLocationSourcePath(sourcePath, reportingProjectPackagePath);
 
-            codeLocations.add(pnpmTransformer.generateCodeLocation(
+            CodeLocation codeLocation = pnpmTransformer.generateCodeLocation(
                 generatedSourcePath,
                 projectPackage,
                 reportingProjectPackagePath,
                 extractedNameVersion,
                 pnpmLockYaml.packages,
                 linkedPackageResolver
-            ));
+            );
+            logWorkspaceModuleSummary(projectKey, codeLocation.getDependencyGraph());
+            codeLocations.add(codeLocation);
         }
 
         return codeLocations;
@@ -116,5 +129,33 @@ public class PnpmLockYamlParserv5 {
             return new File(sourcePath, reportingProjectPackagePath);
         }
         return sourcePath;
+    }
+
+    private void logWorkspaceModuleSummary(String projectKey, DependencyGraph graph) {
+        String moduleLabel = isNodeRoot.evaluate(projectKey) ? "(root)" : projectKey;
+        Set<Dependency> allDeps = collectAllDependencies(graph);
+        int directCount = graph.getRootDependencies().size();
+        int transitiveCount = allDeps.size() - directCount;
+        logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
+            moduleLabel, directCount, transitiveCount);
+        if (logger.isDebugEnabled()) {
+            List<String> depNames = allDeps.stream()
+                .map(dep -> dep.getName() + "@" + dep.getVersion())
+                .sorted()
+                .collect(Collectors.toList());
+            logger.debug("Workspace module '{}' full dependency list: {}", moduleLabel, depNames);
+        }
+    }
+
+    private Set<Dependency> collectAllDependencies(DependencyGraph graph) {
+        Set<Dependency> visited = new HashSet<>();
+        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
+        while (!queue.isEmpty()) {
+            Dependency dep = queue.poll();
+            if (visited.add(dep)) {
+                queue.addAll(graph.getChildrenForParent(dep));
+            }
+        }
+        return visited;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmWorkspaceDependencySummary.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmWorkspaceDependencySummary.java
@@ -1,0 +1,76 @@
+package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
+
+/**
+ * DTO that captures the dependency summary for a single PNPM workspace module.
+ * Built via {@link #from(DependencyGraph)} and logged via {@link #logModuleSummary(Logger, String, DependencyGraph)}.
+ */
+public class PnpmWorkspaceDependencySummary {
+
+    private static final String VERSION_SEPARATOR = "@";
+    private static final String ROOT_MODULE_LABEL = "(root)";
+    private static final String ROOT_KEY = ".";
+
+    public final int directCount;
+    public final int transitiveCount;
+    public final List<String> depNames;
+
+    private PnpmWorkspaceDependencySummary(int directCount, int transitiveCount, List<String> depNames) {
+        this.directCount = directCount;
+        this.transitiveCount = transitiveCount;
+        this.depNames = depNames;
+    }
+
+    /**
+     * Builds a summary by performing a BFS traversal of the dependency graph.
+     * The {@link java.util.HashSet} ensures each dependency is counted exactly once,
+     * correctly handling diamond dependencies (A→D and B→D both shared).
+     */
+    public static PnpmWorkspaceDependencySummary from(DependencyGraph graph) {
+        Set<Dependency> visited = new HashSet<>();
+        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
+        while (!queue.isEmpty()) {
+            Dependency dep = queue.poll();
+            if (visited.add(dep)) {
+                queue.addAll(graph.getChildrenForParent(dep));
+            }
+        }
+        int directCount = graph.getRootDependencies().size();
+        int transitiveCount = visited.size() - directCount;
+        List<String> depNames = visited.stream()
+            .map(dep -> dep.getName() + VERSION_SEPARATOR + dep.getVersion())
+            .sorted()
+            .collect(Collectors.toList());
+        return new PnpmWorkspaceDependencySummary(directCount, transitiveCount, depNames);
+    }
+
+    /**
+     * Logs the workspace module summary at INFO and DEBUG levels.
+     * The BFS traversal in {@link #from(DependencyGraph)} is only performed when
+     * at least INFO or DEBUG logging is enabled, avoiding unnecessary CPU cost.
+     */
+    public static void logModuleSummary(Logger logger, String projectKey, DependencyGraph graph) {
+        if (!logger.isInfoEnabled() && !logger.isDebugEnabled()) {
+            return;
+        }
+        String moduleLabel = ROOT_KEY.equals(projectKey) ? ROOT_MODULE_LABEL : projectKey;
+        PnpmWorkspaceDependencySummary summary = from(graph);
+        logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
+            moduleLabel, summary.directCount, summary.transitiveCount);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Workspace module '{}' full dependency list: {}", moduleLabel, summary.depNames);
+        }
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmWorkspaceDependencySummary.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/pnpm/lockfile/process/PnpmWorkspaceDependencySummary.java
@@ -1,5 +1,6 @@
 package com.blackduck.integration.detectable.detectables.pnpm.lockfile.process;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.Predicate;
 import org.slf4j.Logger;
 
 import com.blackduck.integration.bdio.graph.DependencyGraph;
@@ -14,13 +16,15 @@ import com.blackduck.integration.bdio.model.dependency.Dependency;
 
 /**
  * DTO that captures the dependency summary for a single PNPM workspace module.
- * Built via {@link #from(DependencyGraph)} and logged via {@link #logModuleSummary(Logger, String, DependencyGraph)}.
+ * Built via {@link #from(DependencyGraph, boolean)} and logged via {@link #logModuleSummary(Logger, String, DependencyGraph)}.
  */
 public class PnpmWorkspaceDependencySummary {
 
     private static final String VERSION_SEPARATOR = "@";
-    private static final String ROOT_MODULE_LABEL = "(root)";
-    private static final String ROOT_KEY = ".";
+
+    /** Shared constant identifying the root workspace module key. Used by both parsers and this class. */
+    static final Predicate<String> IS_NODE_ROOT = "."::equals;
+    static final String ROOT_MODULE_LABEL = "(root)";
 
     public final int directCount;
     public final int transitiveCount;
@@ -29,43 +33,50 @@ public class PnpmWorkspaceDependencySummary {
     private PnpmWorkspaceDependencySummary(int directCount, int transitiveCount, List<String> depNames) {
         this.directCount = directCount;
         this.transitiveCount = transitiveCount;
-        this.depNames = depNames;
+        this.depNames = Collections.unmodifiableList(depNames); // immutable DTO field
     }
 
     /**
      * Builds a summary by performing a BFS traversal of the dependency graph.
-     * The {@link java.util.HashSet} ensures each dependency is counted exactly once,
+     * The {@link HashSet} ensures each dependency is counted exactly once,
      * correctly handling diamond dependencies (A→D and B→D both shared).
+     *
+     * @param includeDepNames if {@code true}, populates the full sorted dep name list;
+     *                        pass {@code false} (e.g. when only INFO is active) to skip
+     *                        the stream/sort/collect and avoid unnecessary CPU cost.
      */
-    public static PnpmWorkspaceDependencySummary from(DependencyGraph graph) {
+    public static PnpmWorkspaceDependencySummary from(DependencyGraph graph, boolean includeDepNames) {
+        Set<Dependency> rootDeps = graph.getRootDependencies();
         Set<Dependency> visited = new HashSet<>();
-        Queue<Dependency> queue = new LinkedList<>(graph.getRootDependencies());
+        Queue<Dependency> queue = new LinkedList<>(rootDeps);
         while (!queue.isEmpty()) {
             Dependency dep = queue.poll();
             if (visited.add(dep)) {
                 queue.addAll(graph.getChildrenForParent(dep));
             }
         }
-        int directCount = graph.getRootDependencies().size();
+        int directCount = rootDeps.size();
         int transitiveCount = visited.size() - directCount;
-        List<String> depNames = visited.stream()
-            .map(dep -> dep.getName() + VERSION_SEPARATOR + dep.getVersion())
-            .sorted()
-            .collect(Collectors.toList());
+        List<String> depNames = includeDepNames
+            ? visited.stream()
+                .map(dep -> dep.getName() + VERSION_SEPARATOR + dep.getVersion())
+                .sorted()
+                .collect(Collectors.toList())
+            : Collections.emptyList();
         return new PnpmWorkspaceDependencySummary(directCount, transitiveCount, depNames);
     }
 
     /**
      * Logs the workspace module summary at INFO and DEBUG levels.
-     * The BFS traversal in {@link #from(DependencyGraph)} is only performed when
-     * at least INFO or DEBUG logging is enabled, avoiding unnecessary CPU cost.
+     * BFS traversal is skipped entirely when both levels are off.
+     * The dep name list is only computed when DEBUG is enabled.
      */
     public static void logModuleSummary(Logger logger, String projectKey, DependencyGraph graph) {
         if (!logger.isInfoEnabled() && !logger.isDebugEnabled()) {
             return;
         }
-        String moduleLabel = ROOT_KEY.equals(projectKey) ? ROOT_MODULE_LABEL : projectKey;
-        PnpmWorkspaceDependencySummary summary = from(graph);
+        String moduleLabel = IS_NODE_ROOT.evaluate(projectKey) ? ROOT_MODULE_LABEL : projectKey; // Fix 4: consistent Predicate
+        PnpmWorkspaceDependencySummary summary = from(graph, logger.isDebugEnabled()); // Fix 3: pass flag
         logger.info("Workspace module '{}': {} direct and {} transitive dependencies discovered.",
             moduleLabel, summary.directCount, summary.transitiveCount);
         if (logger.isDebugEnabled()) {
@@ -73,4 +84,3 @@ public class PnpmWorkspaceDependencySummary {
         }
     }
 }
-

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pnpm/unit/PnpmWorkspaceDependencySummaryTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pnpm/unit/PnpmWorkspaceDependencySummaryTest.java
@@ -1,0 +1,117 @@
+package com.blackduck.integration.detectable.detectables.pnpm.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.bdio.graph.BasicDependencyGraph;
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.dependency.Dependency;
+import com.blackduck.integration.bdio.model.dependency.DependencyFactory;
+import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
+import com.blackduck.integration.detectable.detectables.pnpm.lockfile.process.PnpmWorkspaceDependencySummary;
+
+class PnpmWorkspaceDependencySummaryTest {
+
+    private final DependencyFactory dependencyFactory = new DependencyFactory(new ExternalIdFactory());
+    private final Forge forge = Forge.NPMJS;
+
+    private Dependency dep(String name, String version) {
+        return dependencyFactory.createNameVersionDependency(forge, name, version);
+    }
+
+    /** An empty graph (no deps at all) should produce all-zero counts and an empty list. */
+    @Test
+    void testEmptyGraph() {
+        DependencyGraph graph = new BasicDependencyGraph();
+
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+
+        assertEquals(0, summary.directCount);
+        assertEquals(0, summary.transitiveCount);
+        assertTrue(summary.depNames.isEmpty());
+    }
+
+    /** A graph with only root-level deps and no children: direct=2, transitive=0. */
+    @Test
+    void testOnlyDirectDependencies() {
+        DependencyGraph graph = new BasicDependencyGraph();
+        graph.addChildrenToRoot(dep("react", "18.0.0"), dep("lodash", "4.17.21"));
+
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+
+        assertEquals(2, summary.directCount);
+        assertEquals(0, summary.transitiveCount);
+        assertEquals(2, summary.depNames.size());
+        assertTrue(summary.depNames.contains("lodash@4.17.21"));
+        assertTrue(summary.depNames.contains("react@18.0.0"));
+    }
+
+    /** A graph with one direct dep that itself has one child: direct=1, transitive=1. */
+    @Test
+    void testDirectAndTransitiveDependencies() {
+        Dependency webpack = dep("webpack", "5.0.0");
+        Dependency acorn = dep("acorn", "8.0.0");
+
+        DependencyGraph graph = new BasicDependencyGraph();
+        graph.addChildrenToRoot(webpack);
+        graph.addParentWithChild(webpack, acorn);
+
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+
+        assertEquals(1, summary.directCount);
+        assertEquals(1, summary.transitiveCount);
+        assertEquals(2, summary.depNames.size());
+        assertTrue(summary.depNames.contains("webpack@5.0.0"));
+        assertTrue(summary.depNames.contains("acorn@8.0.0"));
+    }
+
+    /**
+     * Diamond dependency: A and B are both direct deps, and both depend on D.
+     * D must be counted exactly ONCE — proves the HashSet dedup in BFS works.
+     * root → A → D
+     * root → B → D
+     * Expected: directCount=2, transitiveCount=1, total depNames size=3.
+     */
+    @Test
+    void testDiamondDependencyIsCountedOnce() {
+        Dependency a = dep("pkg-a", "1.0.0");
+        Dependency b = dep("pkg-b", "1.0.0");
+        Dependency d = dep("shared-dep", "1.0.0");
+
+        DependencyGraph graph = new BasicDependencyGraph();
+        graph.addChildrenToRoot(a, b);
+        graph.addParentWithChild(a, d);
+        graph.addParentWithChild(b, d);
+
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+
+        assertEquals(2, summary.directCount, "Expected 2 direct deps (pkg-a, pkg-b)");
+        assertEquals(1, summary.transitiveCount, "Expected 1 transitive dep (shared-dep counted once, not twice)");
+        assertEquals(3, summary.depNames.size(), "Expected 3 total unique deps");
+        assertTrue(summary.depNames.contains("shared-dep@1.0.0"));
+    }
+
+    /** The depNames list must be sorted alphabetically so log output is stable and readable. */
+    @Test
+    void testDepNamesAreSortedAlphabetically() {
+        DependencyGraph graph = new BasicDependencyGraph();
+        graph.addChildrenToRoot(
+            dep("zlib", "1.0.0"),
+            dep("acorn", "1.0.0"),
+            dep("moment", "1.0.0")
+        );
+
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+
+        List<String> names = summary.depNames;
+        assertEquals(3, names.size());
+        assertEquals("acorn@1.0.0", names.get(0));
+        assertEquals("moment@1.0.0", names.get(1));
+        assertEquals("zlib@1.0.0", names.get(2));
+    }
+}

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pnpm/unit/PnpmWorkspaceDependencySummaryTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/pnpm/unit/PnpmWorkspaceDependencySummaryTest.java
@@ -29,7 +29,7 @@ class PnpmWorkspaceDependencySummaryTest {
     void testEmptyGraph() {
         DependencyGraph graph = new BasicDependencyGraph();
 
-        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph, true);
 
         assertEquals(0, summary.directCount);
         assertEquals(0, summary.transitiveCount);
@@ -42,7 +42,7 @@ class PnpmWorkspaceDependencySummaryTest {
         DependencyGraph graph = new BasicDependencyGraph();
         graph.addChildrenToRoot(dep("react", "18.0.0"), dep("lodash", "4.17.21"));
 
-        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph, true);
 
         assertEquals(2, summary.directCount);
         assertEquals(0, summary.transitiveCount);
@@ -61,7 +61,7 @@ class PnpmWorkspaceDependencySummaryTest {
         graph.addChildrenToRoot(webpack);
         graph.addParentWithChild(webpack, acorn);
 
-        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph, true);
 
         assertEquals(1, summary.directCount);
         assertEquals(1, summary.transitiveCount);
@@ -88,7 +88,7 @@ class PnpmWorkspaceDependencySummaryTest {
         graph.addParentWithChild(a, d);
         graph.addParentWithChild(b, d);
 
-        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph, true);
 
         assertEquals(2, summary.directCount, "Expected 2 direct deps (pkg-a, pkg-b)");
         assertEquals(1, summary.transitiveCount, "Expected 1 transitive dep (shared-dep counted once, not twice)");
@@ -106,7 +106,7 @@ class PnpmWorkspaceDependencySummaryTest {
             dep("moment", "1.0.0")
         );
 
-        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph);
+        PnpmWorkspaceDependencySummary summary = PnpmWorkspaceDependencySummary.from(graph, true);
 
         List<String> names = summary.depNames;
         assertEquals(3, names.size());


### PR DESCRIPTION
# Description

### Summary
Improves the log output of the PNPM detector when scanning a workspace project, addressing the visibility gap.

### Problem
When Detect processed a `pnpm-lock.yaml` containing workspace modules (`importers`), the logs gave no indication that a workspace had been found, which modules were discovered, or how many dependencies were detected per module. Users had to manually inspect the Black Duck UI after every scan to verify completeness.

### Changes
**`PnpmLockYamlParser.java`** (v6/v9/v11) and **`PnpmLockYamlParserv5.java`** (v5):

- **INFO** — On entering workspace processing, logs the number of workspace modules discovered and their paths (e.g. `.`, `packages/frontend`, `packages/backend`).
- **INFO** — Explicitly states that subdirectory `package.json` files do not need separate processing because all dependency information is already contained in the root `pnpm-lock.yaml`.
- **INFO** — For each workspace module, logs the count of direct and transitive dependencies discovered.
- **DEBUG** — For each workspace module, logs the full sorted list of all discovered dependencies (`name@version`) for detailed verification.

Two private helpers were added to both parsers:
- `logWorkspaceModuleSummary(projectKey, graph)` — drives the INFO summary and DEBUG listing per module
- `collectAllDependencies(graph)` — BFS walk of the dependency graph to collect all unique direct + transitive nodes
