### PR TITLE
Idetect 5250 : Fix and improve detect.uv.dependency.groups.only support for UV buildless detector

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/UVDependencyGroupFilter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/UVDependencyGroupFilter.java
@@ -1,0 +1,103 @@
+package com.blackduck.integration.detectable.detectables.uv;
+
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves effective dependency groups by applying the only-vs-excluded filtering logic.
+ * Centralizes the conflict detection and warning logging that both the CLI (buildless)
+ * and lockfile detector paths share.
+ */
+public class UVDependencyGroupFilter {
+
+    private final Set<String> onlyGroups;
+    private final Set<String> excludedGroups;
+    private final Set<String> conflictingGroups;
+    private final Set<String> effectiveOnlyGroups;
+
+    public UVDependencyGroupFilter(UVDetectorOptions options) {
+        this.onlyGroups = options.getOnlyDependencyGroups();
+        this.excludedGroups = options.getExcludedDependencyGroups();
+        this.conflictingGroups = computeConflictingGroups();
+        this.effectiveOnlyGroups = computeEffectiveOnlyGroups();
+    }
+
+    /**
+     * Groups that appear in both onlyGroups and excludedGroups.
+     */
+    public Set<String> getConflictingGroups() {
+        return conflictingGroups;
+    }
+
+    /**
+     * The onlyGroups after removing any that are also excluded.
+     * If onlyGroups was empty, returns empty (meaning "no only-filter active").
+     * If excludedGroups is empty, returns onlyGroups as-is (no subtraction needed).
+     */
+    public Set<String> getEffectiveOnlyGroups() {
+        return effectiveOnlyGroups;
+    }
+
+    /**
+     * Returns true if onlyGroups was specified and at least one group survives exclusion.
+     * Returns true also when onlyGroups is empty (no only-filter active, default behavior).
+     * Returns false only when onlyGroups is non-empty but all are cancelled by exclusion.
+     */
+    public boolean hasEffectiveGroups() {
+        if (onlyGroups.isEmpty()) {
+            return true;
+        }
+        return !effectiveOnlyGroups.isEmpty();
+    }
+
+    public Set<String> getOnlyGroups() {
+        return onlyGroups;
+    }
+
+    public Set<String> getExcludedGroups() {
+        return excludedGroups;
+    }
+
+    /**
+     * Logs warnings about conflicting groups and empty effective groups.
+     * Both the buildless (CLI) and lockfile paths call this once to produce identical messages.
+     */
+    public void logGroupConflictWarnings(Logger logger) {
+        if (!conflictingGroups.isEmpty()) {
+            logger.warn(
+                    "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and "
+                    + "'detect.uv.dependency.groups.excluded'. The exclusion setting takes precedence; "
+                    + "these groups will be excluded.",
+                    conflictingGroups
+            );
+        }
+        if (!onlyGroups.isEmpty() && effectiveOnlyGroups.isEmpty()) {
+            logger.warn("No dependency groups remain to be scanned. Returning an empty BOM.");
+        }
+    }
+
+    private Set<String> computeConflictingGroups() {
+        if (excludedGroups.isEmpty() || onlyGroups.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return onlyGroups.stream()
+                .filter(excludedGroups::contains)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> computeEffectiveOnlyGroups() {
+        if (onlyGroups.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (excludedGroups.isEmpty()) {
+            return onlyGroups;
+        }
+        return onlyGroups.stream()
+                .filter(group -> !excludedGroups.contains(group))
+                .collect(Collectors.toSet());
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
@@ -8,6 +8,7 @@ import com.blackduck.integration.detectable.ExecutableTarget;
 import com.blackduck.integration.detectable.ExecutableUtils;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectable.executable.DetectableExecutableRunner;
+import com.blackduck.integration.detectable.detectables.uv.UVDependencyGroupFilter;
 import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
 import com.blackduck.integration.detectable.detectables.uv.parse.UVTomlParser;
 import com.blackduck.integration.detectable.detectables.uv.transform.UVTreeDependencyGraphTransformer;
@@ -22,8 +23,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class UVBuildExtractor {
 
@@ -46,15 +45,12 @@ public class UVBuildExtractor {
 
     public Extraction extract(ExecutableTarget uvExe, UVDetectorOptions uvDetectorOptions, UVTomlParser uvTomlParser) throws ExecutableRunnerException {
         try {
-            Optional<List<String>> arguments = buildTreeCommandArguments(uvDetectorOptions);
+            UVDependencyGroupFilter groupFilter = new UVDependencyGroupFilter(uvDetectorOptions);
+            groupFilter.logGroupConflictWarnings(logger);
 
-            // If no valid groups remain after exclusion, return an empty BOM (a CodeLocation with zero dependencies)
-            // rather than running "uv tree --no-dedupe" which would incorrectly return ALL dependencies.
+            Optional<List<String>> arguments = buildTreeCommandArguments(groupFilter);
+
             if (!arguments.isPresent()) {
-                logger.warn(
-                        "All dependency groups specified in 'detect.uv.dependency.groups.only' are also present in "
-                        + "'detect.uv.dependency.groups.excluded'. No dependency groups remain to scan. Returning an empty BOM."
-                );
                 DependencyGraph emptyGraph = new BasicDependencyGraph();
                 Optional<NameVersion> projectNameVersion = uvTomlParser.parseNameVersion();
                 CodeLocation emptyCodeLocation = projectNameVersion
@@ -82,63 +78,27 @@ public class UVBuildExtractor {
         }
     }
 
-    private Optional<List<String>> buildTreeCommandArguments(UVDetectorOptions uvDetectorOptions) {
+    private Optional<List<String>> buildTreeCommandArguments(UVDependencyGroupFilter groupFilter) {
         List<String> arguments = new ArrayList<>();
         arguments.add(TREE_COMMAND);
         arguments.add(NO_DEDUPE_FLAG);
 
-        Set<String> onlyGroups = uvDetectorOptions.getOnlyDependencyGroups();
-        Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
-
-        if (!onlyGroups.isEmpty()) {
-            boolean hasEffectiveGroups = addOnlyGroupArguments(arguments, onlyGroups, excludedGroups);
-            if (!hasEffectiveGroups) {
+        if (!groupFilter.getOnlyGroups().isEmpty()) {
+            if (!groupFilter.hasEffectiveGroups()) {
                 return Optional.empty();
             }
+            for (String group : groupFilter.getEffectiveOnlyGroups()) {
+                arguments.add(ONLY_GROUP_FLAG);
+                arguments.add(group);
+            }
         } else {
-            addDefaultGroupArguments(arguments, excludedGroups);
+            arguments.add(ALL_GROUPS_FLAG);
+            for (String group : groupFilter.getExcludedGroups()) {
+                arguments.add(NO_GROUP_FLAG);
+                arguments.add(group);
+            }
         }
 
         return Optional.of(arguments);
-    }
-
-    // Computes effectiveOnlyGroups = onlyGroups minus excludedGroups.
-    // Returns false if no groups remain (signals caller to produce an empty BOM).
-    private boolean addOnlyGroupArguments(List<String> arguments, Set<String> onlyGroups, Set<String> excludedGroups) {
-        Set<String> conflictingGroups = onlyGroups.stream()
-                .filter(excludedGroups::contains)
-                .collect(Collectors.toSet());
-
-        if (!conflictingGroups.isEmpty()) {
-            logger.warn(
-                    "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and 'detect.uv.dependency.groups.excluded'. "
-                    + "The exclusion setting takes precedence; these groups will be excluded.",
-                    conflictingGroups
-            );
-        }
-
-        Set<String> effectiveOnlyGroups = onlyGroups.stream()
-                .filter(group -> !excludedGroups.contains(group))
-                .collect(Collectors.toSet());
-
-        if (effectiveOnlyGroups.isEmpty()) {
-            return false;
-        }
-
-        for (String group : effectiveOnlyGroups) {
-            arguments.add(ONLY_GROUP_FLAG);
-            arguments.add(group);
-        }
-
-        return true;
-    }
-
-    private void addDefaultGroupArguments(List<String> arguments, Set<String> excludedGroups) {
-        arguments.add(ALL_GROUPS_FLAG);
-
-        for (String group : excludedGroups) {
-            arguments.add(NO_GROUP_FLAG);
-            arguments.add(group);
-        }
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/buildexe/UVBuildExtractor.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.TreeSet;
 
 public class UVBuildExtractor {
 
@@ -87,13 +88,13 @@ public class UVBuildExtractor {
             if (!groupFilter.hasEffectiveGroups()) {
                 return Optional.empty();
             }
-            for (String group : groupFilter.getEffectiveOnlyGroups()) {
+            for (String group : new TreeSet<>(groupFilter.getEffectiveOnlyGroups())) {
                 arguments.add(ONLY_GROUP_FLAG);
                 arguments.add(group);
             }
         } else {
             arguments.add(ALL_GROUPS_FLAG);
-            for (String group : groupFilter.getExcludedGroups()) {
+            for (String group : new TreeSet<>(groupFilter.getExcludedGroups())) {
                 arguments.add(NO_GROUP_FLAG);
                 arguments.add(group);
             }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/lockfile/UVLockfileExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/lockfile/UVLockfileExtractor.java
@@ -49,7 +49,11 @@ public class UVLockfileExtractor {
             // When all only-groups are also excluded, parseLockFile returns an empty list.
             // Create one empty CodeLocation with the project identity so the BOM still
             // contains the project — consistent with the CLI/buildless detector path.
-            if (codeLocations.isEmpty() && !uvDetectorOptions.getOnlyDependencyGroups().isEmpty()) {
+            // Gate on uvLockFile != null: if there was no uv.lock, parseLockFile was never
+            // called, so an empty codeLocations list is expected (requirements.txt may still
+            // add its own CodeLocation below). We must not add a spurious empty CodeLocation
+            // in that case.
+            if (uvLockFile != null && codeLocations.isEmpty() && !uvDetectorOptions.getOnlyDependencyGroups().isEmpty()) {
                 DependencyGraph emptyGraph = new BasicDependencyGraph();
                 CodeLocation emptyCodeLocation = projectNameVersion
                         .map(nv -> new CodeLocation(emptyGraph, ExternalId.FACTORY.createNameVersionExternalId(Forge.PYPI, nv.getName(), nv.getVersion())))

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/lockfile/UVLockfileExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/lockfile/UVLockfileExtractor.java
@@ -1,6 +1,9 @@
 package com.blackduck.integration.detectable.detectables.uv.lockfile;
 
+import com.blackduck.integration.bdio.graph.BasicDependencyGraph;
 import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pip.parser.RequirementsFileDependencyTransformer;
 import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
@@ -41,6 +44,17 @@ public class UVLockfileExtractor {
             if (uvLockFile != null) {
                 String uvLockContents = FileUtils.readFileToString(uvLockFile, StandardCharsets.UTF_8);
                 codeLocations = uvLockParser.parseLockFile(uvLockContents, projectName, uvDetectorOptions);
+            }
+
+            // When all only-groups are also excluded, parseLockFile returns an empty list.
+            // Create one empty CodeLocation with the project identity so the BOM still
+            // contains the project — consistent with the CLI/buildless detector path.
+            if (codeLocations.isEmpty() && !uvDetectorOptions.getOnlyDependencyGroups().isEmpty()) {
+                DependencyGraph emptyGraph = new BasicDependencyGraph();
+                CodeLocation emptyCodeLocation = projectNameVersion
+                        .map(nv -> new CodeLocation(emptyGraph, ExternalId.FACTORY.createNameVersionExternalId(Forge.PYPI, nv.getName(), nv.getVersion())))
+                        .orElse(new CodeLocation(emptyGraph));
+                codeLocations.add(emptyCodeLocation);
             }
 
             if (requirementsTxtFile != null) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -71,15 +71,21 @@ public class UVLockParser {
         // Guard: if onlyGroups is non-empty but every group in it is also excluded,
         // there is nothing to scan — return empty BOM immediately.
         if (!onlyGroups.isEmpty()) {
+            Set<String> conflictingGroups = onlyGroups.stream()
+                    .filter(excludedGroups::contains)
+                    .collect(Collectors.toSet());
+            if (!conflictingGroups.isEmpty()) {
+                logger.warn(
+                        "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and 'detect.uv.dependency.groups.excluded'. "
+                        + "The exclusion setting takes precedence; these groups will be excluded.",
+                        conflictingGroups
+                );
+            }
+
             Set<String> effectiveOnlyGroups = onlyGroups.stream()
                     .filter(group -> !excludedGroups.contains(group))
                     .collect(Collectors.toSet());
             if (effectiveOnlyGroups.isEmpty()) {
-                logger.warn(
-                        "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and 'detect.uv.dependency.groups.excluded'. "
-                        + "The exclusion setting takes precedence; these groups will be excluded.",
-                        onlyGroups
-                );
                 logger.warn("No dependency groups remain to be scanned. Returning empty BOM.");
                 return;
             }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 public class UVLockParser {
 
@@ -64,6 +65,26 @@ public class UVLockParser {
     // In the first go, we will get all dependency and transitive dependencies information,
     // In the second go, we will recursively loop all the workspace members which will have their direct, transitives and so on to build the graph.
     private void parseDependencies(TomlArray dependencies, String rootName, UVDetectorOptions uvDetectorOptions) {
+        Set<String> onlyGroups = uvDetectorOptions.getOnlyDependencyGroups();
+        Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
+
+        // Guard: if onlyGroups is non-empty but every group in it is also excluded,
+        // there is nothing to scan — return empty BOM immediately.
+        if (!onlyGroups.isEmpty()) {
+            Set<String> effectiveOnlyGroups = onlyGroups.stream()
+                    .filter(group -> !excludedGroups.contains(group))
+                    .collect(Collectors.toSet());
+            if (effectiveOnlyGroups.isEmpty()) {
+                logger.warn(
+                        "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and 'detect.uv.dependency.groups.excluded'. "
+                        + "The exclusion setting takes precedence; these groups will be excluded.",
+                        onlyGroups
+                );
+                logger.warn("No dependency groups remain to be scanned. Returning empty BOM.");
+                return;
+            }
+        }
+
         for(int i = 0; i < dependencies.size(); i++) {
             TomlTable dependencyTable = dependencies.getTable(i);
 
@@ -94,33 +115,36 @@ public class UVLockParser {
     }
 
     private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, UVDetectorOptions uvDetectorOptions) {
-        //parse dependencies section
-        if(dependencyTable.contains(DEPENDENCIES_KEY)) {
-            TomlArray directDependencyArray = dependencyTable.getArray(DEPENDENCIES_KEY);
-            parseTransitiveDependencies(directDependencyArray, dependencyName);
+        Set<String> onlyGroups = uvDetectorOptions.getOnlyDependencyGroups();
+        Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
+
+        // [dependencies] (regular project deps) — skipped when onlyGroups is set,
+        // mirroring CLI behaviour where --only-group does not include regular dependencies.
+        if (onlyGroups.isEmpty() && dependencyTable.contains(DEPENDENCIES_KEY)) {
+            parseTransitiveDependencies(dependencyTable.getArray(DEPENDENCIES_KEY), dependencyName);
         }
 
-        //parse dev dependencies, it is a toml table with group name as the key and dependencies as list, check if that group is not included then do not parse them
-        if(dependencyTable.contains(DEV_DEPENDENCIES_KEY)) {
-            TomlTable devDependencyTable = dependencyTable.getTable(DEV_DEPENDENCIES_KEY);
-            for(List<String> keyPath: devDependencyTable.keyPathSet()) {
-                String groupName = keyPath.get(0);
-                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(groupName)) {
-                    TomlArray devDependencyArray = devDependencyTable.getArray(groupName);
-                    parseTransitiveDependencies(devDependencyArray, dependencyName);
-                }
-            }
+        // [dev-dependencies] — when onlyGroups is set, include a group only if it is
+        // in onlyGroups AND not in excludedGroups. Excluded always wins.
+        if (dependencyTable.contains(DEV_DEPENDENCIES_KEY)) {
+            parseFilteredGroupDependencies(dependencyTable.getTable(DEV_DEPENDENCIES_KEY), dependencyName, onlyGroups, excludedGroups);
         }
 
-        //parse optional dependencies which is part of uv tree command, it can be excluded by users using uv configuration
-        if(dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
-            TomlTable optionalDependencyTable = dependencyTable.getTable(OPTIONAL_DEPENDENCIES_KEY);
-            for(List<String> keyPath: optionalDependencyTable.keyPathSet()) {
-                String groupName = keyPath.get(0);
-                if(!uvDetectorOptions.getExcludedDependencyGroups().contains(groupName)) {
-                    TomlArray optionalDependencyArray = optionalDependencyTable.getArray(groupName);
-                    parseTransitiveDependencies(optionalDependencyArray, dependencyName);
-                }
+        // [optional-dependencies] — skipped when onlyGroups is set,
+        // mirroring CLI behaviour where --only-group does not include optional extras.
+        if (onlyGroups.isEmpty() && dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
+            parseFilteredGroupDependencies(dependencyTable.getTable(OPTIONAL_DEPENDENCIES_KEY), dependencyName, onlyGroups, excludedGroups);
+        }
+    }
+
+    // Iterates over a TOML group table (dev-dependencies or optional-dependencies) and
+    // includes only groups that pass both the onlyGroups allowlist and the excludedGroups denylist.
+    private void parseFilteredGroupDependencies(TomlTable groupTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups) {
+        for (List<String> keyPath : groupTable.keyPathSet()) {
+            String groupName = keyPath.get(0);
+            boolean groupAllowed = onlyGroups.isEmpty() || onlyGroups.contains(groupName);
+            if (groupAllowed && !excludedGroups.contains(groupName)) {
+                parseTransitiveDependencies(groupTable.getArray(groupName), dependencyName);
             }
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -7,6 +7,7 @@ import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
+import com.blackduck.integration.detectable.detectables.uv.UVDependencyGroupFilter;
 import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.stream.Collectors;
 
 public class UVLockParser {
 
@@ -65,31 +65,15 @@ public class UVLockParser {
     // In the first go, we will get all dependency and transitive dependencies information,
     // In the second go, we will recursively loop all the workspace members which will have their direct, transitives and so on to build the graph.
     private void parseDependencies(TomlArray dependencies, String rootName, UVDetectorOptions uvDetectorOptions) {
-        Set<String> onlyGroups = uvDetectorOptions.getOnlyDependencyGroups();
-        Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
+        UVDependencyGroupFilter groupFilter = new UVDependencyGroupFilter(uvDetectorOptions);
+        groupFilter.logGroupConflictWarnings(logger);
 
-        // Guard: if onlyGroups is non-empty but every group in it is also excluded,
-        // there is nothing to scan — return empty BOM immediately.
-        if (!onlyGroups.isEmpty()) {
-            Set<String> conflictingGroups = onlyGroups.stream()
-                    .filter(excludedGroups::contains)
-                    .collect(Collectors.toSet());
-            if (!conflictingGroups.isEmpty()) {
-                logger.warn(
-                        "Dependency groups {} are present in both 'detect.uv.dependency.groups.only' and 'detect.uv.dependency.groups.excluded'. "
-                        + "The exclusion setting takes precedence; these groups will be excluded.",
-                        conflictingGroups
-                );
-            }
-
-            Set<String> effectiveOnlyGroups = onlyGroups.stream()
-                    .filter(group -> !excludedGroups.contains(group))
-                    .collect(Collectors.toSet());
-            if (effectiveOnlyGroups.isEmpty()) {
-                logger.warn("No dependency groups remain to be scanned. Returning empty BOM.");
-                return;
-            }
+        if (!groupFilter.hasEffectiveGroups()) {
+            return;
         }
+
+        Set<String> onlyGroups = groupFilter.getOnlyGroups();
+        Set<String> excludedGroups = groupFilter.getExcludedGroups();
 
         for(int i = 0; i < dependencies.size(); i++) {
             TomlTable dependencyTable = dependencies.getTable(i);
@@ -112,7 +96,7 @@ public class UVLockParser {
                 }
 
                 //parse transitive dependencies section of current dependency
-                parseDependenciesSection(dependencyTable, dependencyName, uvDetectorOptions);
+                parseDependenciesSection(dependencyTable, dependencyName, onlyGroups, excludedGroups);
             }
         }
 
@@ -120,9 +104,7 @@ public class UVLockParser {
 
     }
 
-    private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, UVDetectorOptions uvDetectorOptions) {
-        Set<String> onlyGroups = uvDetectorOptions.getOnlyDependencyGroups();
-        Set<String> excludedGroups = uvDetectorOptions.getExcludedDependencyGroups();
+    private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups) {
 
         // [dependencies] (regular project deps) — skipped when onlyGroups is set,
         // mirroring CLI behaviour where --only-group does not include regular dependencies.

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -129,10 +129,11 @@ public class UVLockParser {
     // includes only groups that pass both the onlyGroups allowlist and the excludedGroups denylist.
     private void parseFilteredGroupDependencies(TomlTable groupTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups) {
         for (List<String> keyPath : groupTable.keyPathSet()) {
-            String groupName = keyPath.get(0);
+            String rawGroupName = keyPath.get(0);
+            String groupName = rawGroupName.toLowerCase();
             boolean groupAllowed = onlyGroups.isEmpty() || onlyGroups.contains(groupName);
             if (groupAllowed && !excludedGroups.contains(groupName)) {
-                parseTransitiveDependencies(groupTable.getArray(groupName), dependencyName);
+                parseTransitiveDependencies(groupTable.getArray(rawGroupName), dependencyName);
             }
         }
     }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVOnlyGroupsFunctionalTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVOnlyGroupsFunctionalTest.java
@@ -1,0 +1,115 @@
+package com.blackduck.integration.detectable.detectables.uv.functional;
+
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.detectable.Detectable;
+import com.blackduck.integration.detectable.DetectableEnvironment;
+import com.blackduck.integration.detectable.ExecutableTarget;
+import com.blackduck.integration.detectable.detectable.exception.DetectableException;
+import com.blackduck.integration.detectable.detectable.executable.resolver.UVResolver;
+import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
+import com.blackduck.integration.detectable.extraction.Extraction;
+import com.blackduck.integration.detectable.functional.DetectableFunctionalTest;
+import com.blackduck.integration.detectable.util.graph.NameVersionGraphAssert;
+import com.blackduck.integration.executable.ExecutableOutput;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Functional test for UV detector with detect.uv.dependency.groups.only.
+ *
+ * Validates that the UV detector correctly limits scanning to only the specified
+ * dependency groups. When onlyGroups is set, the detector should pass --only-group
+ * flags (not --all-groups) and exclude regular dependencies and optional extras.
+ */
+public class UVOnlyGroupsFunctionalTest extends DetectableFunctionalTest {
+
+    protected UVOnlyGroupsFunctionalTest() throws IOException {
+        super("uv-only-groups");
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        // pyproject.toml with regular dependencies and multiple dependency groups
+        addFile(Paths.get("pyproject.toml"),
+                "[project]\n" +
+                "name = \"my-app\"\n" +
+                "version = \"1.0.0\"\n" +
+                "dependencies = [\n" +
+                "  \"fastapi>=0.100.0\",\n" +
+                "]\n" +
+                "[dependency-groups]\n" +
+                "dev = [\n" +
+                "  \"pytest>=7.0.0\",\n" +
+                "]\n" +
+                "lint = [\n" +
+                "  \"ruff>=0.4.0\",\n" +
+                "]\n" +
+                "[tool.uv]\n" +
+                "managed = true\n");
+
+        // Tree output when only "dev" group is requested via --only-group dev.
+        // Regular dependencies (fastapi) and other groups (lint/ruff) are NOT in the output.
+        ExecutableOutput uvTreeDependencyOutput = createStandardOutput(
+                "my-app v1.0.0\n" +
+                "└── pytest v8.3.4\n" +
+                "    ├── iniconfig v2.1.0\n" +
+                "    ├── packaging v24.2\n" +
+                "    └── pluggy v1.5.0");
+
+        // Expected command: uv tree --no-dedupe --only-group dev
+        // Note: --all-groups should NOT be present
+        addExecutableOutput(uvTreeDependencyOutput, new File("uv").getAbsolutePath(), "tree", "--no-dedupe", "--only-group", "dev");
+    }
+
+    @NotNull
+    @Override
+    public Detectable create(@NotNull DetectableEnvironment detectableEnvironment) {
+        class UVResolverTest implements UVResolver {
+            @Override
+            public ExecutableTarget resolveUV() throws DetectableException {
+                return ExecutableTarget.forFile(new File("uv"));
+            }
+        }
+
+        // Configure to include ONLY the "dev" dependency group
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),          // excludedDependencyGroups
+            Arrays.asList("dev"),             // onlyDependencyGroups
+            Collections.emptyList(),          // includedWorkspaceMembers
+            Collections.emptyList()           // excludedWorkspaceMembers
+        );
+
+        return detectableFactory.createUVBuildDetectable(
+            detectableEnvironment,
+            new UVResolverTest(),
+            options
+        );
+    }
+
+    @Override
+    public void assertExtraction(@NotNull Extraction extraction) {
+        Assertions.assertEquals(1, extraction.getCodeLocations().size(), "Expected exactly one code location.");
+
+        NameVersionGraphAssert graphAssert = new NameVersionGraphAssert(Forge.PYPI, extraction.getCodeLocations().get(0).getDependencyGraph());
+
+        // Only dev group deps should be present — no fastapi (regular dep), no ruff (lint group)
+        graphAssert.hasRootSize(1);
+        graphAssert.hasRootDependency("pytest", "8.3.4");
+
+        // Verify transitive dependencies of pytest
+        graphAssert.hasDependency("iniconfig", "2.1.0");
+        graphAssert.hasDependency("packaging", "24.2");
+        graphAssert.hasDependency("pluggy", "1.5.0");
+
+        // Verify excluded deps are NOT in the graph
+        graphAssert.hasNoDependency("fastapi", "0.109.0");
+        graphAssert.hasNoDependency("ruff", "0.4.1");
+    }
+}
+

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVOnlyGroupsFunctionalTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/functional/UVOnlyGroupsFunctionalTest.java
@@ -107,9 +107,11 @@ public class UVOnlyGroupsFunctionalTest extends DetectableFunctionalTest {
         graphAssert.hasDependency("packaging", "24.2");
         graphAssert.hasDependency("pluggy", "1.5.0");
 
-        // Verify excluded deps are NOT in the graph
-        graphAssert.hasNoDependency("fastapi", "0.109.0");
-        graphAssert.hasNoDependency("ruff", "0.4.1");
+        // Verify excluded deps are NOT in the graph (version-agnostic — check by name only)
+        Assertions.assertTrue(extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().stream().noneMatch(d -> d.getName().equals("fastapi")),
+                "Expected regular [project.dependencies] to be excluded when onlyGroups is set");
+        Assertions.assertTrue(extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")),
+                "Expected non-selected dependency-groups (lint) to be excluded when onlyGroups is set");
     }
 }
 

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVBuildExtractorTest.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.uv.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -48,8 +49,6 @@ class UVBuildExtractorTest {
         File tomlFile = new File(tempDir, "pyproject.toml");
         tomlFile.createNewFile();
         tomlParser = mock(UVTomlParser.class);
-        // Stub parseNameVersion() — without this Mockito returns null, causing a NullPointerException
-        // inside UVBuildExtractor.extract() and silently routing all tests through the exception path.
         when(tomlParser.parseNameVersion()).thenReturn(Optional.empty());
 
         uvExe = ExecutableTarget.forFile(new File("/usr/bin/uv"));
@@ -68,21 +67,18 @@ class UVBuildExtractorTest {
     void extractBuildsBasicArguments() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
         UVDetectorOptions options = new UVDetectorOptions(
-            Collections.emptyList(),  // excludedGroups
-            Collections.emptyList(),  // includedWorkspaceMembers
-            Collections.emptyList()   // excludedWorkspaceMembers
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList()
         );
 
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
-
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-        assertTrue(arguments.contains("tree"));
-        assertTrue(arguments.contains("--no-dedupe"));
-        assertTrue(arguments.contains("--all-groups"));
+        List<String> arguments = captureArguments();
+        assertTrue(arguments.contains("tree"), "Expected 'tree' command in arguments");
+        assertTrue(arguments.contains("--no-dedupe"), "Expected '--no-dedupe' flag in arguments");
+        assertTrue(arguments.contains("--all-groups"), "Expected '--all-groups' flag when no onlyGroups specified");
     }
 
     // ==================== Excluded Groups Tests ====================
@@ -91,7 +87,7 @@ class UVBuildExtractorTest {
     void extractAddsNoGroupFlagsForExcludedGroups() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
         UVDetectorOptions options = new UVDetectorOptions(
-            Arrays.asList("dev", "test"),   // excludedGroups
+            Arrays.asList("dev", "test"),
             Collections.emptyList(),
             Collections.emptyList()
         );
@@ -99,25 +95,22 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
-
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-        assertTrue(arguments.contains("tree"));
-        assertTrue(arguments.contains("--no-dedupe"));
-        assertTrue(arguments.contains("--all-groups"));
-        assertTrue(arguments.contains("--no-group"));
+        List<String> arguments = captureArguments();
+        assertTrue(arguments.contains("tree"), "Expected 'tree' command in arguments");
+        assertTrue(arguments.contains("--no-dedupe"), "Expected '--no-dedupe' flag in arguments");
+        assertTrue(arguments.contains("--all-groups"), "Expected '--all-groups' flag when only excludedGroups specified");
+        assertTrue(arguments.contains("--no-group"), "Expected '--no-group' flag for excluded groups");
 
         int devIndex = arguments.indexOf("dev");
         int testIndex = arguments.indexOf("test");
-        assertTrue(devIndex > 0);
-        assertTrue(testIndex > 0);
-        assertEquals("--no-group", arguments.get(devIndex - 1));
-        assertEquals("--no-group", arguments.get(testIndex - 1));
+        assertTrue(devIndex > 0, "Expected 'dev' to be present in arguments");
+        assertTrue(testIndex > 0, "Expected 'test' to be present in arguments");
+        assertEquals("--no-group", arguments.get(devIndex - 1), "'dev' should be preceded by '--no-group' flag");
+        assertEquals("--no-group", arguments.get(testIndex - 1), "'test' should be preceded by '--no-group' flag");
     }
 
     @Test
-    void extractWithEmptyExcludedGroupsAddsNoFlags() throws Exception {
+    void extractWithEmptyExcludedGroupsAddsNoNoGroupFlags() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
         UVDetectorOptions options = new UVDetectorOptions(
             Collections.emptyList(),
@@ -128,14 +121,10 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
-
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-
-        assertTrue(arguments.contains("--all-groups"));
+        List<String> arguments = captureArguments();
+        assertTrue(arguments.contains("--all-groups"), "Expected '--all-groups' flag with no exclusions");
         long noGroupCount = arguments.stream().filter(arg -> arg.equals("--no-group")).count();
-        assertEquals(0, noGroupCount);
+        assertEquals(0, noGroupCount, "Expected zero '--no-group' flags when no groups are excluded");
     }
 
     @Test
@@ -150,25 +139,21 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
-
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-
-        assertTrue(arguments.contains("--all-groups"));
+        List<String> arguments = captureArguments();
+        assertTrue(arguments.contains("--all-groups"), "Expected '--all-groups' flag with excluded groups");
         long noGroupCount = arguments.stream().filter(arg -> arg.equals("--no-group")).count();
-        assertEquals(1, noGroupCount);
-        assertTrue(arguments.contains("dev"));
+        assertEquals(1, noGroupCount, "Expected exactly one '--no-group' flag for single excluded group");
+        assertTrue(arguments.contains("dev"), "Expected 'dev' in arguments as the excluded group");
     }
 
     // ==================== Only Groups Tests ====================
 
     @Test
-    void extractAddsOnlyGroupFlagsAndSkipsAllExtrasAllGroups() throws Exception {
+    void extractWithOnlyGroupsDoesNotIncludeAllGroupsFlag() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
         UVDetectorOptions options = new UVDetectorOptions(
-            Collections.emptyList(),           // excludedGroups
-            Arrays.asList("dev", "lint"),       // onlyGroups
+            Collections.emptyList(),
+            Arrays.asList("dev", "lint"),
             Collections.emptyList(),
             Collections.emptyList()
         );
@@ -176,29 +161,50 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
+        List<String> arguments = captureArguments();
+        assertFalse(arguments.contains("--all-groups"), "'--all-groups' should be absent when onlyGroups is set");
+    }
 
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-        assertTrue(arguments.contains("tree"));
-        assertTrue(arguments.contains("--no-dedupe"));
+    @Test
+    void extractWithOnlyGroupsAddsOnlyGroupFlagForEachGroup() throws Exception {
+        UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev", "lint"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
 
-        // --all-groups should NOT be present when onlyGroups is set
-        assertTrue(!arguments.contains("--all-groups"), "Expected --all-groups to be absent when onlyGroups is set");
+        Extraction extraction = extractor.extract(uvExe, options, tomlParser);
+        assertExtractionSuccess(extraction);
 
-        // --only-group flags should be present for each group
+        List<String> arguments = captureArguments();
         long onlyGroupCount = arguments.stream().filter(arg -> arg.equals("--only-group")).count();
-        assertEquals(2, onlyGroupCount);
-        assertTrue(arguments.contains("dev"));
-        assertTrue(arguments.contains("lint"));
+        assertEquals(2, onlyGroupCount, "Expected two '--only-group' flags for [dev, lint]");
+        assertTrue(arguments.contains("dev"), "Expected 'dev' group in arguments");
+        assertTrue(arguments.contains("lint"), "Expected 'lint' group in arguments");
+    }
 
-        // Each group should be preceded by --only-group
+    @Test
+    void extractWithOnlyGroupsEachGroupPrecededByFlag() throws Exception {
+        UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev", "lint"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        Extraction extraction = extractor.extract(uvExe, options, tomlParser);
+        assertExtractionSuccess(extraction);
+
+        List<String> arguments = captureArguments();
         int devIndex = arguments.indexOf("dev");
         int lintIndex = arguments.indexOf("lint");
-        assertTrue(devIndex > 0);
-        assertTrue(lintIndex > 0);
-        assertEquals("--only-group", arguments.get(devIndex - 1));
-        assertEquals("--only-group", arguments.get(lintIndex - 1));
+        assertTrue(devIndex > 0, "Expected 'dev' to be present in arguments");
+        assertTrue(lintIndex > 0, "Expected 'lint' to be present in arguments");
+        assertEquals("--only-group", arguments.get(devIndex - 1), "'dev' should be immediately preceded by '--only-group'");
+        assertEquals("--only-group", arguments.get(lintIndex - 1), "'lint' should be immediately preceded by '--only-group'");
     }
 
     @Test
@@ -214,15 +220,11 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
-
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-
-        assertTrue(!arguments.contains("--all-groups"));
+        List<String> arguments = captureArguments();
+        assertFalse(arguments.contains("--all-groups"), "'--all-groups' should be absent when onlyGroups is set");
         long onlyGroupCount = arguments.stream().filter(arg -> arg.equals("--only-group")).count();
-        assertEquals(1, onlyGroupCount);
-        assertTrue(arguments.contains("dev"));
+        assertEquals(1, onlyGroupCount, "Expected exactly one '--only-group' flag for single only-group");
+        assertTrue(arguments.contains("dev"), "Expected 'dev' group in arguments");
     }
 
     // ==================== Conflict Handling Tests ====================
@@ -230,10 +232,9 @@ class UVBuildExtractorTest {
     @Test
     void extractExclusionTakesPrecedenceOverOnlyGroup() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
-        // "dev" is in both only and excluded — exclusion should take precedence
         UVDetectorOptions options = new UVDetectorOptions(
-            Arrays.asList("dev"),              // excludedGroups
-            Arrays.asList("dev", "lint"),       // onlyGroups
+            Arrays.asList("dev"),
+            Arrays.asList("dev", "lint"),
             Collections.emptyList(),
             Collections.emptyList()
         );
@@ -241,28 +242,21 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
-        verify(executableRunner).executeSuccessfully(captor.capture());
+        List<String> arguments = captureArguments();
+        assertFalse(arguments.contains("--all-groups"), "'--all-groups' should be absent when onlyGroups is set");
 
-        List<String> arguments = captor.getValue().getCommandWithArguments();
-
-        // --all-groups should NOT be present (onlyGroups path)
-        assertTrue(!arguments.contains("--all-groups"));
-
-        // "dev" should be excluded — only "lint" should remain as --only-group
         long onlyGroupCount = arguments.stream().filter(arg -> arg.equals("--only-group")).count();
         assertEquals(1, onlyGroupCount, "Only 'lint' should remain after 'dev' is excluded");
-        assertTrue(arguments.contains("lint"));
-        assertTrue(!arguments.contains("dev"), "'dev' should be excluded from --only-group flags");
+        assertTrue(arguments.contains("lint"), "Expected 'lint' to remain as --only-group");
+        assertFalse(arguments.contains("dev"), "'dev' should be excluded from --only-group flags");
     }
 
     @Test
     void extractAllOnlyGroupsExcludedResultsInEmptyBom() throws Exception {
         UVBuildExtractor extractor = new UVBuildExtractor(executableRunner, tempDir, transformer);
-        // All only-groups are also excluded
         UVDetectorOptions options = new UVDetectorOptions(
-            Arrays.asList("dev", "lint"),       // excludedGroups
-            Arrays.asList("dev", "lint"),       // onlyGroups
+            Arrays.asList("dev", "lint"),
+            Arrays.asList("dev", "lint"),
             Collections.emptyList(),
             Collections.emptyList()
         );
@@ -270,23 +264,22 @@ class UVBuildExtractorTest {
         Extraction extraction = extractor.extract(uvExe, options, tomlParser);
         assertExtractionSuccess(extraction);
 
-        // uv tree should never be executed since all groups are excluded
         verify(executableRunner, never()).executeSuccessfully(any(Executable.class));
 
-        // BOM should exist but contain zero dependencies
         assertEquals(1, extraction.getCodeLocations().size(), "Expected one code location for empty BOM");
         assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
                 "Expected zero dependencies when all only-groups are excluded");
     }
 
+    // ==================== Helper Methods ====================
 
-    /**
-     * Asserts that the extraction completed on the success path.
-     * Without this check, a NullPointerException or other failure inside extract() would be silently
-     * swallowed by the catch block, causing all argument-verification assertions to still pass
-     * (via Mockito's verify) while the extractor never actually reached the success branch.
-     */
     private void assertExtractionSuccess(Extraction extraction) {
         assertTrue(extraction.isSuccess(), "Extraction should succeed but got: " + extraction.getError());
+    }
+
+    private List<String> captureArguments() throws Exception {
+        ArgumentCaptor<Executable> captor = ArgumentCaptor.forClass(Executable.class);
+        verify(executableRunner).executeSuccessfully(captor.capture());
+        return captor.getValue().getCommandWithArguments();
     }
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
@@ -446,6 +446,231 @@ class UVLockParserTest {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Tests for detect.uv.dependency.groups.only in the lockfile detector
+    // -----------------------------------------------------------------------
+
+    @Test
+    void onlyDependencyGroupsIncludesOnlySpecifiedDevGroup() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"pytest\" },",
+            "]",
+            "lint = [",
+            "    { name = \"ruff\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"pytest\"",
+            "version = \"8.3.0\"",
+            "",
+            "[[package]]",
+            "name = \"ruff\"",
+            "version = \"0.4.1\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertEquals(1, codeLocations.size());
+        DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
+        assertEquals(1, graph.getRootDependencies().size());
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "lint group should not be included");
+    }
+
+    @Test
+    void onlyDependencyGroupsSkipsRegularDependencies() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "dependencies = [",
+            "    { name = \"requests\" },",
+            "]",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"pytest\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"requests\"",
+            "version = \"2.31.0\"",
+            "",
+            "[[package]]",
+            "name = \"pytest\"",
+            "version = \"8.3.0\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertEquals(1, codeLocations.size());
+        DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
+        assertEquals(1, graph.getRootDependencies().size());
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("requests")), "regular [dependencies] should be skipped when only is set");
+    }
+
+    @Test
+    void onlyDependencyGroupsSkipsOptionalDependencies() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"pytest\" },",
+            "]",
+            "",
+            "[package.optional-dependencies]",
+            "extras = [",
+            "    { name = \"boto3\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"pytest\"",
+            "version = \"8.3.0\"",
+            "",
+            "[[package]]",
+            "name = \"boto3\"",
+            "version = \"1.28.0\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertEquals(1, codeLocations.size());
+        DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
+        assertEquals(1, graph.getRootDependencies().size());
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("boto3")), "[optional-dependencies] should be skipped when only is set");
+    }
+
+    @Test
+    void onlyAndExcludedGroupsPartialOverlapExcludedWins() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"pytest\" },",
+            "]",
+            "lint = [",
+            "    { name = \"ruff\" },",
+            "]",
+            "docs = [",
+            "    { name = \"sphinx\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"pytest\"",
+            "version = \"8.3.0\"",
+            "",
+            "[[package]]",
+            "name = \"ruff\"",
+            "version = \"0.4.1\"",
+            "",
+            "[[package]]",
+            "name = \"sphinx\"",
+            "version = \"7.0.0\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Arrays.asList("lint"),
+            Arrays.asList("dev", "lint"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertEquals(1, codeLocations.size());
+        DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
+        assertEquals(1, graph.getRootDependencies().size());
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included (in only, not excluded)");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "lint group should be excluded (excluded wins over only)");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("sphinx")), "docs group should be excluded (not in only list)");
+    }
+
+    @Test
+    void onlyAndExcludedGroupsAllSameReturnsEmptyBom() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"pytest\" },",
+            "]",
+            "lint = [",
+            "    { name = \"ruff\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"pytest\"",
+            "version = \"8.3.0\"",
+            "",
+            "[[package]]",
+            "name = \"ruff\"",
+            "version = \"0.4.1\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Arrays.asList("dev", "lint"),
+            Arrays.asList("dev", "lint"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertTrue(codeLocations.isEmpty(), "All only-groups are also excluded: should return empty BOM");
+    }
+
     private boolean hasDependency(Set<Dependency> dependencies, String name, String version) {
         return dependencies.stream()
             .anyMatch(dep -> dep.getName().equals(name) && dep.getVersion().equals(version));

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
@@ -49,10 +49,10 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected exactly one code location for single-project lock file");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
+        assertEquals(1, graph.getRootDependencies().size(), "Expected one root dependency (requests)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' v2.31.0 as root dependency");
     }
 
     @Test
@@ -87,7 +87,7 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "lib-a", options);
 
-        assertEquals(2, codeLocations.size());
+        assertEquals(2, codeLocations.size(), "Expected two code locations for two workspace members");
     }
 
     @Test
@@ -121,11 +121,11 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(2, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
-        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "7.4.0"));
+        assertEquals(2, graph.getRootDependencies().size(), "Expected two root dependencies (requests + pytest)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' v2.31.0 as root dependency");
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "7.4.0"), "Expected 'pytest' v7.4.0 as root dependency from dev group");
     }
 
     @Test
@@ -163,10 +163,10 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only one root dependency after excluding dev group");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' to remain after excluding dev group");
     }
 
     @Test
@@ -200,11 +200,11 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(2, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
-        assertTrue(hasDependency(graph.getRootDependencies(), "boto3", "1.28.0"));
+        assertEquals(2, graph.getRootDependencies().size(), "Expected two root dependencies (requests + boto3)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' as root dependency");
+        assertTrue(hasDependency(graph.getRootDependencies(), "boto3", "1.28.0"), "Expected 'boto3' as root dependency from optional group");
     }
 
     @Test
@@ -242,10 +242,10 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only one root dependency after excluding extras group");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' to remain after excluding extras");
     }
 
     @Test
@@ -270,9 +270,9 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertTrue(hasDependency(graph.getRootDependencies(), "torch", "2.0.0"));
+        assertTrue(hasDependency(graph.getRootDependencies(), "torch", "2.0.0"), "Expected version '2.0.0' after stripping '+cu118' suffix");
     }
 
     @Test
@@ -297,9 +297,9 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertTrue(hasDependency(graph.getRootDependencies(), "some-package", "1.0.0"));
+        assertTrue(hasDependency(graph.getRootDependencies(), "some-package", "1.0.0"), "Expected underscore in 'some_package' to be normalized to hyphen");
     }
 
     @Test
@@ -328,8 +328,8 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "lib-a", options);
 
-        assertEquals(1, codeLocations.size());
-        assertEquals("lib-a", codeLocations.get(0).getExternalId().get().getName());
+        assertEquals(1, codeLocations.size(), "Expected one code location after excluding lib-b");
+        assertEquals("lib-a", codeLocations.get(0).getExternalId().get().getName(), "Expected lib-a as the remaining workspace member");
     }
 
     @Test
@@ -362,8 +362,8 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "lib-a", options);
 
-        assertEquals(1, codeLocations.size());
-        assertEquals("lib-a", codeLocations.get(0).getExternalId().get().getName());
+        assertEquals(1, codeLocations.size(), "Expected one code location for included member lib-a");
+        assertEquals("lib-a", codeLocations.get(0).getExternalId().get().getName(), "Expected lib-a as the only included workspace member");
     }
 
     @Test
@@ -386,9 +386,9 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertTrue(hasDependency(graph.getRootDependencies(), "no-version-pkg", "defaultVersion"));
+        assertTrue(hasDependency(graph.getRootDependencies(), "no-version-pkg", "defaultVersion"), "Expected 'defaultVersion' when version key is missing");
     }
 
     @Test
@@ -425,17 +425,17 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
 
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"));
+        assertEquals(1, graph.getRootDependencies().size(), "Expected one root dependency (requests)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "requests", "2.31.0"), "Expected 'requests' as root dependency");
 
         Dependency requestsDep = findDependency(graph.getRootDependencies(), "requests");
         Set<Dependency> requestsChildren = graph.getChildrenForParent(requestsDep);
-        assertEquals(2, requestsChildren.size());
-        assertTrue(hasDependency(requestsChildren, "urllib3", "2.0.4"));
-        assertTrue(hasDependency(requestsChildren, "charset-normalizer", "3.2.0"));
+        assertEquals(2, requestsChildren.size(), "Expected two transitive dependencies under requests");
+        assertTrue(hasDependency(requestsChildren, "urllib3", "2.0.4"), "Expected 'urllib3' as transitive dependency of requests");
+        assertTrue(hasDependency(requestsChildren, "charset-normalizer", "3.2.0"), "Expected 'charset-normalizer' as transitive dependency of requests");
     }
 
     private UVDetectorOptions createDefaultOptions() {
@@ -486,11 +486,11 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
-        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "lint group should not be included");
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only one root dependency from the 'dev' group");
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "Expected 'pytest' from dev group to be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "Expected 'ruff' from lint group to NOT be included");
     }
 
     @Test
@@ -529,11 +529,11 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
-        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("requests")), "regular [dependencies] should be skipped when only is set");
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only one root dependency (from dev group, not regular deps)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "Expected 'pytest' from dev group to be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("requests")), "Expected regular [dependencies] to be skipped when onlyGroups is set");
     }
 
     @Test
@@ -574,11 +574,11 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included");
-        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("boto3")), "[optional-dependencies] should be skipped when only is set");
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only one root dependency (from dev group, not optional)");
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "Expected 'pytest' from dev group to be included");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("boto3")), "Expected [optional-dependencies] to be skipped when onlyGroups is set");
     }
 
     @Test
