### PR TITLE
fix(maven) - Fix Maven CLI parser silent BOM corruption on maven-resolver INFO provenance lines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA2-IDETECT-5287'
+version = '12.1.0-SIGQA3-IDETECT-5287-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA3-IDETECT-5287-SNAPSHOT'
+version = '12.1.0-SIGQA3-IDETECT-5287'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA2-IDETECT-5287-SNAPSHOT'
+version = '12.1.0-SIGQA2-IDETECT-5287'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA1-IDETECT-5287'
+version = '12.1.0-SIGQA2-IDETECT-5287-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA3-IDETECT-5287'
+version = '12.1.0-SIGQA4-IDETECT-5287-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SNAPSHOT'
+version = '12.1.0-SIGQA1-IDETECT-5287'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
@@ -28,13 +28,9 @@ public class MavenCodeLocationPackager {
 
     private static final String END_OF_TREE_PATTERN_STRING = "^-*< .* >-*$";
     private final Pattern endOfTreePattern = Pattern.compile(END_OF_TREE_PATTERN_STRING);
-    // Characters that never appear in a valid Maven coordinate part (groupId,
-    // artifactId, type, classifier, version, scope). Any project-header
-    // candidate whose colon-split parts contain these characters is log prose,
-    // not a GAV, and is rejected. Prevents INFO-level messages (e.g. artifact
-    // provenance warnings from newer maven-resolver versions) that happen to
-    // embed a coordinate and colon-heavy URLs from being mistaken for the
-    // project header.
+    // Characters that are never valid in a Maven coordinate part. A
+    // project-header candidate whose colon-split parts contain any of
+    // these is treated as log prose, not a GAV.
     private static final Pattern PROJECT_COORDINATE_INVALID_CHARS = Pattern.compile("[\\s/()\\[\\]{},]");
     private final ExternalIdFactory externalIdFactory;
     private List<MavenParseResult> codeLocations = new ArrayList<>();
@@ -43,10 +39,13 @@ public class MavenCodeLocationPackager {
     // in-scope components found in an out-of-scope tree go in the orphans list
     private final List<Dependency> orphans = new ArrayList<>();
     private boolean parsingProjectSection;
-    // True if any dependency:tree goal header was observed during this
-    // extraction. Used to emit a WARN when the parser sees a tree section
-    // but fails to anchor a project — a historically-silent failure mode.
+    // True if a dependency:tree goal header was observed in this extraction.
     private boolean treeHeaderEverSeen;
+    // True if at least one valid project GAV was recognized in this
+    // extraction, whether the modules filter later included or excluded it.
+    // Used to distinguish "parser failed to identify a project" from
+    // "modules filter excluded every project."
+    private boolean validProjectHeaderSeen;
     private int level;
     private boolean inOutOfScopeTree = false;
     private DependencyGraph currentGraph = null;
@@ -75,6 +74,7 @@ public class MavenCodeLocationPackager {
         dependencyParentStack = new Stack<>();
         parsingProjectSection = false;
         treeHeaderEverSeen = false;
+        validProjectHeaderSeen = false;
         currentGraph = new BasicDependencyGraph();
 
         if(!shadedDependencies.isEmpty()) {
@@ -130,12 +130,10 @@ public class MavenCodeLocationPackager {
         addOrphansToGraph(currentGraph, orphans);
         logger.debug(String.format("Modified %d Eclipse package external IDs.", eclipsePackageExternalIdModifiedCounter));
 
-        // If we saw a dependency:tree goal header but never anchored a
-        // project, the parser was unable to identify the project GAV in
-        // Maven's output. This has historically manifested as a SUCCESS
-        // scan with an empty BOM. Emit a WARN so the condition is visible
-        // in the run log instead of failing silently.
-        if (treeHeaderEverSeen && codeLocations.isEmpty()) {
+        // Warn if a tree header was seen but no project GAV was ever
+        // recognized. Keyed on validProjectHeaderSeen so scans where the
+        // modules filter legitimately excludes every project do not warn.
+        if (treeHeaderEverSeen && !validProjectHeaderSeen) {
             logger.warn(
                 "Maven dependency:tree output was scanned but no project could be extracted. "
               + "This can occur when Maven or maven-resolver emits unexpected INFO lines "
@@ -169,45 +167,45 @@ public class MavenCodeLocationPackager {
     }
 
     private void initializeCurrentMavenProject(ExcludedIncludedWildcardFilter modulesFilter, String sourcePath, String line) {
-        // The candidate line is the first non-noise line seen after a
-        // dependency:tree goal header. In well-formed Maven output this is
-        // always the project GAV. Three outcomes are possible:
-        //   (1) valid GAV, module included -> anchor the project and start
-        //       collecting the tree.
-        //   (2) valid GAV, module excluded by the user's modules filter ->
-        //       disarm parsingProjectSection so we fast-forward past this
-        //       module's tree body until the next @ module header re-arms.
-        //   (3) not a valid GAV -> keep parsingProjectSection = true and
-        //       retry the next non-noise line. This lets the parser recover
-        //       when Maven or maven-resolver emit unexpected INFO lines
-        //       between the tree header and the project header.
-        // The graph is allocated only when we actually anchor a project,
-        // to avoid churn while (3) retries consume candidate lines.
-        DependencyGraph candidateGraph = new BasicDependencyGraph();
-        MavenParseResult mavenProject = createMavenParseResult(sourcePath, line, candidateGraph);
+        // The candidate line is the first non-noise line after a
+        // dependency:tree goal header. Three outcomes:
+        //   (1) valid GAV, module included -> anchor and start collecting.
+        //   (2) valid GAV, module excluded -> disarm so the tree body is
+        //       fast-forwarded until the next @ module header re-arms.
+        //   (3) anything else -> keep parsingProjectSection = true and
+        //       retry the next non-noise line.
+        //
+        // End-of-section for an anchored module is handled by the main
+        // loop's finished branch, not here.
+        //
+        // currentGraph is allocated unconditionally here so leftover
+        // shaded-dependency orphans emitted at end-of-extraction are
+        // isolated per candidate — reassigning only in the happy path
+        // would let an excluded module's leftovers attach to a
+        // previously-anchored module's graph.
+        currentGraph = new BasicDependencyGraph();
+        MavenParseResult mavenProject = createMavenParseResult(sourcePath, line, currentGraph);
         if (null != mavenProject && modulesFilter.shouldInclude(mavenProject.getProjectName())) {
-            // (1) Happy path.
+            // (1) Anchor.
             logger.trace(String.format("Project: %s", mavenProject.getProjectName()));
-            currentGraph = candidateGraph;
             this.currentMavenProject = mavenProject;
             codeLocations.add(mavenProject);
+            validProjectHeaderSeen = true;
         } else if (null != mavenProject) {
-            // (2) Excluded module: valid GAV, but filtered out. Disarm so
-            // subsequent tree body lines are skipped by shouldSkipLine's
+            // (2) Excluded by modules filter. Disarm so subsequent tree
+            // body lines are skipped by shouldSkipLine's
             // !parsingProjectSection gate.
             logger.trace(String.format("Project %s excluded by modules filter", mavenProject.getProjectName()));
             currentMavenProject = null;
             dependencyParentStack.clear();
             parsingProjectSection = false;
             level = 0;
+            validProjectHeaderSeen = true;
         } else {
-            // (3) Candidate line was not a valid project GAV. Do NOT disarm —
-            // leave parsingProjectSection = true so the next non-noise line
-            // is retried as a header candidate.
+            // (3) Not a GAV. Retry on the next line.
             logger.debug(String.format(
                 "Line following dependency:tree header did not parse as a project GAV; will retry with the next non-noise line. Line: %s",
                 line));
-            // Intentionally leave parsingProjectSection, dependencyParentStack, level untouched.
         }
     }
 
@@ -416,15 +414,15 @@ public class MavenCodeLocationPackager {
         // This is a GAV line.
         componentText = removeGroupArtifactPipedSuffixIfExists(componentText);
 
-        String[] gavParts = componentText.split(":");
+        // Preserve trailing empty fields so "g:a:jar:1.0:" is rejected
+        // as invalid rather than silently truncated to 4 parts.
+        String[] gavParts = componentText.split(":", -1);
 
-        // Strict project-header validation. A valid project GAV is exactly
-        // G:A:type:V (4 parts) or G:A:type:classifier:V (5 parts). isGav()
-        // only enforces "at least 4 non-blank parts", which is too loose —
-        // log prose that happens to embed a coordinate and colon-heavy URLs
-        // (e.g. maven-resolver provenance INFO lines listing repository URLs
-        // with explicit :PORTs) can otherwise slip through and be
-        // misidentified as the project header.
+        // A valid project GAV is exactly G:A:type:V (4 parts) or
+        // G:A:type:classifier:V (5 parts), and each part must contain
+        // only characters valid in a Maven coordinate. Reject anything
+        // else — including log prose that embeds a coordinate and
+        // colon-heavy URLs.
         if (gavParts.length != 4 && gavParts.length != 5) {
             logger.debug(String.format(
                 "%s does not look like a project header we can parse (colon-part count: %d)",
@@ -432,6 +430,12 @@ public class MavenCodeLocationPackager {
             return null;
         }
         for (String part : gavParts) {
+            if (StringUtils.isBlank(part)) {
+                logger.debug(String.format(
+                    "%s does not look like a project header we can parse (blank part)",
+                    componentText));
+                return null;
+            }
             if (PROJECT_COORDINATE_INVALID_CHARS.matcher(part).find()) {
                 logger.debug(String.format(
                     "%s does not look like a project header we can parse (part '%s' contains characters not valid in a Maven coordinate)",

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/maven/cli/MavenCodeLocationPackager.java
@@ -28,6 +28,14 @@ public class MavenCodeLocationPackager {
 
     private static final String END_OF_TREE_PATTERN_STRING = "^-*< .* >-*$";
     private final Pattern endOfTreePattern = Pattern.compile(END_OF_TREE_PATTERN_STRING);
+    // Characters that never appear in a valid Maven coordinate part (groupId,
+    // artifactId, type, classifier, version, scope). Any project-header
+    // candidate whose colon-split parts contain these characters is log prose,
+    // not a GAV, and is rejected. Prevents INFO-level messages (e.g. artifact
+    // provenance warnings from newer maven-resolver versions) that happen to
+    // embed a coordinate and colon-heavy URLs from being mistaken for the
+    // project header.
+    private static final Pattern PROJECT_COORDINATE_INVALID_CHARS = Pattern.compile("[\\s/()\\[\\]{},]");
     private final ExternalIdFactory externalIdFactory;
     private List<MavenParseResult> codeLocations = new ArrayList<>();
     private MavenParseResult currentMavenProject = null;
@@ -35,6 +43,10 @@ public class MavenCodeLocationPackager {
     // in-scope components found in an out-of-scope tree go in the orphans list
     private final List<Dependency> orphans = new ArrayList<>();
     private boolean parsingProjectSection;
+    // True if any dependency:tree goal header was observed during this
+    // extraction. Used to emit a WARN when the parser sees a tree section
+    // but fails to anchor a project — a historically-silent failure mode.
+    private boolean treeHeaderEverSeen;
     private int level;
     private boolean inOutOfScopeTree = false;
     private DependencyGraph currentGraph = null;
@@ -62,6 +74,7 @@ public class MavenCodeLocationPackager {
         currentMavenProject = null;
         dependencyParentStack = new Stack<>();
         parsingProjectSection = false;
+        treeHeaderEverSeen = false;
         currentGraph = new BasicDependencyGraph();
 
         if(!shadedDependencies.isEmpty()) {
@@ -117,6 +130,19 @@ public class MavenCodeLocationPackager {
         addOrphansToGraph(currentGraph, orphans);
         logger.debug(String.format("Modified %d Eclipse package external IDs.", eclipsePackageExternalIdModifiedCounter));
 
+        // If we saw a dependency:tree goal header but never anchored a
+        // project, the parser was unable to identify the project GAV in
+        // Maven's output. This has historically manifested as a SUCCESS
+        // scan with an empty BOM. Emit a WARN so the condition is visible
+        // in the run log instead of failing silently.
+        if (treeHeaderEverSeen && codeLocations.isEmpty()) {
+            logger.warn(
+                "Maven dependency:tree output was scanned but no project could be extracted. "
+              + "This can occur when Maven or maven-resolver emits unexpected INFO lines "
+              + "between the tree header and the project header. "
+              + "No components will be reported for this Maven detector run.");
+        }
+
         return codeLocations;
     }
 
@@ -130,6 +156,7 @@ public class MavenCodeLocationPackager {
         }
         if (isProjectSection(line)) {
             parsingProjectSection = true;
+            treeHeaderEverSeen = true;
             return true;
         }
         if (!parsingProjectSection) {
@@ -142,19 +169,45 @@ public class MavenCodeLocationPackager {
     }
 
     private void initializeCurrentMavenProject(ExcludedIncludedWildcardFilter modulesFilter, String sourcePath, String line) {
-        // this is the first line of a new code location, the following lines will be the tree of dependencies for this code location
-        currentGraph = new BasicDependencyGraph();
-        MavenParseResult mavenProject = createMavenParseResult(sourcePath, line, currentGraph);
+        // The candidate line is the first non-noise line seen after a
+        // dependency:tree goal header. In well-formed Maven output this is
+        // always the project GAV. Three outcomes are possible:
+        //   (1) valid GAV, module included -> anchor the project and start
+        //       collecting the tree.
+        //   (2) valid GAV, module excluded by the user's modules filter ->
+        //       disarm parsingProjectSection so we fast-forward past this
+        //       module's tree body until the next @ module header re-arms.
+        //   (3) not a valid GAV -> keep parsingProjectSection = true and
+        //       retry the next non-noise line. This lets the parser recover
+        //       when Maven or maven-resolver emit unexpected INFO lines
+        //       between the tree header and the project header.
+        // The graph is allocated only when we actually anchor a project,
+        // to avoid churn while (3) retries consume candidate lines.
+        DependencyGraph candidateGraph = new BasicDependencyGraph();
+        MavenParseResult mavenProject = createMavenParseResult(sourcePath, line, candidateGraph);
         if (null != mavenProject && modulesFilter.shouldInclude(mavenProject.getProjectName())) {
+            // (1) Happy path.
             logger.trace(String.format("Project: %s", mavenProject.getProjectName()));
+            currentGraph = candidateGraph;
             this.currentMavenProject = mavenProject;
             codeLocations.add(mavenProject);
-        } else {
-            logger.trace("Project: unknown");
+        } else if (null != mavenProject) {
+            // (2) Excluded module: valid GAV, but filtered out. Disarm so
+            // subsequent tree body lines are skipped by shouldSkipLine's
+            // !parsingProjectSection gate.
+            logger.trace(String.format("Project %s excluded by modules filter", mavenProject.getProjectName()));
             currentMavenProject = null;
             dependencyParentStack.clear();
             parsingProjectSection = false;
             level = 0;
+        } else {
+            // (3) Candidate line was not a valid project GAV. Do NOT disarm —
+            // leave parsingProjectSection = true so the next non-noise line
+            // is retried as a header candidate.
+            logger.debug(String.format(
+                "Line following dependency:tree header did not parse as a project GAV; will retry with the next non-noise line. Line: %s",
+                line));
+            // Intentionally leave parsingProjectSection, dependencyParentStack, level untouched.
         }
     }
 
@@ -364,18 +417,38 @@ public class MavenCodeLocationPackager {
         componentText = removeGroupArtifactPipedSuffixIfExists(componentText);
 
         String[] gavParts = componentText.split(":");
+
+        // Strict project-header validation. A valid project GAV is exactly
+        // G:A:type:V (4 parts) or G:A:type:classifier:V (5 parts). isGav()
+        // only enforces "at least 4 non-blank parts", which is too loose —
+        // log prose that happens to embed a coordinate and colon-heavy URLs
+        // (e.g. maven-resolver provenance INFO lines listing repository URLs
+        // with explicit :PORTs) can otherwise slip through and be
+        // misidentified as the project header.
+        if (gavParts.length != 4 && gavParts.length != 5) {
+            logger.debug(String.format(
+                "%s does not look like a project header we can parse (colon-part count: %d)",
+                componentText, gavParts.length));
+            return null;
+        }
+        for (String part : gavParts) {
+            if (PROJECT_COORDINATE_INVALID_CHARS.matcher(part).find()) {
+                logger.debug(String.format(
+                    "%s does not look like a project header we can parse (part '%s' contains characters not valid in a Maven coordinate)",
+                    componentText, part));
+                return null;
+            }
+        }
+
         String group = gavParts[0];
         String artifact = gavParts[1];
         String version;
         if (gavParts.length == 4) {
             // Dependency does not include the classifier
             version = gavParts[gavParts.length - 1];
-        } else if (gavParts.length == 5) {
-            // Dependency does include the classifier
-            version = gavParts[gavParts.length - 1]; //Should be 2. Possible sleeper.
         } else {
-            logger.debug(String.format("%s does not look like a dependency we can parse", componentText));
-            return null;
+            // Dependency does include the classifier (gavParts.length == 5)
+            version = gavParts[gavParts.length - 1]; //Should be 2. Possible sleeper.
         }
         ExternalId externalId = externalIdFactory.createMavenExternalId(group, artifact, version);
         return new Dependency(artifact, version, externalId);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/maven/unit/MavenCodeLocationPackagerTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/maven/unit/MavenCodeLocationPackagerTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.blackduck.integration.bdio.model.Forge;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +17,7 @@ import com.blackduck.integration.bdio.model.dependency.Dependency;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.annotations.UnitTest;
 import com.blackduck.integration.detectable.detectables.maven.cli.MavenCodeLocationPackager;
+import com.blackduck.integration.detectable.detectables.maven.cli.MavenParseResult;
 import com.blackduck.integration.detectable.detectables.maven.cli.ScopedDependency;
 
 @UnitTest
@@ -267,5 +272,104 @@ public class MavenCodeLocationPackagerTest {
         String cleanedLine = mavenCodeLocationPackager.calculateCurrentLevelAndCleanLine(line);
         Dependency dependency = mavenCodeLocationPackager.textToDependency(cleanedLine);
         assertEquals("org.eclipse.scout.sdk.deps:org.eclipse.core.jobs:pants (version selected from", dependency.getExternalId().createExternalId());
+    }
+
+    // Provenance INFO line with a 5-part colon split that would previously
+    // have been latched as a fake project header. Real project GAV should
+    // still be anchored on the next line.
+    @Test
+    public void testProvenanceInfoLineWithFewColons_realProjectStillAnchored() {
+        MavenCodeLocationPackager packager = new MavenCodeLocationPackager(new ExternalIdFactory());
+        List<String> mavenOutput = Arrays.asList(
+            "[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ demo ---",
+            "[INFO] Artifact org.codehaus.plexus:plexus-utils:pom:4.0.1 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [internal (https://repo.maven.apache.org/maven2, default, releases+snapshots)]",
+            "[INFO] com.example:demo:jar:1.0",
+            "[INFO] +- com.google.guava:guava:jar:32.1.3-jre:compile"
+        );
+
+        List<MavenParseResult> results = packager.extractCodeLocations(
+            "", mavenOutput,
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyMap()
+        );
+
+        assertEquals(1, results.size());
+        assertEquals("demo", results.get(0).getProjectName());
+        assertEquals("1.0", results.get(0).getProjectVersion());
+    }
+
+    // Provenance INFO line with a many-part colon split (URL contains ":443")
+    // that would previously have disarmed the parser and produced an empty
+    // BOM. Real project GAV should still be anchored on the next line.
+    @Test
+    public void testProvenanceInfoLineWithManyColons_realProjectStillAnchored() {
+        MavenCodeLocationPackager packager = new MavenCodeLocationPackager(new ExternalIdFactory());
+        List<String> mavenOutput = Arrays.asList(
+            "[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ demo ---",
+            "[INFO] Artifact org.codehaus.plexus:plexus-utils:pom:4.0.1 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [internal (https://repo.maven.apache.org:443/maven2, default, releases+snapshots)]",
+            "[INFO] com.example:demo:jar:1.0",
+            "[INFO] +- com.google.guava:guava:jar:32.1.3-jre:compile"
+        );
+
+        List<MavenParseResult> results = packager.extractCodeLocations(
+            "", mavenOutput,
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyMap()
+        );
+
+        assertEquals(1, results.size());
+        assertEquals("demo", results.get(0).getProjectName());
+        assertEquals("1.0", results.get(0).getProjectVersion());
+    }
+
+    // Tree goal header seen but no valid project GAV ever recognized in the
+    // output. Extraction must return an empty list (not a fabricated one).
+    @Test
+    public void testTreeHeaderButNoValidProjectGav_returnsEmpty() {
+        MavenCodeLocationPackager packager = new MavenCodeLocationPackager(new ExternalIdFactory());
+        List<String> mavenOutput = Arrays.asList(
+            "[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ demo ---",
+            "[INFO] Artifact org.codehaus.plexus:plexus-utils:pom:4.0.1 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [internal (https://repo.maven.apache.org/maven2, default, releases+snapshots)]",
+            "[INFO] BUILD SUCCESS"
+        );
+
+        List<MavenParseResult> results = packager.extractCodeLocations(
+            "", mavenOutput,
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyMap()
+        );
+
+        assertTrue(results.isEmpty());
+    }
+
+    // Reactor with two modules where the user excludes one. Only the
+    // included module should be returned; the excluded module's tree body
+    // must not leak into the included module.
+    @Test
+    public void testExcludedModuleFilter_onlyIncludedModuleReturned() {
+        MavenCodeLocationPackager packager = new MavenCodeLocationPackager(new ExternalIdFactory());
+        List<String> mavenOutput = Arrays.asList(
+            "[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ moduleA ---",
+            "[INFO] com.example:moduleA:jar:1.0",
+            "[INFO] +- com.google.guava:guava:jar:32.1.3-jre:compile",
+            "[INFO] ------------------------------------------------------------------------",
+            "[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ moduleB ---",
+            "[INFO] com.example:moduleB:jar:1.0",
+            "[INFO] +- org.apache.commons:commons-lang3:jar:3.14.0:compile",
+            "[INFO] ------------------------------------------------------------------------"
+        );
+
+        List<MavenParseResult> results = packager.extractCodeLocations(
+            "", mavenOutput,
+            Collections.emptyList(), Collections.emptyList(),
+            Collections.singletonList("moduleB"), Collections.emptyList(),
+            Collections.emptyMap()
+        );
+
+        assertEquals(1, results.size());
+        assertEquals("moduleA", results.get(0).getProjectName());
     }
 }


### PR DESCRIPTION
## What
Fixes silent Maven scan corruption on Maven 3.9.1+ when the local `~/.m2`
cache holds artifacts recorded under repository IDs that aren't in the
active `settings.xml` (typical corporate Artifactory/Nexus mirror shape).


## Symptom
Maven-resolver emits an INFO provenance line between the `dependency:tree`
goal header and the project GAV. The parser mistook it for the header and
produced one of two wrong results — both reported as SUCCESS:
- BOM under a **fabricated project name** (few colons in the line)
- **Empty BOM** under the correct project name (many colons in the line)

## Fix
In `MavenCodeLocationPackager`:
1. On an unrecognized header candidate, keep looking on the next line
   instead of tearing down parser state.
2. Strict validation in `textToProject`: exactly 4/5 colon-parts and no
   whitespace/slashes/parens/brackets/braces/commas per part.
3. WARN when a `dependency:tree` header was seen but no project was
   anchored, so this class of failure surfaces in logs going forward.
4. Preserved existing `detect.maven.excluded.modules` behavior.