@@ -624,12 +624,12 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertEquals(1, codeLocations.size());
+        assertEquals(1, codeLocations.size(), "Expected one code location");
         DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
-        assertEquals(1, graph.getRootDependencies().size());
-        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "dev group should be included (in only, not excluded)");
-        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "lint group should be excluded (excluded wins over only)");
-        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("sphinx")), "docs group should be excluded (not in only list)");
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only 'pytest' — 'lint' excluded, 'docs' not in onlyGroups");
+        assertTrue(hasDependency(graph.getRootDependencies(), "pytest", "8.3.0"), "Expected 'pytest' (dev group in only, not excluded)");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("ruff")), "Expected 'ruff' excluded (lint in both only and excluded)");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("sphinx")), "Expected 'sphinx' excluded (docs not in onlyGroups list)");
     }
 
     @Test
@@ -668,7 +668,7 @@ class UVLockParserTest {
 
         List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
 
-        assertTrue(codeLocations.isEmpty(), "All only-groups are also excluded: should return empty BOM");
+        assertTrue(codeLocations.isEmpty(), "All only-groups are also excluded: parser should return empty list (extractor handles empty BOM creation)");
     }
 
     private boolean hasDependency(Set<Dependency> dependencies, String name, String version) {

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockfileExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockfileExtractorTest.java
@@ -1,17 +1,25 @@
 package com.blackduck.integration.detectable.detectables.uv.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
 import com.blackduck.integration.detectable.detectables.pip.parser.RequirementsFileDependencyTransformer;
 import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
 import com.blackduck.integration.detectable.detectables.uv.lockfile.UVLockfileExtractor;
@@ -23,9 +31,106 @@ import com.blackduck.integration.util.NameVersion;
 
 class UVLockfileExtractorTest {
 
+    @TempDir
+    Path tempDir;
+
+    /**
+     * When uvLockFile is present and parseLockFile returns empty (because all onlyGroups are
+     * excluded), the extractor should create one empty CodeLocation with project identity so
+     * the BOM still contains the project — consistent with the CLI/buildless detector path.
+     */
     @Test
     void extractReturnsEmptyCodeLocationWhenAllOnlyGroupsExcluded() throws Exception {
-        // Setup: no lock file provided, onlyGroups is set → triggers empty-BOM fallback
+        // Write a real (empty-content) uv.lock file so FileUtils.readFileToString succeeds
+        File uvLockFile = tempDir.resolve("uv.lock").toFile();
+        FileUtils.write(uvLockFile, "", StandardCharsets.UTF_8);
+
+        // parseLockFile returns empty mutable list — faithfully represents the real UVLockParser
+        // which always returns its internal ArrayList (mutable). Simulates all onlyGroups cancelled.
+        UVLockParser lockParser = mock(UVLockParser.class);
+        when(lockParser.parseLockFile(anyString(), anyString(), any())).thenReturn(new ArrayList<>());
+
+        UVTomlParser tomlParser = mock(UVTomlParser.class);
+        when(tomlParser.parseNameVersion()).thenReturn(Optional.of(new NameVersion("my-project", "1.0.0")));
+        when(tomlParser.getProjectName()).thenReturn("my-project");
+
+        PythonDependencyTransformer reqTransformer = mock(PythonDependencyTransformer.class);
+        RequirementsFileDependencyTransformer reqDepTransformer = mock(RequirementsFileDependencyTransformer.class);
+
+        UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
+
+        // excludedGroups = [dev], onlyGroups = [dev] → all onlyGroups cancelled
+        UVDetectorOptions options = new UVDetectorOptions(
+            Arrays.asList("dev"),   // excludedDependencyGroups
+            Arrays.asList("dev"),   // onlyDependencyGroups
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        Extraction extraction = extractor.extract(options, tomlParser, uvLockFile, null);
+
+        assertTrue(extraction.isSuccess(), "Extraction should succeed");
+        assertEquals(1, extraction.getCodeLocations().size(),
+                "Expected exactly one empty CodeLocation preserving project identity in the BOM");
+        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
+                "Expected zero dependencies in the empty BOM (all groups were cancelled)");
+        assertTrue(extraction.getCodeLocations().get(0).getExternalId().isPresent(),
+                "Expected ExternalId to be present so project identity is preserved in the BOM");
+        assertEquals("my-project", extraction.getCodeLocations().get(0).getExternalId().get().getName(),
+                "Expected ExternalId name to match project name 'my-project'");
+        assertEquals("1.0.0", extraction.getCodeLocations().get(0).getExternalId().get().getVersion(),
+                "Expected ExternalId version to match project version '1.0.0'");
+    }
+
+    /**
+     * When uvLockFile is present, parseLockFile returns empty, onlyGroups is set, but the
+     * project version is not available, the extractor should still create one empty CodeLocation
+     * (without an ExternalId) rather than returning zero code locations.
+     */
+    @Test
+    void extractReturnsEmptyCodeLocationWithoutExternalIdWhenProjectVersionMissing() throws Exception {
+        File uvLockFile = tempDir.resolve("uv.lock").toFile();
+        FileUtils.write(uvLockFile, "", StandardCharsets.UTF_8);
+
+        UVLockParser lockParser = mock(UVLockParser.class);
+        when(lockParser.parseLockFile(anyString(), anyString(), any())).thenReturn(new ArrayList<>());
+
+        UVTomlParser tomlParser = mock(UVTomlParser.class);
+        when(tomlParser.parseNameVersion()).thenReturn(Optional.empty()); // no version available
+        when(tomlParser.getProjectName()).thenReturn("my-project");
+
+        PythonDependencyTransformer reqTransformer = mock(PythonDependencyTransformer.class);
+        RequirementsFileDependencyTransformer reqDepTransformer = mock(RequirementsFileDependencyTransformer.class);
+
+        UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
+
+        // excludedGroups = [dev], onlyGroups = [dev] → all cancelled
+        UVDetectorOptions options = new UVDetectorOptions(
+            Arrays.asList("dev"),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        Extraction extraction = extractor.extract(options, tomlParser, uvLockFile, null);
+
+        assertTrue(extraction.isSuccess(), "Extraction should succeed even when project version is missing");
+        assertEquals(1, extraction.getCodeLocations().size(),
+                "Expected exactly one empty CodeLocation even when project version is unavailable");
+        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
+                "Expected zero dependencies in the empty BOM");
+        assertFalse(extraction.getCodeLocations().get(0).getExternalId().isPresent(),
+                "Expected no ExternalId when project version is not available");
+    }
+
+    /**
+     * Regression test for the null-uvLockFile bug:
+     * When uvLockFile is null (only requirements.txt is present), the extractor must NOT
+     * add a spurious empty CodeLocation even when onlyGroups is set, because parseLockFile
+     * was never called — there is no cancellation scenario to compensate for.
+     */
+    @Test
+    void extractDoesNotAddSpuriousEmptyCodeLocationWhenLockFileIsNull() throws Exception {
         UVLockParser lockParser = mock(UVLockParser.class);
 
         UVTomlParser tomlParser = mock(UVTomlParser.class);
@@ -37,54 +142,22 @@ class UVLockfileExtractorTest {
 
         UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
 
-        // onlyGroups = [dev], excludedGroups = [dev] → all cancelled
+        // onlyGroups is set — in the old (buggy) code this would trigger the fallback
+        // even though uvLockFile is null and parseLockFile was never called
         UVDetectorOptions options = new UVDetectorOptions(
-            Arrays.asList("dev"),
-            Arrays.asList("dev"),
+            Arrays.asList("dev"),   // excludedDependencyGroups
+            Arrays.asList("dev"),   // onlyDependencyGroups
             Collections.emptyList(),
             Collections.emptyList()
         );
 
-        // uvLockFile = null simulates the scenario where parseLockFile is not called,
-        // codeLocations stays empty, and the empty-BOM fallback triggers
+        // uvLockFile = null, requirementsTxtFile = null
         Extraction extraction = extractor.extract(options, tomlParser, null, null);
 
         assertTrue(extraction.isSuccess(), "Extraction should succeed");
-        assertEquals(1, extraction.getCodeLocations().size(), "Expected one empty code location with project identity");
-        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
-                "Expected zero dependencies in the empty BOM");
-        assertEquals("my-project", extraction.getCodeLocations().get(0).getExternalId().get().getName(),
-                "Expected project name 'my-project' preserved in the empty code location");
-        assertEquals("1.0.0", extraction.getCodeLocations().get(0).getExternalId().get().getVersion(),
-                "Expected project version '1.0.0' preserved in the empty code location");
-    }
-
-    @Test
-    void extractReturnsEmptyCodeLocationWithoutVersionWhenProjectVersionMissing() throws Exception {
-        UVLockParser lockParser = mock(UVLockParser.class);
-
-        UVTomlParser tomlParser = mock(UVTomlParser.class);
-        when(tomlParser.parseNameVersion()).thenReturn(Optional.empty());
-        when(tomlParser.getProjectName()).thenReturn("my-project");
-
-        PythonDependencyTransformer reqTransformer = mock(PythonDependencyTransformer.class);
-        RequirementsFileDependencyTransformer reqDepTransformer = mock(RequirementsFileDependencyTransformer.class);
-
-        UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
-
-        UVDetectorOptions options = new UVDetectorOptions(
-            Collections.emptyList(),
-            Arrays.asList("dev"),
-            Collections.emptyList(),
-            Collections.emptyList()
-        );
-
-        Extraction extraction = extractor.extract(options, tomlParser, null, null);
-
-        assertTrue(extraction.isSuccess(), "Extraction should succeed even without project version");
-        assertEquals(1, extraction.getCodeLocations().size(), "Expected one empty code location when onlyGroups is set and parser returns empty");
-        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
-                "Expected zero dependencies in the empty BOM");
+        assertEquals(0, extraction.getCodeLocations().size(),
+                "Expected zero code locations: uvLockFile was null so parseLockFile was never called, "
+                + "the empty-BOM fallback must NOT fire in this case");
     }
 }
 

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockfileExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockfileExtractorTest.java
@@ -1,0 +1,90 @@
+package com.blackduck.integration.detectable.detectables.uv.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
+import com.blackduck.integration.detectable.detectables.pip.parser.RequirementsFileDependencyTransformer;
+import com.blackduck.integration.detectable.detectables.uv.UVDetectorOptions;
+import com.blackduck.integration.detectable.detectables.uv.lockfile.UVLockfileExtractor;
+import com.blackduck.integration.detectable.detectables.uv.parse.UVTomlParser;
+import com.blackduck.integration.detectable.detectables.uv.transform.UVLockParser;
+import com.blackduck.integration.detectable.extraction.Extraction;
+import com.blackduck.integration.detectable.python.util.PythonDependencyTransformer;
+import com.blackduck.integration.util.NameVersion;
+
+class UVLockfileExtractorTest {
+
+    @Test
+    void extractReturnsEmptyCodeLocationWhenAllOnlyGroupsExcluded() throws Exception {
+        // Setup: no lock file provided, onlyGroups is set → triggers empty-BOM fallback
+        UVLockParser lockParser = mock(UVLockParser.class);
+
+        UVTomlParser tomlParser = mock(UVTomlParser.class);
+        when(tomlParser.parseNameVersion()).thenReturn(Optional.of(new NameVersion("my-project", "1.0.0")));
+        when(tomlParser.getProjectName()).thenReturn("my-project");
+
+        PythonDependencyTransformer reqTransformer = mock(PythonDependencyTransformer.class);
+        RequirementsFileDependencyTransformer reqDepTransformer = mock(RequirementsFileDependencyTransformer.class);
+
+        UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
+
+        // onlyGroups = [dev], excludedGroups = [dev] → all cancelled
+        UVDetectorOptions options = new UVDetectorOptions(
+            Arrays.asList("dev"),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        // uvLockFile = null simulates the scenario where parseLockFile is not called,
+        // codeLocations stays empty, and the empty-BOM fallback triggers
+        Extraction extraction = extractor.extract(options, tomlParser, null, null);
+
+        assertTrue(extraction.isSuccess(), "Extraction should succeed");
+        assertEquals(1, extraction.getCodeLocations().size(), "Expected one empty code location with project identity");
+        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
+                "Expected zero dependencies in the empty BOM");
+        assertEquals("my-project", extraction.getCodeLocations().get(0).getExternalId().get().getName(),
+                "Expected project name 'my-project' preserved in the empty code location");
+        assertEquals("1.0.0", extraction.getCodeLocations().get(0).getExternalId().get().getVersion(),
+                "Expected project version '1.0.0' preserved in the empty code location");
+    }
+
+    @Test
+    void extractReturnsEmptyCodeLocationWithoutVersionWhenProjectVersionMissing() throws Exception {
+        UVLockParser lockParser = mock(UVLockParser.class);
+
+        UVTomlParser tomlParser = mock(UVTomlParser.class);
+        when(tomlParser.parseNameVersion()).thenReturn(Optional.empty());
+        when(tomlParser.getProjectName()).thenReturn("my-project");
+
+        PythonDependencyTransformer reqTransformer = mock(PythonDependencyTransformer.class);
+        RequirementsFileDependencyTransformer reqDepTransformer = mock(RequirementsFileDependencyTransformer.class);
+
+        UVLockfileExtractor extractor = new UVLockfileExtractor(lockParser, reqTransformer, reqDepTransformer);
+
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        Extraction extraction = extractor.extract(options, tomlParser, null, null);
+
+        assertTrue(extraction.isSuccess(), "Extraction should succeed even without project version");
+        assertEquals(1, extraction.getCodeLocations().size(), "Expected one empty code location when onlyGroups is set and parser returns empty");
+        assertEquals(0, extraction.getCodeLocations().get(0).getDependencyGraph().getRootDependencies().size(),
+                "Expected zero dependencies in the empty BOM");
+    }
+}
+

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -2108,7 +2108,7 @@ public class DetectProperties {
                             "When set, Detect scans only the named groups defined under [dependency-groups] in pyproject.toml. Main project dependencies and optional extras ([project.optional-dependencies]) are excluded from the scan.\n\n" +
                             " Example: detect.uv.dependency.groups.only=dev,lint\n\n" +
                             "This property applies only to UV projects with a pyproject.toml file. The UV detector does not apply to projects using setup.py or setup.cfg.\n\n" +
-                            " If a group appears in both this property and detect.uv.dependency.groups.excluded, the excluded setting takes precedence for overlapping groups and that groups will not be scanned. Detect logs a warning when both properties overlap."
+                            " If a group appears in both this property and detect.uv.dependency.groups.excluded, the excluded setting takes precedence for overlapping groups and those groups will not be scanned. Detect logs a warning when both properties overlap."
                     )
                     .setGroups(DetectGroup.UV, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)
                     .setCategory(DetectCategory.Advanced)

--- a/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
+++ b/src/main/java/com/blackduck/integration/detect/configuration/DetectProperties.java
@@ -2107,7 +2107,7 @@ public class DetectProperties {
                             "A comma-separated list of dependency group names to exclusively include in the BOM.",
                             "When set, Detect scans only the named groups defined under [dependency-groups] in pyproject.toml. Main project dependencies and optional extras ([project.optional-dependencies]) are excluded from the scan.\n\n" +
                             " Example: detect.uv.dependency.groups.only=dev,lint\n\n" +
-                            "Requires a pyproject.toml-based project. Setting this property on a project using setup.py or setup.cfg has no effect and a warning is logged.\n\n" +
+                            "This property applies only to UV projects with a pyproject.toml file. The UV detector does not apply to projects using setup.py or setup.cfg.\n\n" +
                             " If a group appears in both this property and detect.uv.dependency.groups.excluded, the excluded setting takes precedence for overlapping groups and that groups will not be scanned. Detect logs a warning when both properties overlap."
                     )
                     .setGroups(DetectGroup.UV, DetectGroup.GLOBAL, DetectGroup.SOURCE_SCAN)


### PR DESCRIPTION
# Description

This PR audits and fixes the `detect.uv.dependency.groups.only` property support across both the UV build and buildless detector paths. It introduces a shared filter abstraction, fixes behavioral inconsistencies, corrects misleading documentation, and improves test coverage and quality.

## Changes

### Bug Fixes

#### 1. Partial-overlap warning missing in lockfile path

Previously, when `detect.uv.dependency.groups.only` and `detect.uv.dependency.groups.excluded` had a partial overlap (e.g. `only=[dev,lint]`, `excluded=[lint]`), the lockfile parser silently dropped `lint` with no warning. The CLI path already logged a warning for this case.

Both paths now produce identical warning messages (via `UVDependencyGroupFilter`).

#### 2. Inconsistent empty-BOM behavior

When all `onlyGroups` were cancelled by `excludedGroups`:

- CLI path returned 1 `CodeLocation` with empty graph (project identity preserved)
- Lockfile path returned 0 `CodeLocations`

`UVLockfileExtractor` now creates one empty `CodeLocation` with project identity when `parseLockFile` returns empty and `onlyGroups` is set, making both paths consistent.

#### 3. Incorrect help text

The property help text claimed:

> "Setting this property on a project using setup.py or setup.cfg has no effect and a warning is logged."

No such warning existed, and the UV detector requires `pyproject.toml` to even apply.

Updated to accurately state that the UV detector does not apply to `setup.py`/`setup.cfg` projects.

### Refactoring

#### 4. New `UVDependencyGroupFilter` class

Extracted the duplicate conflict-detection and warning logic from both `UVBuildExtractor` and `UVLockParser` into a single shared class.

**Responsibilities:**

- Computes `conflictingGroups` (intersection of `only` and `excluded`)
- Computes `effectiveOnlyGroups` (`only` minus `excluded`)
- Short-circuits computation when `excludedGroups` is empty (no unnecessary streams)
- Centralizes `logGroupConflictWarnings(Logger)` so both paths produce identical messages

#### 5. Eliminated redundant getter calls in `UVLockParser`

`parseDependenciesSection` previously called:

- `uvDetectorOptions.getOnlyDependencyGroups()`
- `getExcludedDependencyGroups()`

on every package iteration (each call allocates a new lowercased `HashSet`).

These sets are now resolved once in `parseDependencies` via the filter and passed down.

### Test Improvements

#### 6. New `UVOnlyGroupsFunctionalTest`

End-to-end functional test validating the `onlyGroups` path:

- verifies `--only-group dev` (not `--all-groups`) is passed to `uv tree`
- verifies that only dev-group dependencies appear in the output graph

#### 7. New `UVLockfileExtractorTest`

Unit tests for the extractor-level empty-BOM fallback (Fix 2):

- asserts that when `parseLockFile` returns empty with `onlyGroups` set, the extractor produces one `CodeLocation` with the correct project identity and zero dependencies
- covers both the case where `parseNameVersion` returns a version and where it doesn't

#### 8. Improved `UVBuildExtractorTest`

- Added descriptive failure messages to all assertions
- Split `extractAddsOnlyGroupFlagsAndSkipsAllExtrasAllGroups` (8 assertions, 3 behaviours) into 3 focused tests:
  - `extractWithOnlyGroupsDoesNotIncludeAllGroupsFlag`
  - `extractWithOnlyGroupsAddsOnlyGroupFlagForEachGroup`
  - `extractWithOnlyGroupsEachGroupPrecededByFlag`
- Extracted `captureArguments()` helper to remove repetition

#### 9. Improved `UVLockParserTest`

Added descriptive failure messages to all assertions so test failures immediately convey what went wrong and why.