### PR TITLE
Improvement (Bazel Tool): Structural refactoring, query caching, etc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA3-IDETECT-5277'
+version = '12.1.0-SIGQA4-IDETECT-5277-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA3-IDETECT-5277-SNAPSHOT'
+version = '12.1.0-SIGQA3-IDETECT-5277'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA2-IDETECT-5277-SNAPSHOT'
+version = '12.1.0-SIGQA2-IDETECT-5277'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA4-IDETECT-5277-SNAPSHOT'
+version = '12.1.0-SIGQA4-IDETECT-5277'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SNAPSHOT'
+version = '12.1.0-SIGQA1-IDETECT-5277'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA2-IDETECT-5277'
+version = '12.1.0-SIGQA3-IDETECT-5277-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA4-IDETECT-5277'
+version = '12.1.0-SIGQA5-IDETECT-5277-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA1-IDETECT-5277'
+version = '12.1.0-SIGQA2-IDETECT-5277-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/HttpArchiveDispatchPipeline.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/HttpArchiveDispatchPipeline.java
@@ -58,22 +58,22 @@ public class HttpArchiveDispatchPipeline extends Pipeline {
     public List<Dependency> run() throws DetectableException, ExecutableFailedException {
         // WORKSPACE-only environment: run workspace pipeline and return its result.
         if (mode == BazelEnvironmentAnalyzer.Mode.WORKSPACE) {
-            logger.info("HttpArchiveDispatch: mode=WORKSPACE → running workspace pipeline only");
+            logger.debug("HttpArchiveDispatch: mode=WORKSPACE → running workspace pipeline only");
             return workspacePipeline.run();
         }
 
         // BZLMOD-capable environment: attempt bzlmod pipeline first.
         try {
-            logger.info("HttpArchiveDispatch: mode=BZLMOD → attempting bzlmod pipeline first");
+            logger.debug("HttpArchiveDispatch: mode=BZLMOD → attempting bzlmod pipeline first");
             List<Dependency> bzlmodDeps = bzlmodPipeline.run();
             if (bzlmodDeps != null && !bzlmodDeps.isEmpty()) {
                 logger.debug("HttpArchiveDispatch: bzlmod pipeline produced {} deps → returning", bzlmodDeps.size());
                 return bzlmodDeps;
             }
-            logger.info("HttpArchiveDispatch: bzlmod pipeline returned empty result → fallback to workspace pipeline");
+            logger.debug("HttpArchiveDispatch: bzlmod pipeline returned empty result → fallback to workspace pipeline");
         } catch (ExecutableFailedException | DetectableException e) {
             // Controlled fallback for HTTP probing only. Do not treat as fatal here.
-            logger.info("HttpArchiveDispatch: bzlmod pipeline failed, falling back to workspace pipeline: {}", e.getMessage());
+            logger.debug("HttpArchiveDispatch: bzlmod pipeline failed, falling back to workspace pipeline: {}", e.getMessage());
             logger.debug("HttpArchiveDispatch: exception", e);
         }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/Pipelines.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/Pipelines.java
@@ -14,6 +14,7 @@ import com.blackduck.integration.detectable.detectables.bazel.pipeline.xpathquer
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
 import com.blackduck.integration.detectable.detectables.bazel.query.OutputFormat;
 import com.blackduck.integration.detectable.detectables.bazel.v2.BazelEnvironmentAnalyzer;
+import com.blackduck.integration.detectable.detectables.bazel.v2.BazelInfrastructureModules;
 import com.blackduck.integration.detectable.detectables.bazel.v2.BazelVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,8 @@ public class Pipelines {
     private static final String STRIP_LEADING_ATS_REGEX = "^@+";
     private static final String STRIP_SINGLE_AT_REGEX = "^@";
     private static final String STRIP_REPO_PATH_REGEX = "//.*";
-    private static final String EXCLUDE_BUILTINS_REGEX = "^(?!(bazel_tools|platforms|remotejdk|local_config_.*|rules_python|rules_java|rules_cc|maven|unpinned_maven|rules_jvm_external)).*$";
+    // Infrastructure/builtins exclusion regex is derived from the single BazelInfrastructureModules source of truth.
+    private static final String EXCLUDE_BUILTINS_REGEX = BazelInfrastructureModules.exclusionLookaheadRegex();
     private static final String PREPEND_AT = "@";
     private static final String PREPEND_EXTERNAL = "//external:";
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelCommandExecutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelCommandExecutor.java
@@ -60,7 +60,7 @@ public class BazelCommandExecutor {
      * @return stdout content if non-empty, {@link Optional#empty()} otherwise
      */
     public Optional<String> executeModCommandToString(List<String> args) {
-        ExecutableOutput result = executeWithoutThrowing(args);
+        ExecutableOutput result = executeToleratingExitCode(args);
         int exitCode = result.getReturnCode();
         if (exitCode != 0) {
             String stderr = result.getErrorOutput();
@@ -102,7 +102,7 @@ public class BazelCommandExecutor {
      * @throws ExecutableFailedException if exit code is non-zero and not 3
      */
     public Optional<String> executeQueryToString(List<String> args) throws ExecutableFailedException {
-        ExecutableOutput result = executeWithoutThrowing(args);
+        ExecutableOutput result = executeToleratingExitCode(args);
         int exitCode = result.getReturnCode();
 
         if (exitCode == BAZEL_EXIT_CODE_PARTIAL_SUCCESS) {
@@ -142,12 +142,25 @@ public class BazelCommandExecutor {
     private static final int BAZEL_EXIT_CODE_PARTIAL_SUCCESS = 3;
 
     /**
-     * Executes a Bazel command without throwing on failure, allowing caller to inspect exit code and error output.
-     * Used for probing commands where we need to distinguish different failure modes.
+     * Executes a Bazel command and returns the raw {@link ExecutableOutput} <b>without throwing on a
+     * non-zero exit code</b>, so the caller can inspect the return code, stdout, and stderr itself.
+     * This is the counterpart to {@link #executeToString} / {@code executeSuccessfully}, which treat
+     * any non-zero exit as a hard failure. Probing commands need the opposite: a non-zero exit is
+     * frequently expected and still carries usable output (e.g. a broken but unrelated module
+     * extension poisons the exit code to 2 while the requested graph is fully written to stdout).
+     *
+     * <p><b>Why this method still throws:</b> the {@code catch} below only triggers on an
+     * {@link com.blackduck.integration.executable.ExecutableRunnerException} — i.e. Bazel could not be
+     * launched at all (executable missing, IO error, interrupted). That is a genuinely unrecoverable
+     * environment problem, distinct from "Bazel ran and returned a non-zero exit code." There is no
+     * meaningful {@code ExecutableOutput} to hand back when the process never started, and returning a
+     * fabricated empty result would silently mask a broken setup as an empty query result. So a
+     * launch failure is surfaced as a {@link RuntimeException}; a non-zero exit is not.
+     *
      * @param args Bazel command arguments
      * @return ExecutableOutput containing return code, stdout, and stderr
      */
-    public ExecutableOutput executeWithoutThrowing(List<String> args) {
+    public ExecutableOutput executeToleratingExitCode(List<String> args) {
         try {
             return executableRunner.execute(ExecutableUtils.createFromTarget(workspaceDir, bazelExe, args));
         } catch (Exception e) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelCommandExecutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelCommandExecutor.java
@@ -1,8 +1,11 @@
 package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -22,6 +25,19 @@ public class BazelCommandExecutor {
     private final ExecutableTarget bazelExe;
     private static final String BAZEL = "bazel";
 
+    // Memoization of read-only Bazel command results for the lifetime of a single extraction.
+    // The workspace is never modified between Bazel invocations during a scan, so an identical
+    // command is deterministic — we cache its raw ExecutableOutput and reuse it. Caching at this
+    // lowest layer (executeToleratingExitCode) means every read-only path that funnels through it —
+    // executeQueryToString (query/cquery) and executeModCommandToString (mod graph / show_repo) —
+    // shares one cache. This eliminates redundant re-execution of, e.g., the kind(.*library, deps(T))
+    // query (issued during probing and again during extraction) and 'mod graph --output json'
+    // (issued by both HttpFamilyProber's fast path and BzlmodBcrExtractor), without relying on
+    // Bazel's server-side analysis cache (which may be evicted by intervening commands).
+    // Keyed on the exact argument list; only successful (non-throwing) results are cached, and each
+    // caller still applies its own exit-code interpretation to the shared raw output.
+    private final Map<List<String>, ExecutableOutput> rawOutputCache = new HashMap<>();
+
     public BazelCommandExecutor(DetectableExecutableRunner executableRunner, File workspaceDir, ExecutableTarget bazelExe) {
         this.executableRunner = executableRunner;
         this.workspaceDir = workspaceDir;
@@ -29,13 +45,27 @@ public class BazelCommandExecutor {
     }
 
     public Optional<String> executeToString(List<String> args) throws ExecutableFailedException {
-        ExecutableOutput targetDependenciesQueryResults = executableRunner.executeSuccessfully(ExecutableUtils.createFromTarget(workspaceDir, bazelExe, args));
-        String cmdStdErr = targetDependenciesQueryResults.getErrorOutput();
+        // Route through the cached raw-output path (executeToleratingExitCode) so an identical
+        // read-only command issued elsewhere in the extraction (e.g. the same maven cquery run by a
+        // pipeline via executeQueryToString) is reused instead of re-executed.
+        //
+        // Semantics are preserved exactly: this method is strict — ANY non-zero exit code is a hard
+        // failure surfaced as ExecutableFailedException (it does NOT tolerate exit 3, unlike
+        // executeQueryToString). A launch failure still propagates as the RuntimeException thrown by
+        // executeToleratingExitCode; callers (BazelGraphProber probes, HttpFamilyProber) catch broadly.
+        ExecutableOutput result = executeToleratingExitCode(args);
+        if (result.getReturnCode() != 0) {
+            throw new ExecutableFailedException(
+                ExecutableUtils.createFromTarget(workspaceDir, bazelExe, args),
+                result
+            );
+        }
+        String cmdStdErr = result.getErrorOutput();
         if (cmdStdErr != null && cmdStdErr.contains("ERROR")) {
             logger.warn("Bazel error: {}", cmdStdErr.trim());
         }
-        String cmdStdOut = targetDependenciesQueryResults.getStandardOutput();
-        if ((StringUtils.isBlank(cmdStdOut))) {
+        String cmdStdOut = result.getStandardOutput();
+        if (StringUtils.isBlank(cmdStdOut)) {
             logger.debug("bazel command produced no output");
             return Optional.empty();
         }
@@ -102,6 +132,8 @@ public class BazelCommandExecutor {
      * @throws ExecutableFailedException if exit code is non-zero and not 3
      */
     public Optional<String> executeQueryToString(List<String> args) throws ExecutableFailedException {
+        // Raw output is served from the shared per-extraction cache (see executeToleratingExitCode);
+        // this method re-applies query exit-code interpretation to it on every call.
         ExecutableOutput result = executeToleratingExitCode(args);
         int exitCode = result.getReturnCode();
 
@@ -156,13 +188,25 @@ public class BazelCommandExecutor {
      * meaningful {@code ExecutableOutput} to hand back when the process never started, and returning a
      * fabricated empty result would silently mask a broken setup as an empty query result. So a
      * launch failure is surfaced as a {@link RuntimeException}; a non-zero exit is not.
+     * <p><b>Caching:</b> successful results are memoized per extraction in {@link #rawOutputCache}
+     * keyed on the exact argument list, so an identical read-only command issued more than once
+     * (e.g. during probing and again during extraction) runs Bazel only once. A launch failure is
+     * never cached.
      *
      * @param args Bazel command arguments
      * @return ExecutableOutput containing return code, stdout, and stderr
      */
     public ExecutableOutput executeToleratingExitCode(List<String> args) {
+        List<String> cacheKey = (args == null) ? Collections.emptyList() : new ArrayList<>(args);
+        ExecutableOutput cached = rawOutputCache.get(cacheKey);
+        if (cached != null) {
+            logger.debug("Reusing cached Bazel command result for args: {}", cacheKey);
+            return cached;
+        }
         try {
-            return executableRunner.execute(ExecutableUtils.createFromTarget(workspaceDir, bazelExe, args));
+            ExecutableOutput output = executableRunner.execute(ExecutableUtils.createFromTarget(workspaceDir, bazelExe, args));
+            rawOutputCache.put(cacheKey, output);
+            return output;
         } catch (Exception e) {
             String command = (bazelExe != null ? bazelExe.toCommand() : BAZEL) + " " + String.join(" ", args == null ? Collections.emptyList() : args);
             String msg = String.format("Failed to execute Bazel command '%s': %s", command, e.getMessage());

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelVariableSubstitutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelVariableSubstitutor.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +22,18 @@ public class BazelVariableSubstitutor {
         listInsertions.put("${detect.bazel.query.options}", queryAdditionalOptions);
     }
 
-    public List<String> substitute(List<String> origStrings, String input) {
-        List<String> modifiedStrings = new ArrayList<>(origStrings.size());
+    /**
+     * Returns the user-supplied {@code detect.bazel.query.options} list (never null).
+     * Allows callers that build queries directly (not via placeholder substitution) — e.g. the
+     * BCR target-scope query — to apply the same options, keeping their command args identical to
+     * the substituted pipeline/prober queries.
+     */
+    public List<String> getQueryAdditionalOptions() {
+        List<String> opts = listInsertions.get("${detect.bazel.query.options}");
+        return opts != null ? opts : Collections.emptyList();
+    }
+
+    public List<String> substitute(List<String> origStrings, String input) {        List<String> modifiedStrings = new ArrayList<>(origStrings.size());
         for (String origString : origStrings) {
             boolean foundListInsertionPlaceholder = handleListInsertion(modifiedStrings, origString, input);
             if (!foundListInsertionPlaceholder) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelVariableSubstitutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/BazelVariableSubstitutor.java
@@ -33,7 +33,8 @@ public class BazelVariableSubstitutor {
         return opts != null ? opts : Collections.emptyList();
     }
 
-    public List<String> substitute(List<String> origStrings, String input) {        List<String> modifiedStrings = new ArrayList<>(origStrings.size());
+    public List<String> substitute(List<String> origStrings, String input) {
+        List<String> modifiedStrings = new ArrayList<>(origStrings.size());
         for (String origString : origStrings) {
             boolean foundListInsertionPlaceholder = handleListInsertion(modifiedStrings, origString, input);
             if (!foundListInsertionPlaceholder) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
@@ -2,7 +2,6 @@ package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
 
 import com.blackduck.integration.detectable.detectable.exception.DetectableException;
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
-import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
 import com.blackduck.integration.detectable.detectables.bazel.v2.BazelVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +27,8 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
     // Logger for this class
     private static final Logger logger = LoggerFactory.getLogger(IntermediateStepExecuteShowRepoHeuristic.class);
 
-    // Bazel command executor dependency
-    private final BazelCommandExecutor bazel;
+    // Shared show_repo execution mechanics (batching, block splitting, per-candidate fallback)
+    private final ShowRepoExecutor showRepoExecutor;
     // Detected Bazel version; null means unknown (treat as < 7.1)
     private final BazelVersion bazelVersion;
 
@@ -41,9 +40,6 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
     //   SUFFIX_PLUS  (+) — used in Bazel 7.x (pre-7.5) and some 8.x builds
     private static final String SUFFIX_TILDE = BazelCommandArguments.REPO_CANONICAL_SUFFIX_TILDE;
     private static final String SUFFIX_PLUS  = BazelCommandArguments.REPO_CANONICAL_SUFFIX_PLUS;
-
-    // Separator between repo blocks in batched show_repo output
-    private static final String REPO_BLOCK_SEPARATOR = "## @";
 
     /**
      * Constructor for IntermediateStepExecuteShowRepoHeuristic (backward-compatible).
@@ -59,7 +55,7 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
      * @param bazelVersion Detected Bazel version; null means unknown (per-repo fallback)
      */
     public IntermediateStepExecuteShowRepoHeuristic(BazelCommandExecutor bazel, BazelVersion bazelVersion) {
-        this.bazel = bazel;
+        this.showRepoExecutor = new ShowRepoExecutor(bazel);
         this.bazelVersion = bazelVersion;
     }
 
@@ -105,41 +101,14 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
 
         if (repoArgs.isEmpty()) return Optional.of(new ArrayList<>());
 
-        try {
-            logger.debug("Attempting batched show_repo for {} repos (Bazel {})", repoArgs.size(), bazelVersion);
-            List<String> modArgs = BazelQueryBuilder.mod()
-                .showRepoRawBatch(repoArgs)
-                .build();
-
-            // Use executeModCommandToString: a broken module extension (e.g., bazel_jar_jar+ on Bazel 9)
-            // causes exit code 2 even when the batch output is fully valid in stdout.
-            Optional<String> result = bazel.executeModCommandToString(modArgs);
-            if (result.isPresent() && !result.get().trim().isEmpty()) {
-                List<String> blocks = splitShowRepoOutput(result.get());
-                logger.debug("Batched show_repo succeeded: {} blocks from {} repos", blocks.size(), repoArgs.size());
-                return Optional.of(blocks);
-            }
-        } catch (Exception e) {
-            logger.debug("Batched show_repo failed: {}", e.getMessage());
+        logger.debug("Attempting batched show_repo for {} repos (Bazel {})", repoArgs.size(), bazelVersion);
+        Optional<String> result = showRepoExecutor.runBatch(repoArgs);
+        if (result.isPresent()) {
+            List<String> blocks = showRepoExecutor.splitIntoBlocks(result.get());
+            logger.debug("Batched show_repo succeeded: {} blocks from {} repos", blocks.size(), repoArgs.size());
+            return Optional.of(blocks);
         }
         return Optional.empty();
-    }
-
-    /**
-     * Splits the combined output of a batched `bazel mod show_repo` into individual repo blocks.
-     * Each block starts with "## @reponame:" header.
-     */
-    private List<String> splitShowRepoOutput(String combinedOutput) {
-        List<String> blocks = new ArrayList<>();
-        // Split on the "## @" boundary which separates repo blocks
-        String[] parts = combinedOutput.split("(?=" + REPO_BLOCK_SEPARATOR + ")");
-        for (String part : parts) {
-            String trimmed = part.trim();
-            if (!trimmed.isEmpty()) {
-                blocks.add(trimmed);
-            }
-        }
-        return blocks;
     }
 
     /**
@@ -148,23 +117,21 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
     private List<String> processPerRepo(List<String> input) {
         List<String> out = new ArrayList<>();
 
-        int successes = 0, failures = 0;
+        int successes = 0;
+        int failures = 0;
         for (String raw : input) {
             if (raw == null) continue;
             String token = raw.trim();
             if (token.isEmpty()) continue;
 
             // Generate candidate repo arguments according to heuristic and try them in order
-            List<String> candidates = candidateRepoArgs(token);
-            boolean success = false;
-            for (String candidate : candidates) {
-                if (tryShowRepoAddOutput(candidate, out)) {
-                    success = true;
-                    break;
-                }
+            Optional<String> resolved = showRepoExecutor.runFirstSuccessful(candidateRepoArgs(token));
+            if (resolved.isPresent()) {
+                out.add(resolved.get());
+                successes++;
+            } else {
+                failures++;
             }
-
-            if (success) successes++; else failures++;
         }
         logger.info("bzlmod HTTP show_repo (heuristic) summary: successes={}, failures={}", successes, failures);
         return out;
@@ -206,24 +173,5 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
     private boolean looksSynthetic(String name) {
         // Treat '+' (Bazel 8) and '~' (Bazel 7) as synthetic markers
         return name.contains(SUFFIX_PLUS) || name.contains(SUFFIX_TILDE);
-    }
-
-    /**
-     * Runs 'bazel mod show_repo' for the given repo argument and adds output to the result list if successful.
-     * @param repoArg Repo argument (with leading @ or @@)
-     * @param out Output list to add successful results
-     * @return true if the command succeeded and output was added, false otherwise
-     */
-    private boolean tryShowRepoAddOutput(String repoArg, List<String> out) {
-        // Use executeModCommandToString: a broken module extension (e.g., bazel_jar_jar+ on Bazel 9)
-        // poisons the exit code to 2 even when show_repo produced a valid repo definition in stdout.
-        // stdout being non-empty is the authoritative success signal for mod show_repo.
-        Optional<String> res = bazel.executeModCommandToString(Arrays.asList("mod", "show_repo", repoArg));
-        if (res.isPresent()) {
-            out.add(res.get());
-            return true;
-        }
-        logger.debug("mod show_repo {} produced no usable output", repoArg);
-        return false;
     }
 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
@@ -76,7 +76,7 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
             if (batchResult.isPresent()) {
                 return batchResult.get();
             }
-            logger.info("Batched show_repo failed; falling back to per-repo calls.");
+            logger.debug("Batched show_repo failed; falling back to per-repo calls.");
         }
 
         return processPerRepo(input);
@@ -133,7 +133,7 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
                 failures++;
             }
         }
-        logger.info("bzlmod HTTP show_repo (heuristic) summary: successes={}, failures={}", successes, failures);
+        logger.debug("show_repo resolution summary: successes={}, failures={}", successes, failures);
         return out;
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepExecuteShowRepoHeuristic.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
 
 import com.blackduck.integration.detectable.detectable.exception.DetectableException;
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
 import com.blackduck.integration.detectable.detectables.bazel.v2.BazelVersion;
 import org.slf4j.Logger;
@@ -32,14 +33,14 @@ public class IntermediateStepExecuteShowRepoHeuristic implements IntermediateSte
     // Detected Bazel version; null means unknown (treat as < 7.1)
     private final BazelVersion bazelVersion;
 
-    // Extracted string constants for repo prefix markers
-    private static final String REPO_PREFIX_SINGLE    = "@";
-    private static final String REPO_PREFIX_CANONICAL = "@@";
+    // Extracted string constants for repo prefix markers (centralized in BazelCommandArguments)
+    private static final String REPO_PREFIX_SINGLE    = BazelCommandArguments.REPO_PREFIX_SINGLE;
+    private static final String REPO_PREFIX_CANONICAL = BazelCommandArguments.REPO_PREFIX_CANONICAL;
     // The two canonical suffix characters used by Bazel across versions:
     //   SUFFIX_TILDE (~) — introduced in Bazel 7.5+
     //   SUFFIX_PLUS  (+) — used in Bazel 7.x (pre-7.5) and some 8.x builds
-    private static final String SUFFIX_TILDE = "~";
-    private static final String SUFFIX_PLUS  = "+";
+    private static final String SUFFIX_TILDE = BazelCommandArguments.REPO_CANONICAL_SUFFIX_TILDE;
+    private static final String SUFFIX_PLUS  = BazelCommandArguments.REPO_CANONICAL_SUFFIX_PLUS;
 
     // Separator between repo blocks in batched show_repo output
     private static final String REPO_BLOCK_SEPARATOR = "## @";

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepParseShowRepoToUrlCandidates.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/IntermediateStepParseShowRepoToUrlCandidates.java
@@ -44,13 +44,20 @@ public class IntermediateStepParseShowRepoToUrlCandidates implements Intermediat
             }
 
             // 1) Extract explicit url(s)
-            addExplicitUrlAttributes(block, results);
-
             // 2) git_repository: remote (only http/https)
+            // Track the list size before processing this block so the go_repository synthesis
+            // guard can be evaluated per-block rather than against the accumulated results list.
+            // (Previously, results.isEmpty() was checked inside addSynthesizedGoUrlIfNoExplicit,
+            // which caused synthesis to be skipped for any block that followed a block that
+            // contributed URLs — a bug when processing multiple repos in one call.)
+            int sizeBeforeBlock = results.size();
+            addExplicitUrlAttributes(block, results);
             addRemoteUrls(block, results);
 
-            // 3) go_repository: synthesize from importpath if rule class is go_repository and no urls present
-            addSynthesizedGoUrlIfNoExplicit(block, results);
+            // 3) go_repository: synthesize from importpath only when THIS block produced no URLs
+            if (results.size() == sizeBeforeBlock) {
+                addSynthesizedGoUrlIfNoExplicit(block, results);
+            }
         }
         return results;
     }
@@ -79,10 +86,11 @@ public class IntermediateStepParseShowRepoToUrlCandidates implements Intermediat
         }
     }
 
-    // Synthesize a https://<importpath> URL for go_repository only when no explicit URLs were found so far
+    // Synthesize a https://<importpath> URL for go_repository.
+    // Only called when the current block has not yet contributed any explicit URLs (guarded by caller).
     private void addSynthesizedGoUrlIfNoExplicit(String block, List<String> results) {
         String ruleClass = extractRuleClass(block).orElse("");
-        if (results.isEmpty() && ruleClass.equalsIgnoreCase(RULE_CLASS_GO_REPOSITORY)) {
+        if (ruleClass.equalsIgnoreCase(RULE_CLASS_GO_REPOSITORY)) {
             Matcher mImport = IMPORTPATH_PATTERN.matcher(block);
             if (mImport.find()) {
                 String importPath = mImport.group(1).trim();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/ShowRepoExecutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/ShowRepoExecutor.java
@@ -1,0 +1,93 @@
+package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
+
+/**
+ * Shared execution helpers for {@code bazel mod show_repo}: batched calls, output-block splitting,
+ * and an ordered per-candidate fallback. Callers supply their own candidate arguments.
+ */
+public class ShowRepoExecutor {
+    private static final Logger logger = LoggerFactory.getLogger(ShowRepoExecutor.class);
+
+    // Repo blocks in batched show_repo output start with "## @@<name>:" or "## @<name>:".
+    public static final String BLOCK_HEADER_PREFIX = "## @";
+    private static final String BLOCK_SPLIT_REGEX = "(?=" + BLOCK_HEADER_PREFIX + ")";
+
+    private final BazelCommandExecutor bazel;
+
+    public ShowRepoExecutor(BazelCommandExecutor bazel) {
+        this.bazel = bazel;
+    }
+
+    /**
+     * Runs a single batched {@code bazel mod show_repo <repoArgs...>}, returning stdout if non-empty.
+     */
+    public Optional<String> runBatch(List<String> repoArgs) {
+        if (repoArgs == null || repoArgs.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            List<String> cmd = BazelQueryBuilder.mod().showRepoRawBatch(repoArgs).build();
+            // stdout is authoritative even on a non-zero exit code (a broken unrelated extension can
+            // poison it, e.g. bazel_jar_jar+ on Bazel 9).
+            Optional<String> out = bazel.executeModCommandToString(cmd);
+            if (out.isPresent() && !out.get().trim().isEmpty()) {
+                return out;
+            }
+        } catch (Exception e) {
+            logger.debug("Batched show_repo failed with exception: {}", e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Splits combined batched output into trimmed, non-empty repo blocks on the {@code ## @} boundary.
+     */
+    public List<String> splitIntoBlocks(String combinedOutput) {
+        List<String> blocks = new ArrayList<>();
+        if (combinedOutput == null) {
+            return blocks;
+        }
+        for (String part : combinedOutput.split(BLOCK_SPLIT_REGEX)) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                blocks.add(trimmed);
+            }
+        }
+        return blocks;
+    }
+
+    /**
+     * Tries each candidate in order and returns the first non-empty {@code show_repo} output.
+     * A candidate that throws or returns empty is skipped (handles the Bazel 7.x NPE on some
+     * canonical forms).
+     */
+    public Optional<String> runFirstSuccessful(List<String> candidateArgs) {
+        if (candidateArgs == null) {
+            return Optional.empty();
+        }
+        for (String candidate : candidateArgs) {
+            try {
+                List<String> cmd = BazelQueryBuilder.mod().showRepoRaw(candidate).build();
+                Optional<String> out = bazel.executeModCommandToString(cmd);
+                if (out.isPresent() && !out.get().trim().isEmpty()) {
+                    logger.debug("show_repo resolved using candidate '{}'", candidate);
+                    return out;
+                }
+                logger.debug("show_repo candidate '{}' returned no output; trying next", candidate);
+            } catch (Exception e) {
+                logger.debug("show_repo candidate '{}' failed: {} — trying next", candidate, e.getMessage());
+            }
+        }
+        return Optional.empty();
+    }
+}
+
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/ShowRepoExecutor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/pipeline/step/ShowRepoExecutor.java
@@ -1,13 +1,20 @@
 package com.blackduck.integration.detectable.detectables.bazel.pipeline.step;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
+import com.blackduck.integration.detectable.detectables.bazel.v2.BzlmodGraphJsonParser;
+import com.blackduck.integration.detectable.detectables.bazel.v2.BzlmodRepoMappingResolver;
 
 /**
  * Shared execution helpers for {@code bazel mod show_repo}: batched calls, output-block splitting,
@@ -19,6 +26,10 @@ public class ShowRepoExecutor {
     // Repo blocks in batched show_repo output start with "## @@<name>:" or "## @<name>:".
     public static final String BLOCK_HEADER_PREFIX = "## @";
     private static final String BLOCK_SPLIT_REGEX = "(?=" + BLOCK_HEADER_PREFIX + ")";
+
+    // Canonical header prefix (double-@): "## @@name~:" or "## @@name+:"
+    private static final String BLOCK_HEADER_CANONICAL = BLOCK_HEADER_PREFIX + "@"; // "## @@"
+    // Apparent header prefix (single-@): "## @name:" — same as BLOCK_HEADER_PREFIX
 
     private final BazelCommandExecutor bazel;
 
@@ -88,6 +99,128 @@ public class ShowRepoExecutor {
         }
         return Optional.empty();
     }
+
+    /**
+     * Resolves a set of BCR module keys to their {@code show_repo} block output.
+     *
+     * <p>Uses a single batched call first (fast path). If the batch returns nothing at all,
+     * falls back to per-module calls for every key. If the batch partially succeeds, only the
+     * missing keys are retried per-module.
+     *
+     * <p>The batch arg for each module is determined by
+     * {@link BzlmodRepoMappingResolver#canonicalRepoArg}, which picks the best single form based
+     * on the repo mapping (canonical {@code @@name~}, bare name, or suffix-appended form).
+     * The per-module fallback uses {@link BzlmodRepoMappingResolver#candidateRepoArgs}, which tries
+     * multiple forms in priority order to handle cross-version Bazel inconsistencies.
+     *
+     * @param moduleKeys set of module keys in {@code name@version} form (non-null, non-empty)
+     * @param resolver   resolver loaded from {@code bazel mod dump_repo_mapping ""}
+     * @return map from module key to its show_repo block output; keys with no output are absent
+     */
+    public Map<String, String> resolveWithFallback(Set<String> moduleKeys, BzlmodRepoMappingResolver resolver) {
+        if (moduleKeys == null || moduleKeys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // Build primary batch args: canonicalRepoArg selects the best single form per module
+        List<String> batchArgs = new ArrayList<>();
+        for (String moduleKey : moduleKeys) {
+            batchArgs.add(resolver.canonicalRepoArg(BzlmodGraphJsonParser.extractName(moduleKey)));
+        }
+
+        Map<String, String> result = tryBatchedResolve(moduleKeys, batchArgs, resolver);
+
+        if (result.isEmpty()) {
+            logger.debug("BZLMOD BCR: batched show_repo returned no results; falling back to per-module calls");
+            return runPerModuleFallback(moduleKeys, resolver);
+        }
+
+        logger.debug("BZLMOD BCR: batched show_repo resolved {} of {} module(s)", result.size(), moduleKeys.size());
+
+        // Retry any modules the batch did not resolve
+        Set<String> missing = new LinkedHashSet<>(moduleKeys);
+        missing.removeAll(result.keySet());
+        if (!missing.isEmpty()) {
+            logger.debug("BZLMOD BCR: {} module(s) not resolved by batch; retrying per-module", missing.size());
+            result.putAll(runPerModuleFallback(missing, resolver));
+        }
+
+        return result;
+    }
+
+    /**
+     * Runs a batched show_repo call and maps each returned block back to its module key.
+     * Returns an empty map if the batch produces no output or no blocks can be header-matched.
+     */
+    private Map<String, String> tryBatchedResolve(Set<String> moduleKeys, List<String> batchArgs,
+                                                   BzlmodRepoMappingResolver resolver) {
+        if (batchArgs.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Optional<String> batchOutput = runBatch(batchArgs);
+        if (!batchOutput.isPresent()) {
+            return Collections.emptyMap();
+        }
+
+        // Parse block headers: map module name → block
+        List<String> blocks = splitIntoBlocks(batchOutput.get());
+        Map<String, String> blocksByModuleName = new LinkedHashMap<>();
+        for (String block : blocks) {
+            String headerRepoName = extractHeaderRepoName(block);
+            if (headerRepoName != null) {
+                String moduleName = resolver.stripCanonicalSuffix(headerRepoName);
+                logger.debug("BZLMOD BCR: batch block header: headerRepoName='{}' → moduleName='{}'",
+                    headerRepoName, moduleName);
+                blocksByModuleName.put(moduleName, block);
+            }
+        }
+
+        // Map module keys to their corresponding blocks
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String moduleKey : moduleKeys) {
+            String block = blocksByModuleName.get(BzlmodGraphJsonParser.extractName(moduleKey));
+            if (block != null) {
+                result.put(moduleKey, block);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Runs per-module show_repo for each key using the resolver's ordered candidate list.
+     * Each candidate that fails or throws is skipped (handles Bazel 7.x NPE on some canonical forms).
+     */
+    private Map<String, String> runPerModuleFallback(Set<String> moduleKeys, BzlmodRepoMappingResolver resolver) {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String moduleKey : moduleKeys) {
+            String name = BzlmodGraphJsonParser.extractName(moduleKey);
+            Optional<String> output = runFirstSuccessful(resolver.candidateRepoArgs(name));
+            if (output.isPresent()) {
+                result.put(moduleKey, output.get());
+            } else {
+                logger.debug("BZLMOD BCR: per-module show_repo produced no output for '{}'", moduleKey);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Extracts the repo name from a show_repo block header.
+     * Handles both canonical form ({@code ## @@name~:}) and apparent form ({@code ## @name:}).
+     * Returns {@code null} if the header cannot be parsed.
+     */
+    private static String extractHeaderRepoName(String block) {
+        if (block.startsWith(BLOCK_HEADER_CANONICAL)) {
+            int colonIdx = block.indexOf(':');
+            if (colonIdx > BLOCK_HEADER_CANONICAL.length()) {
+                return block.substring(BLOCK_HEADER_CANONICAL.length(), colonIdx);
+            }
+        } else if (block.startsWith(BLOCK_HEADER_PREFIX)) {
+            int colonIdx = block.indexOf(':');
+            if (colonIdx > BLOCK_HEADER_PREFIX.length()) {
+                return block.substring(BLOCK_HEADER_PREFIX.length(), colonIdx);
+            }
+        }
+        return null;
+    }
 }
-
-

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/BazelCommandArguments.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/BazelCommandArguments.java
@@ -85,5 +85,35 @@ public final class BazelCommandArguments {
      * Double @@ prefix for canonical repository references
      */
     public static final String REPO_PREFIX_CANONICAL = "@@";
+
+    // ===== Canonical Repo-Name Suffixes (version-specific) =====
+
+    /**
+     * Canonical repo-name suffix used by Bazel 7.5+ (e.g. {@code @@protobuf~}).
+     */
+    public static final String REPO_CANONICAL_SUFFIX_TILDE = "~";
+
+    /**
+     * Canonical repo-name suffix used by Bazel 7.x (pre-7.5) and some 8.x builds (e.g. {@code @@protobuf+}).
+     */
+    public static final String REPO_CANONICAL_SUFFIX_PLUS = "+";
+
+    /**
+     * Regex matching any known trailing canonical suffix ({@code ~} or {@code +}) at end of a repo name.
+     * Used as a best-effort strip when the exact suffix is unknown.
+     */
+    public static final String KNOWN_CANONICAL_SUFFIX_REGEX = "[+~]$";
+
+    /**
+     * Marker present in canonical names of module-extension sub-repos
+     * (e.g. {@code rules_jvm_external++maven+guava}). These never appear as
+     * {@code bazel mod graph} module keys and are excluded from BCR resolution.
+     */
+    public static final String MODULE_EXTENSION_MARKER = "++";
+
+    /**
+     * Separator between the repo-name part and the {@code //path:target} part of a Bazel label.
+     */
+    public static final String LABEL_PATH_SEPARATOR = "//";
 }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/BazelCommandArguments.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/BazelCommandArguments.java
@@ -115,5 +115,12 @@ public final class BazelCommandArguments {
      * Separator between the repo-name part and the {@code //path:target} part of a Bazel label.
      */
     public static final String LABEL_PATH_SEPARATOR = "//";
+
+    /**
+     * Separator between the module name and version in a {@code bazel mod graph} module key
+     * (e.g. the {@code @} in {@code protobuf@31.0}). Same character as {@link #REPO_PREFIX_SINGLE}
+     * but semantically distinct — this one splits {@code name@version}, not a repo reference.
+     */
+    public static final String MODULE_KEY_SEPARATOR = "@";
 }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/ModCommandBuilder.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/query/ModCommandBuilder.java
@@ -62,7 +62,7 @@ public class ModCommandBuilder {
 
         // Remove any existing @ prefixes from the repo name
         String cleanRepoName = repoName;
-        while (cleanRepoName.startsWith("@")) {
+        while (cleanRepoName.startsWith(BazelCommandArguments.REPO_PREFIX_SINGLE)) {
             cleanRepoName = cleanRepoName.substring(1);
         }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelEnvironmentAnalyzer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelEnvironmentAnalyzer.java
@@ -33,7 +33,7 @@ public class BazelEnvironmentAnalyzer {
             .graph()
             .build();
 
-        ExecutableOutput output = bazel.executeWithoutThrowing(modGraphCommand);
+        ExecutableOutput output = bazel.executeToleratingExitCode(modGraphCommand);
 
         if (output.getReturnCode() == 0) {
             String stdout = output.getStandardOutput().trim();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelGraphProber.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelGraphProber.java
@@ -108,7 +108,7 @@ public class BazelGraphProber {
             enabled.add(DependencySource.HTTP_ARCHIVE);
         }
 
-        logger.info("Probing completed. Enabled pipelines: {}", enabled);
+        logger.debug("Probing completed. Enabled pipelines: {}", enabled);
         return enabled;
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelInfrastructureModules.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelInfrastructureModules.java
@@ -1,0 +1,74 @@
+package com.blackduck.integration.detectable.detectables.bazel.v2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Single source of truth for Bazel "infrastructure" repo/module name prefixes — toolchain repos,
+ * build-rule rulesets, and Maven-plumbing repos that are NOT shipped software components and must
+ * be excluded from every BOM path.
+ *
+ * <p>Previously this list was duplicated in three places with slight drift:
+ * <ul>
+ *   <li>{@code HttpFamilyProber.EXCLUDED_REPO_PREFIXES}</li>
+ *   <li>{@code BzlmodBcrExtractor.EXCLUDED_REPO_PREFIXES}</li>
+ *   <li>{@code Pipelines.EXCLUDE_BUILTINS_REGEX}</li>
+ * </ul>
+ * Consolidating them here prevents the "someone adds a ruleset to two of three copies" bug.
+ *
+ * <p>{@code rules_shell} is included: Bazel 9 implicitly injects it into every Java target as a
+ * build toolchain module, so it must be excluded consistently across all paths.
+ */
+public final class BazelInfrastructureModules {
+
+    private BazelInfrastructureModules() {
+        throw new IllegalStateException("Utility class - do not instantiate");
+    }
+
+    private static final List<String> INFRASTRUCTURE_PREFIXES = Collections.unmodifiableList(Arrays.asList(
+        "bazel_tools",
+        "local_config_",
+        "remotejdk",
+        "platforms",
+        "rules_python",
+        "rules_java",
+        "rules_cc",
+        "rules_shell",
+        "maven",
+        "unpinned_maven",
+        "rules_jvm_external"
+    ));
+
+    /**
+     * Returns the immutable list of infrastructure name prefixes.
+     */
+    public static List<String> prefixes() {
+        return INFRASTRUCTURE_PREFIXES;
+    }
+
+    /**
+     * Returns true if {@code name} starts with any infrastructure prefix (i.e. is build
+     * infrastructure, not a shipped software component).
+     */
+    public static boolean isInfrastructure(String name) {
+        if (name == null) {
+            return false;
+        }
+        for (String prefix : INFRASTRUCTURE_PREFIXES) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Builds the negative-lookahead regex used by the HTTP_ARCHIVE pipeline's line filter to drop
+     * infrastructure repos. Equivalent to the previously hardcoded {@code EXCLUDE_BUILTINS_REGEX}.
+     */
+    public static String exclusionLookaheadRegex() {
+        return "^(?!(" + String.join("|", INFRASTRUCTURE_PREFIXES) + ")).*$";
+    }
+}
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelLabel.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelLabel.java
@@ -1,0 +1,138 @@
+package com.blackduck.integration.detectable.detectables.bazel.v2;
+
+import java.util.Objects;
+
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
+
+/**
+ * Value type for a Bazel repository label token as emitted by {@code bazel query} / {@code cquery},
+ * e.g. {@code @@abseil-cpp~//absl:strings} (canonical) or {@code @com_google_protobuf//:protobuf}
+ * (apparent).
+ *
+ * <p>This type owns only the <b>pure structural</b> parse of a label:
+ * <ul>
+ *   <li>whether it is a repo label at all (starts with {@code @}),</li>
+ *   <li>whether it is in canonical form ({@code @@}) vs apparent form ({@code @}),</li>
+ *   <li>the repo name — the repository portion after the prefix and before {@code //}, with any
+ *       version suffix ({@code ~}/{@code +}) left intact,</li>
+ *   <li>whether that name denotes a module-extension sub-repo (contains {@code ++}).</li>
+ * </ul>
+ *
+ * <p>It deliberately does <b>not</b> perform version-suffix stripping or repo-map alias resolution.
+ * Those are version- and state-dependent and remain the responsibility of
+ * {@link BzlmodRepoMappingResolver}, which consumes this type. Keeping that boundary makes the
+ * structural parsing here trivially unit-testable while preserving the resolver's existing behavior.
+ *
+ * <p>The parsing rules mirror the historical inline logic in {@code BzlmodRepoMappingResolver.resolveLabel}
+ * and {@code HttpFamilyProber.parseRepoLabels} exactly.
+ */
+public final class BazelLabel {
+    private static final String REPO_PREFIX_SINGLE = BazelCommandArguments.REPO_PREFIX_SINGLE;       // "@"
+    private static final String REPO_PREFIX_CANONICAL = BazelCommandArguments.REPO_PREFIX_CANONICAL; // "@@"
+    private static final String LABEL_PATH_SEPARATOR = BazelCommandArguments.LABEL_PATH_SEPARATOR;   // "//"
+    private static final String MODULE_EXTENSION_MARKER = BazelCommandArguments.MODULE_EXTENSION_MARKER; // "++"
+
+    private final String raw;
+    private final boolean repoLabel;
+    private final boolean canonical;
+    private final boolean hasPath;
+    private final String repoName;
+
+    private BazelLabel(String raw, boolean repoLabel, boolean canonical, boolean hasPath, String repoName) {
+        this.raw = raw;
+        this.repoLabel = repoLabel;
+        this.canonical = canonical;
+        this.hasPath = hasPath;
+        this.repoName = repoName;
+    }
+
+    /**
+     * Parses a raw label string. Tolerates {@code null} (treated as a non-repo label).
+     *
+     * @param raw the raw label string (e.g. {@code @@abseil-cpp~//absl:strings})
+     * @return the parsed label
+     */
+    public static BazelLabel parse(String raw) {
+        String safe = raw == null ? "" : raw;
+        boolean repoLabel = safe.startsWith(REPO_PREFIX_SINGLE);
+        boolean canonical = safe.startsWith(REPO_PREFIX_CANONICAL);
+
+        String repoName;
+        boolean hasPath;
+        if (!repoLabel) {
+            repoName = "";
+            hasPath = safe.contains(LABEL_PATH_SEPARATOR);
+        } else {
+            int prefixLen = canonical ? REPO_PREFIX_CANONICAL.length() : REPO_PREFIX_SINGLE.length();
+            String afterPrefix = safe.substring(prefixLen);
+            int pathIdx = afterPrefix.indexOf(LABEL_PATH_SEPARATOR);
+            hasPath = pathIdx >= 0;
+            repoName = hasPath ? afterPrefix.substring(0, pathIdx) : afterPrefix;
+        }
+        return new BazelLabel(safe, repoLabel, canonical, hasPath, repoName);
+    }
+
+    /** @return true if this is an external repository label (starts with {@code @}). */
+    public boolean isRepoLabel() {
+        return repoLabel;
+    }
+
+    /** @return true if this label is in canonical form (starts with {@code @@}). */
+    public boolean isCanonical() {
+        return canonical;
+    }
+
+    /** @return true if this label contains a {@code //path:target} portion. */
+    public boolean hasPath() {
+        return hasPath;
+    }
+
+    /**
+     * @return the repository name: the portion after the {@code @}/{@code @@} prefix and before
+     *         {@code //}, with any version suffix ({@code ~}/{@code +}) left intact. Empty string
+     *         for non-repo labels. This is the raw name as it appears in the label — callers that
+     *         need the resolved BCR module name must still strip the suffix / resolve aliases.
+     */
+    public String getRepoName() {
+        return repoName;
+    }
+
+    /** @return true if the repo name denotes a module-extension sub-repo (contains {@code ++}). */
+    public boolean isModuleExtensionSubRepo() {
+        return repoName.contains(MODULE_EXTENSION_MARKER);
+    }
+
+    /** @return the original, unmodified label string ({@code ""} if it was parsed from {@code null}). */
+    public String getRaw() {
+        return raw;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BazelLabel that = (BazelLabel) o;
+        return Objects.equals(raw, that.raw);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(raw);
+    }
+
+    @Override
+    public String toString() {
+        return "BazelLabel{raw='" + raw + "', canonical=" + canonical + ", repoName='" + repoName + "'}";
+    }
+}
+
+
+
+
+
+
+

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
@@ -79,7 +79,7 @@ public class BazelV2Extractor {
                           String bazelTarget,
                           BazelEnvironmentAnalyzer.Mode mode,
                           BazelVersion bazelVersion) throws ExecutableFailedException, DetectableException {
-        logger.info("Starting the Bazel tool extraction. Target: {}. Pipelines: {}", bazelTarget, sources);
+        logger.info("Starting Bazel dependency scan for target: {}. Active sources: {}", bazelTarget, sources);
         // Create pipelines for each dependency source (used by both paths)
         Pipelines pipelines = new Pipelines(bazelCmd, bazelVariableSubstitutor, externalIdFactory, haskellParser, mode, bazelVersion);
 
@@ -96,14 +96,13 @@ public class BazelV2Extractor {
         // message explains why everything is reported flat and what to upgrade to.
         if (mode == BazelEnvironmentAnalyzer.Mode.BZLMOD) {
             if (bazelVersion == null) {
-                logger.warn("BZLMOD mode detected but the Bazel version could not be determined — " +
-                    "structured BCR extraction requires Bazel 7.1 or later. " +
-                    "All dependencies will be reported as direct (flat).");
+                logger.warn("BZLMOD mode detected but the Bazel version could not be determined. " +
+                    "Structured dependency analysis requires Bazel 7.1 or later. " +
+                    "All dependencies will be reported as direct.");
             } else {
-                logger.warn("BZLMOD mode detected but Bazel version {} is below 7.1 — " +
-                    "direct/transitive dependency classification is unavailable for BCR modules. " +
-                    "All dependencies will be reported as direct (flat). " +
-                    "Upgrade to Bazel 7.1 or later to enable structured BCR extraction.",
+                logger.warn("BZLMOD mode detected but Bazel {} does not support structured dependency analysis " +
+                    "(requires Bazel 7.1 or later). All dependencies will be reported as direct. " +
+                    "Upgrade to Bazel 7.1 or later for accurate direct/transitive classification.",
                     bazelVersion);
             }
         }
@@ -117,7 +116,7 @@ public class BazelV2Extractor {
         for (DependencySource source : ordered) {
             logger.debug("Executing pipeline for dependency source: {}", source);
             List<Dependency> deps = pipelines.get(source).run();
-            logger.info("Number of dependencies discovered for source {}: {}", source, deps.size());
+            logger.debug("Dependencies discovered for source {}: {}", source, deps.size());
             if (logger.isDebugEnabled()) {
                 logger.debug("Dependencies discovered for source {}: {}", source, dependenciesToDebugString(deps));
             }
@@ -155,7 +154,7 @@ public class BazelV2Extractor {
                                          String bazelTarget,
                                          BazelVersion bazelVersion,
                                          Pipelines pipelines) throws ExecutableFailedException, DetectableException {
-        logger.info("BZLMOD mode on Bazel {}: using BCR extraction path for structured direct/transitive classification", bazelVersion);
+        logger.info("Bazel {} with BZLMOD: using module-aware extraction for accurate direct/transitive dependency classification", bazelVersion);
 
         // Run BCR extraction to get the tree-structured graph (target-scoped via internal query).
         // Pass the user's query options so the internal target-scope query is consistent with the
@@ -182,7 +181,7 @@ public class BazelV2Extractor {
         for (DependencySource source : ordered) {
             logger.debug("Executing pipeline for dependency source: {}", source);
             List<Dependency> deps = pipelines.get(source).run();
-            logger.info("Number of dependencies discovered for source {}: {}", source, deps.size());
+            logger.debug("Dependencies discovered for source {}: {}", source, deps.size());
             if (logger.isDebugEnabled()) {
                 logger.debug("Dependencies discovered for source {}: {}", source, dependenciesToDebugString(deps));
             }
@@ -194,7 +193,7 @@ public class BazelV2Extractor {
                 .collect(Collectors.toList());
             int suppressed = deps.size() - nonBcrDeps.size();
             if (suppressed > 0) {
-                logger.info("Source {}: {} dep(s) already classified by BCR extractor — skipping to preserve direct/transitive edges; {} non-BCR dep(s) added flat",
+                logger.debug("Source {}: {} component(s) already captured by module extraction — skipped to preserve dependency tree; {} additional component(s) added",
                     source, suppressed, nonBcrDeps.size());
             }
             if (!nonBcrDeps.isEmpty()) {
@@ -205,8 +204,8 @@ public class BazelV2Extractor {
             pipelineAddedFlat += nonBcrDeps.size();
         }
 
-        logger.info("Bazel extraction complete — BCR: {} module(s) classified with direct/transitive edges; " +
-                "pipelines: {} found, {} suppressed (BCR overlap), {} added flat",
+        logger.info("Bazel extraction complete — module graph: {} component(s) with dependency edges; " +
+                "additional sources: {} found, {} already covered, {} unique component(s) added",
             bcrExternalIds.size(), pipelineTotalDeps, pipelineSuppressed, pipelineAddedFlat);
 
         CodeLocation cl = new CodeLocation(graph);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
@@ -157,8 +157,11 @@ public class BazelV2Extractor {
                                          Pipelines pipelines) throws ExecutableFailedException, DetectableException {
         logger.info("BZLMOD mode on Bazel {}: using BCR extraction path for structured direct/transitive classification", bazelVersion);
 
-        // Run BCR extraction to get the tree-structured graph (target-scoped via internal query)
-        BzlmodBcrExtractor bcrExtractor = new BzlmodBcrExtractor(bazelCmd, bazelVersion, bazelTarget);
+        // Run BCR extraction to get the tree-structured graph (target-scoped via internal query).
+        // Pass the user's query options so the internal target-scope query is consistent with the
+        // HTTP_ARCHIVE pipeline / HttpFamilyProber (same args → served from the executor's query cache).
+        BzlmodBcrExtractor bcrExtractor = new BzlmodBcrExtractor(bazelCmd, bazelVersion, bazelTarget,
+            bazelVariableSubstitutor.getQueryAdditionalOptions());
         DependencyGraph graph = bcrExtractor.extractGraph();
 
         // Run all configured pipelines (Maven, Haskell, HTTP_ARCHIVE) alongside the BCR graph.

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelV2Extractor.java
@@ -175,6 +175,10 @@ public class BazelV2Extractor {
             .sorted(Comparator.comparingInt(this::priority))
             .collect(Collectors.toList());
 
+        int pipelineTotalDeps = 0;
+        int pipelineSuppressed = 0;
+        int pipelineAddedFlat = 0;
+
         for (DependencySource source : ordered) {
             logger.debug("Executing pipeline for dependency source: {}", source);
             List<Dependency> deps = pipelines.get(source).run();
@@ -196,7 +200,14 @@ public class BazelV2Extractor {
             if (!nonBcrDeps.isEmpty()) {
                 graph.addChildrenToRoot(nonBcrDeps);
             }
+            pipelineTotalDeps += deps.size();
+            pipelineSuppressed += suppressed;
+            pipelineAddedFlat += nonBcrDeps.size();
         }
+
+        logger.info("Bazel extraction complete — BCR: {} module(s) classified with direct/transitive edges; " +
+                "pipelines: {} found, {} suppressed (BCR overlap), {} added flat",
+            bcrExternalIds.size(), pipelineTotalDeps, pipelineSuppressed, pipelineAddedFlat);
 
         CodeLocation cl = new CodeLocation(graph);
         String projectName = projectNameGenerator.generateFromBazelTarget(bazelTarget);

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelVersionChecker.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BazelVersionChecker.java
@@ -27,7 +27,7 @@ public class BazelVersionChecker {
      */
     public Optional<BazelVersion> detectVersion() {
         try {
-            ExecutableOutput output = bazel.executeWithoutThrowing(Collections.singletonList("--version"));
+            ExecutableOutput output = bazel.executeToleratingExitCode(Collections.singletonList("--version"));
             if (output.getReturnCode() != 0) {
                 logger.debug("bazel --version returned non-zero exit code: {}", output.getReturnCode());
                 return Optional.empty();

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -513,7 +513,7 @@ public class BzlmodBcrExtractor {
         Set<String> moduleNames = new LinkedHashSet<>();
         for (String line : queryOutput.get().split("\\r?\\n")) {
             String label = line.trim();
-            if (!label.startsWith("@")) {
+            if (!BazelLabel.parse(label).isRepoLabel()) {
                 continue;
             }
             // Delegate all label-format complexity to the resolver:

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -53,11 +52,6 @@ public class BzlmodBcrExtractor {
 
     // Prefix used in GitHub archive URLs to indicate a tag ref (e.g., refs/tags/v1.2.3)
     private static final String REFS_TAGS_PREFIX = "refs/tags/";
-    // Block header prefix for canonical-form repo names in batched show_repo output (e.g. "## @@googletest~:")
-    private static final String REPO_BLOCK_SEPARATOR_CANONICAL = "## @@";
-    // Block header prefix for apparent/bare-name repo names in batched show_repo output (e.g. "## @bazel_skylib:").
-    // Bazel uses single @ in the header when the module was submitted as a bare/apparent name rather than @@canonical form.
-    private static final String REPO_BLOCK_SEPARATOR_APPARENT = "## @";
 
     // Pattern for the target-scoped library query (same as the HTTP_ARCHIVE pipeline)
     private static final String LIBRARY_RULE_PATTERN = ".*library";
@@ -72,7 +66,7 @@ public class BzlmodBcrExtractor {
     // query so it is consistent with the HTTP_ARCHIVE pipeline and HttpFamilyProber, which both honor
     // these options. Keeping the args identical also lets BazelCommandExecutor memoize/reuse the result.
     private final List<String> queryOptions;
-    // Stateless helpers — instantiated internally, no external injection needed
+    // Stateless helpers — created by default constructors; can be injected for testing
     private final GithubUrlParser githubUrlParser;
     private final IntermediateStepParseShowRepoToUrlCandidates urlCandidateParser;
     // Shared show_repo execution mechanics (batching, block splitting, per-candidate fallback)
@@ -88,13 +82,29 @@ public class BzlmodBcrExtractor {
     }
 
     public BzlmodBcrExtractor(BazelCommandExecutor bazelCmd, BazelVersion bazelVersion, String bazelTarget, List<String> queryOptions) {
+        this(bazelCmd, bazelVersion, bazelTarget, queryOptions,
+            new GithubUrlParser(),
+            new IntermediateStepParseShowRepoToUrlCandidates(),
+            new ShowRepoExecutor(bazelCmd));
+    }
+
+    /**
+     * Full-injection constructor. Accepts all collaborators explicitly, enabling unit tests that
+     * exercise classification and URL-parsing logic without spawning a real Bazel process.
+     * Production code uses the shorter constructors above, which supply default implementations.
+     */
+    public BzlmodBcrExtractor(BazelCommandExecutor bazelCmd, BazelVersion bazelVersion, String bazelTarget,
+                               List<String> queryOptions,
+                               GithubUrlParser githubUrlParser,
+                               IntermediateStepParseShowRepoToUrlCandidates urlCandidateParser,
+                               ShowRepoExecutor showRepoExecutor) {
         this.bazelCmd = bazelCmd;
         this.bazelVersion = bazelVersion;
         this.bazelTarget = bazelTarget;
         this.queryOptions = queryOptions != null ? queryOptions : Collections.emptyList();
-        this.githubUrlParser = new GithubUrlParser();
-        this.urlCandidateParser = new IntermediateStepParseShowRepoToUrlCandidates();
-        this.showRepoExecutor = new ShowRepoExecutor(bazelCmd);
+        this.githubUrlParser = githubUrlParser;
+        this.urlCandidateParser = urlCandidateParser;
+        this.showRepoExecutor = showRepoExecutor;
     }
 
     /**
@@ -217,13 +227,11 @@ public class BzlmodBcrExtractor {
     // -------------------------------------------------------------------------
 
     /**
-     * Resolves each module key to a {@link Dependency} by calling
-     * {@code bazel mod show_repo} and parsing the GitHub URL from the output.
+     * Resolves each module key to a {@link Dependency} by calling {@code bazel mod show_repo}
+     * (via {@link ShowRepoExecutor#resolveWithFallback}) and parsing the GitHub URL from the output.
      *
-     * <p>Strategy: try a single batched call first (fast path). If the batch returns nothing,
-     * fall back to per-module calls using {@link BzlmodRepoMappingResolver#candidateRepoArgs},
-     * which tries multiple argument forms in a safe priority order to handle Bazel version
-     * inconsistencies (see {@link BzlmodRepoMappingResolver} class javadoc for the full matrix).
+     * <p>Batch+fallback orchestration is delegated to {@link ShowRepoExecutor#resolveWithFallback},
+     * which tries a single batched call first and retries only missing modules per-module.
      *
      * <p>Excluded modules (infrastructure / toolchain repos) must be filtered from
      * {@code moduleKeys} by the caller before invoking this method — see Step 1d in
@@ -234,41 +242,8 @@ public class BzlmodBcrExtractor {
      * WARN. The HTTP_ARCHIVE pipeline may still capture it via {@code bazel query}.
      */
     private Map<String, Dependency> resolveModules(Set<String> moduleKeys, BzlmodRepoMappingResolver resolver) {
-        // Build the primary show_repo argument for each module (used in the batch call).
-        // canonicalRepoArg() selects the best single argument form:
-        //   - Suffixed canonical (e.g. "@@protobuf~") when the mapping has a suffixed value
-        //   - Bare module name when the mapping has a no-suffix value (Bazel 7.4 inconsistency)
-        //   - Suffix-appended form (e.g. "@@googletest~") for pure transitives not in the mapping
-        // If the batch fails for any reason, runPerModuleShowRepo() retries with the full
-        // candidateRepoArgs() list which includes additional fallbacks including the bare name.
-        List<String> showRepoArgs = new ArrayList<>();
-        for (String moduleKey : moduleKeys) {
-            String name        = BzlmodGraphJsonParser.extractName(moduleKey);
-            String showRepoArg = resolver.canonicalRepoArg(name);
-            showRepoArgs.add(showRepoArg);
-        }
+        Map<String, String> showRepoOutputByKey = showRepoExecutor.resolveWithFallback(moduleKeys, resolver);
 
-        // Attempt a single batched show_repo call (Bazel 7.1+ supports it; we are always 7.1+ here)
-        Map<String, String> showRepoOutputByKey = tryBatchedShowRepo(moduleKeys, showRepoArgs, resolver);
-        if (showRepoOutputByKey.isEmpty()) {
-            // Batch returned nothing at all — fall back to per-module for every module
-            logger.debug("BZLMOD BCR: batched show_repo returned no results; falling back to per-module calls");
-            showRepoOutputByKey = runPerModuleShowRepo(moduleKeys, resolver);
-        } else {
-            logger.debug("BZLMOD BCR: batched show_repo resolved {} of {} module(s)", showRepoOutputByKey.size(), moduleKeys.size());
-            // Partial batch success: some modules may have been submitted as bare names and came back
-            // with "## @name:" headers instead of "## @@name~:" — the parser now handles both, but
-            // as a safety net, retry any module still missing from the batch result using per-module calls.
-            Set<String> notResolvedByBatch = new LinkedHashSet<>(moduleKeys);
-            notResolvedByBatch.removeAll(showRepoOutputByKey.keySet());
-            if (!notResolvedByBatch.isEmpty()) {
-                logger.debug("BZLMOD BCR: {} module(s) not resolved by batch; retrying per-module", notResolvedByBatch.size());
-                Map<String, String> perModuleResults = runPerModuleShowRepo(notResolvedByBatch, resolver);
-                showRepoOutputByKey.putAll(perModuleResults);
-            }
-        }
-
-        // Convert show_repo output to Dependencies
         Map<String, Dependency> result = new LinkedHashMap<>();
         for (String moduleKey : moduleKeys) {
             String showRepoOutput = showRepoOutputByKey.get(moduleKey);
@@ -287,103 +262,6 @@ public class BzlmodBcrExtractor {
             if (dep != null) {
                 result.put(moduleKey, dep);
                 resolvedExternalIds.add(dep.getExternalId());
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Attempts a single batched {@code bazel mod show_repo @@name~ @@name2~ ...} and maps the
-     * split output blocks back to module keys via the {@code ## @@name<suffix>:} header in each block.
-     * Returns an empty map if the batch fails, returns no stdout, or cannot be split.
-     *
-     * <p>The canonical {@code @@name<suffix>} form is used so that pure transitive modules resolve
-     * without a repo-mapping lookup. See {@link #resolveModules} for the full explanation.
-     * The actual suffix character ("+" or "~") is detected dynamically by the resolver.
-     */
-    private Map<String, String> tryBatchedShowRepo(Set<String> moduleKeys, List<String> showRepoArgs,
-                                                    BzlmodRepoMappingResolver resolver) {
-        if (showRepoArgs.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        Optional<String> batchOutput = showRepoExecutor.runBatch(showRepoArgs);
-        if (!batchOutput.isPresent()) {
-            return Collections.emptyMap();
-        }
-
-        // Each repo block starts with either:
-        //   "## @@<name><suffix>:" — canonical form (submitted as @@name~ or @@name+)
-        //   "## @<name>:"          — apparent/bare form (submitted as bare name, Bazel resolves via apparent-name path)
-        // ShowRepoExecutor splits on the "## @" boundary (catches both); we then determine the prefix
-        // length when extracting the repo name from each block header.
-        List<String> outputBlocks = showRepoExecutor.splitIntoBlocks(batchOutput.get());
-        Map<String, String> blockContentByModuleName = new LinkedHashMap<>();
-        for (String trimmedBlock : outputBlocks) {
-            // Determine which header form this block uses and extract the repo name from the header
-            String headerRepoName = null;
-            if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_CANONICAL)) {
-                // e.g. "## @@protobuf~: ..." → headerRepoName = "protobuf~"
-                int colonIdx = trimmedBlock.indexOf(':');
-                if (colonIdx > REPO_BLOCK_SEPARATOR_CANONICAL.length()) {
-                    headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_CANONICAL.length(), colonIdx);
-                }
-            } else if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_APPARENT)) {
-                // e.g. "## @bazel_skylib: ..." → headerRepoName = "bazel_skylib" (already no suffix)
-                int colonIdx = trimmedBlock.indexOf(':');
-                if (colonIdx > REPO_BLOCK_SEPARATOR_APPARENT.length()) {
-                    headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_APPARENT.length(), colonIdx);
-                }
-            }
-            if (headerRepoName != null) {
-                // Strip any canonical suffix (e.g. "protobuf~" → "protobuf"; "bazel_skylib" → "bazel_skylib")
-                String moduleName = resolver.stripCanonicalSuffix(headerRepoName);
-                logger.debug("BZLMOD BCR: batched show_repo block header: headerRepoName='{}' → moduleName='{}'",
-                    headerRepoName, moduleName);
-                blockContentByModuleName.put(moduleName, trimmedBlock);
-            }
-        }
-
-        // Map module keys to the block content that corresponds to their extracted module name
-        Map<String, String> result = new LinkedHashMap<>();
-        for (String moduleKey : moduleKeys) {
-            String name         = BzlmodGraphJsonParser.extractName(moduleKey);
-            String blockContent = blockContentByModuleName.get(name);
-            if (blockContent != null) {
-                result.put(moduleKey, blockContent);
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Runs {@code bazel mod show_repo} individually for each module key using the ordered candidate
-     * list from {@link BzlmodRepoMappingResolver#candidateRepoArgs}. Used as a fallback when the
-     * batched call fails or returns no results.
-     *
-     * <p>The candidate list is designed to handle cross-version Bazel inconsistencies:
-     * <ul>
-     *   <li>Canonical form ({@code @@name~}) is tried first when the suffix is known — works on 8.x+.</li>
-     *   <li>Bare module name ({@code name}) is tried as a fallback — avoids Bazel 7.x NPE crashes
-     *       that can occur when passing canonical form for some modules.</li>
-     *   <li>Both suffix forms are tried when no suffix evidence exists — avoids guessing wrong.</li>
-     * </ul>
-     *
-     * <p>Any candidate that causes a Bazel crash (exception or empty output) is treated as
-     * "this candidate failed — try next". The loop never propagates a Bazel-side crash upward;
-     * if all candidates fail, the module is logged and skipped.
-     */
-    private Map<String, String> runPerModuleShowRepo(Set<String> moduleKeys, BzlmodRepoMappingResolver resolver) {
-        Map<String, String> result = new LinkedHashMap<>();
-        for (String moduleKey : moduleKeys) {
-            String name = BzlmodGraphJsonParser.extractName(moduleKey);
-            // The ordered candidate list handles cross-version Bazel inconsistencies (see resolver javadoc).
-            // ShowRepoExecutor tries each in turn and returns the first non-empty result; any candidate
-            // that crashes Bazel (7.x NPE) is treated as a miss and the loop advances.
-            Optional<String> output = showRepoExecutor.runFirstSuccessful(resolver.candidateRepoArgs(name));
-            if (output.isPresent()) {
-                result.put(moduleKey, output.get());
-            } else {
-                logger.debug("BZLMOD BCR: per-module show_repo produced no output for '{}'", moduleKey);
             }
         }
         return result;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -68,6 +68,10 @@ public class BzlmodBcrExtractor {
     // The Bazel target being scanned (e.g., //java/src/...:client-combined).
     // Used to scope the BCR BOM to only modules the target actually fetches.
     private final String bazelTarget;
+    // User-supplied query options (detect.bazel.query.options). Applied to the target-scope library
+    // query so it is consistent with the HTTP_ARCHIVE pipeline and HttpFamilyProber, which both honor
+    // these options. Keeping the args identical also lets BazelCommandExecutor memoize/reuse the result.
+    private final List<String> queryOptions;
     // Stateless helpers — instantiated internally, no external injection needed
     private final GithubUrlParser githubUrlParser;
     private final IntermediateStepParseShowRepoToUrlCandidates urlCandidateParser;
@@ -76,10 +80,18 @@ public class BzlmodBcrExtractor {
     // Populated during extractGraph(); used by callers to avoid re-adding BCR deps flat via other pipelines.
     private final Set<ExternalId> resolvedExternalIds = new LinkedHashSet<>();
 
+    /**
+     * Backward-compatible constructor with no user query options (used by unit tests).
+     */
     public BzlmodBcrExtractor(BazelCommandExecutor bazelCmd, BazelVersion bazelVersion, String bazelTarget) {
+        this(bazelCmd, bazelVersion, bazelTarget, Collections.emptyList());
+    }
+
+    public BzlmodBcrExtractor(BazelCommandExecutor bazelCmd, BazelVersion bazelVersion, String bazelTarget, List<String> queryOptions) {
         this.bazelCmd = bazelCmd;
         this.bazelVersion = bazelVersion;
         this.bazelTarget = bazelTarget;
+        this.queryOptions = queryOptions != null ? queryOptions : Collections.emptyList();
         this.githubUrlParser = new GithubUrlParser();
         this.urlCandidateParser = new IntermediateStepParseShowRepoToUrlCandidates();
         this.showRepoExecutor = new ShowRepoExecutor(bazelCmd);
@@ -131,8 +143,10 @@ public class BzlmodBcrExtractor {
 
         // Step 1c — narrow the mod graph to only modules the target actually fetches.
         // This keeps the BCR path consistent with all other Bazel pipelines which are target-scoped
-        // via 'bazel query deps(//target)'. We reuse the same library query the HTTP_ARCHIVE pipeline
-        // runs, so Bazel serves it from its analysis cache at no extra cost.
+        // via 'bazel query deps(//target)'. We reuse the exact same library query (same args, including
+        // detect.bazel.query.options) that HttpFamilyProber runs during probing; BazelCommandExecutor
+        // memoizes read-only query results for the extraction, so this is served in-process rather than
+        // re-executing Bazel.
         //
         // The whitelist check bridges two different Bazel naming planes:
         //   bazel query output  → labels like  @@abseil-cpp~//absl/strings:strings
@@ -488,13 +502,16 @@ public class BzlmodBcrExtractor {
      *   <li>{@code @@module++ext+subrepo//...} (module extension sub-repo) → skipped (empty Optional)</li>
      * </ul>
      *
-     * <p>The same query is run by the HTTP_ARCHIVE pipeline, so Bazel's analysis cache serves it
-     * without a full re-evaluation — effectively zero extra cost.
+     * <p>The same query (same args, including {@code detect.bazel.query.options}) is issued by
+     * {@code HttpFamilyProber} during probing; because {@link BazelCommandExecutor} memoizes
+     * read-only query results for the extraction, this call is served from that in-process cache
+     * rather than re-executing Bazel.
      */
     private Set<String> getTargetScopedModuleNames(BzlmodRepoMappingResolver resolver) {
         logger.debug("BZLMOD BCR: querying target-scoped repos via 'bazel query kind(.*library, deps({}))'", bazelTarget);
         List<String> queryArgs = BazelQueryBuilder.query()
             .kind(LIBRARY_RULE_PATTERN, BazelQueryBuilder.deps(bazelTarget))
+            .withOptions(queryOptions)
             .build();
 
         Optional<String> queryOutput;

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -129,7 +129,7 @@ public class BzlmodBcrExtractor {
         Optional<String> modGraphOutput = bazelCmd.executeModCommandToString(modGraphArgs);
 
         if (!modGraphOutput.isPresent()) {
-            logger.warn("BZLMOD BCR: 'bazel mod graph --output json' produced no output; returning empty graph");
+            logger.warn("Bazel module graph returned no output; dependency extraction will be skipped");
             return new BasicDependencyGraph();
         }
 
@@ -138,7 +138,7 @@ public class BzlmodBcrExtractor {
 
         Set<String> allKeys = tree.getAllModuleKeys();
         if (allKeys.isEmpty()) {
-            logger.warn("BZLMOD BCR: module graph contained no parseable module keys; returning empty graph");
+            logger.warn("Bazel module graph contained no recognizable entries; dependency extraction will be skipped");
             return new BasicDependencyGraph();
         }
         logger.debug("BZLMOD BCR: module graph has {} direct dep(s) and {} total unique module(s)",
@@ -183,7 +183,7 @@ public class BzlmodBcrExtractor {
                 filtered.size(), allKeys.size(), bazelTarget, allKeys.size() - filtered.size());
             allKeys = filtered;
         } else {
-            logger.warn("BZLMOD BCR: target-scoped filter unavailable — reporting full project-scoped mod graph ({} modules)",
+            logger.warn("Target-specific dependency filter unavailable — all {} module(s) in the project will be reported",
                 allKeys.size());
         }
 
@@ -251,10 +251,9 @@ public class BzlmodBcrExtractor {
                 // Module could not be resolved — likely uses git_override or local_path_override
                 // with a non-standard canonical name, or is not a standard BCR module.
                 // The HTTP_ARCHIVE pipeline may still capture it via bazel query.
-                logger.warn("BZLMOD BCR: show_repo produced no output for '{}' — " +
-                    "module may use a git_override or local_path_override with a non-standard canonical name. " +
-                    "It will not be included in the BCR BOM. " +
-                    "It may still appear via the HTTP_ARCHIVE pipeline.",
+                logger.warn("Module '{}' could not be resolved — it may use a local override. " +
+                    "It will not be included in these scan results. " +
+                    "It may still be found via other scan methods.",
                     moduleKey);
                 continue;
             }
@@ -308,13 +307,11 @@ public class BzlmodBcrExtractor {
 
         // No GitHub URL found — log all raw URLs so users can investigate
         if (!urlCandidates.isEmpty()) {
-            logger.warn("BZLMOD BCR: no GitHub URL found for '{}' — raw URL(s): {}. " +
-                "This component is not included in the BOM. " +
-                "Consider running signature scan on this path or consulting the KB team about forge support.",
+            logger.warn("Module '{}' was found but its source URL is not a supported GitHub URL — it will not appear in the scan results. " +
+                "Raw URL(s): {}. Consider running a signature scan for this component.",
                 moduleKey, urlCandidates);
         } else {
-            logger.warn("BZLMOD BCR: no URLs found in show_repo output for '{}'. " +
-                "This component is not included in the BOM.", moduleKey);
+            logger.warn("Module '{}' was found but no source URL could be extracted — it will not appear in the scan results.", moduleKey);
         }
         return null;
     }
@@ -357,7 +354,7 @@ public class BzlmodBcrExtractor {
 
         logger.debug("BZLMOD BCR: dependency tree — {} direct, {} transitive Bazel module(s)",
             directCount, moduleKeyToDep.size() - directCount);
-        logger.info("BZLMOD BCR: structured direct/transitive classification complete.");
+        logger.debug("BZLMOD BCR: structured direct/transitive classification complete.");
         return graph;
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -8,6 +8,7 @@ import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.detectable.detectable.executable.ExecutableFailedException;
 import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.BazelCommandExecutor;
 import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.IntermediateStepParseShowRepoToUrlCandidates;
+import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.ShowRepoExecutor;
 import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.parse.GithubUrlParser;
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
 import org.slf4j.Logger;
@@ -70,6 +71,8 @@ public class BzlmodBcrExtractor {
     // Stateless helpers — instantiated internally, no external injection needed
     private final GithubUrlParser githubUrlParser;
     private final IntermediateStepParseShowRepoToUrlCandidates urlCandidateParser;
+    // Shared show_repo execution mechanics (batching, block splitting, per-candidate fallback)
+    private final ShowRepoExecutor showRepoExecutor;
     // Populated during extractGraph(); used by callers to avoid re-adding BCR deps flat via other pipelines.
     private final Set<ExternalId> resolvedExternalIds = new LinkedHashSet<>();
 
@@ -79,6 +82,7 @@ public class BzlmodBcrExtractor {
         this.bazelTarget = bazelTarget;
         this.githubUrlParser = new GithubUrlParser();
         this.urlCandidateParser = new IntermediateStepParseShowRepoToUrlCandidates();
+        this.showRepoExecutor = new ShowRepoExecutor(bazelCmd);
     }
 
     /**
@@ -288,62 +292,53 @@ public class BzlmodBcrExtractor {
         if (showRepoArgs.isEmpty()) {
             return Collections.emptyMap();
         }
-        try {
-            List<String> batchCmd = BazelQueryBuilder.mod().showRepoRawBatch(showRepoArgs).build();
-            Optional<String> batchOutput = bazelCmd.executeModCommandToString(batchCmd);
-            if (!batchOutput.isPresent() || batchOutput.get().trim().isEmpty()) {
-                return Collections.emptyMap();
-            }
-
-            // Each repo block starts with either:
-            //   "## @@<name><suffix>:" — canonical form (submitted as @@name~ or @@name+)
-            //   "## @<name>:"          — apparent/bare form (submitted as bare name, Bazel resolves via apparent-name path)
-            // Split on "## @" (catches both) and then determine the prefix length when extracting the repo name.
-            String[] outputBlocks = batchOutput.get().split("(?=" + REPO_BLOCK_SEPARATOR_APPARENT + ")");
-            Map<String, String> blockContentByModuleName = new LinkedHashMap<>();
-            for (String outputBlock : outputBlocks) {
-                String trimmedBlock = outputBlock.trim();
-                if (trimmedBlock.isEmpty()) {
-                    continue;
-                }
-                // Determine which header form this block uses and extract the repo name from the header
-                String headerRepoName = null;
-                if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_CANONICAL)) {
-                    // e.g. "## @@protobuf~: ..." → headerRepoName = "protobuf~"
-                    int colonIdx = trimmedBlock.indexOf(':');
-                    if (colonIdx > REPO_BLOCK_SEPARATOR_CANONICAL.length()) {
-                        headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_CANONICAL.length(), colonIdx);
-                    }
-                } else if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_APPARENT)) {
-                    // e.g. "## @bazel_skylib: ..." → headerRepoName = "bazel_skylib" (already no suffix)
-                    int colonIdx = trimmedBlock.indexOf(':');
-                    if (colonIdx > REPO_BLOCK_SEPARATOR_APPARENT.length()) {
-                        headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_APPARENT.length(), colonIdx);
-                    }
-                }
-                if (headerRepoName != null) {
-                    // Strip any canonical suffix (e.g. "protobuf~" → "protobuf"; "bazel_skylib" → "bazel_skylib")
-                    String moduleName = resolver.stripCanonicalSuffix(headerRepoName);
-                    logger.debug("BZLMOD BCR: batched show_repo block header: headerRepoName='{}' → moduleName='{}'",
-                        headerRepoName, moduleName);
-                    blockContentByModuleName.put(moduleName, trimmedBlock);
-                }
-            }
-
-            // Map module keys to the block content that corresponds to their extracted module name
-            Map<String, String> result = new LinkedHashMap<>();
-            for (String moduleKey : moduleKeys) {
-                String name         = BzlmodGraphJsonParser.extractName(moduleKey);
-                String blockContent = blockContentByModuleName.get(name);
-                if (blockContent != null) {
-                    result.put(moduleKey, blockContent);
-                }
-            }
-            return result;
-        } catch (Exception e) {
-            logger.debug("BZLMOD BCR: batched show_repo failed with exception: {}", e.getMessage());
+        Optional<String> batchOutput = showRepoExecutor.runBatch(showRepoArgs);
+        if (!batchOutput.isPresent()) {
             return Collections.emptyMap();
         }
+
+        // Each repo block starts with either:
+        //   "## @@<name><suffix>:" — canonical form (submitted as @@name~ or @@name+)
+        //   "## @<name>:"          — apparent/bare form (submitted as bare name, Bazel resolves via apparent-name path)
+        // ShowRepoExecutor splits on the "## @" boundary (catches both); we then determine the prefix
+        // length when extracting the repo name from each block header.
+        List<String> outputBlocks = showRepoExecutor.splitIntoBlocks(batchOutput.get());
+        Map<String, String> blockContentByModuleName = new LinkedHashMap<>();
+        for (String trimmedBlock : outputBlocks) {
+            // Determine which header form this block uses and extract the repo name from the header
+            String headerRepoName = null;
+            if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_CANONICAL)) {
+                // e.g. "## @@protobuf~: ..." → headerRepoName = "protobuf~"
+                int colonIdx = trimmedBlock.indexOf(':');
+                if (colonIdx > REPO_BLOCK_SEPARATOR_CANONICAL.length()) {
+                    headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_CANONICAL.length(), colonIdx);
+                }
+            } else if (trimmedBlock.startsWith(REPO_BLOCK_SEPARATOR_APPARENT)) {
+                // e.g. "## @bazel_skylib: ..." → headerRepoName = "bazel_skylib" (already no suffix)
+                int colonIdx = trimmedBlock.indexOf(':');
+                if (colonIdx > REPO_BLOCK_SEPARATOR_APPARENT.length()) {
+                    headerRepoName = trimmedBlock.substring(REPO_BLOCK_SEPARATOR_APPARENT.length(), colonIdx);
+                }
+            }
+            if (headerRepoName != null) {
+                // Strip any canonical suffix (e.g. "protobuf~" → "protobuf"; "bazel_skylib" → "bazel_skylib")
+                String moduleName = resolver.stripCanonicalSuffix(headerRepoName);
+                logger.debug("BZLMOD BCR: batched show_repo block header: headerRepoName='{}' → moduleName='{}'",
+                    headerRepoName, moduleName);
+                blockContentByModuleName.put(moduleName, trimmedBlock);
+            }
+        }
+
+        // Map module keys to the block content that corresponds to their extracted module name
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String moduleKey : moduleKeys) {
+            String name         = BzlmodGraphJsonParser.extractName(moduleKey);
+            String blockContent = blockContentByModuleName.get(name);
+            if (blockContent != null) {
+                result.put(moduleKey, blockContent);
+            }
+        }
+        return result;
     }
 
     /**
@@ -367,30 +362,13 @@ public class BzlmodBcrExtractor {
         Map<String, String> result = new LinkedHashMap<>();
         for (String moduleKey : moduleKeys) {
             String name = BzlmodGraphJsonParser.extractName(moduleKey);
-            boolean resolved = false;
-            for (String candidate : resolver.candidateRepoArgs(name)) {
-                try {
-                    List<String> showRepoArgs = BazelQueryBuilder.mod().showRepoRaw(candidate).build();
-                    Optional<String> output = bazelCmd.executeModCommandToString(showRepoArgs);
-                    if (output.isPresent() && !output.get().trim().isEmpty()) {
-                        result.put(moduleKey, output.get());
-                        resolved = true;
-                        logger.debug("BZLMOD BCR: per-module show_repo resolved '{}' using candidate '{}'",
-                            moduleKey, candidate);
-                        break;
-                    }
-                    logger.debug("BZLMOD BCR: show_repo candidate '{}' for '{}' returned no output; trying next",
-                        candidate, name);
-                } catch (Exception e) {
-                    // Bazel 7.x can FATAL-crash (NullPointerException inside ModuleArg$CanonicalRepoName)
-                    // when given certain canonical forms for modules not in its internal repo map.
-                    // Treat any exception as "this candidate failed" and advance to the next candidate.
-                    // See SHOW_REPO_ARG_BUGS.md — Bug 2 for full analysis.
-                    logger.debug("BZLMOD BCR: show_repo candidate '{}' for '{}' failed with exception: {} — trying next",
-                        candidate, name, e.getMessage());
-                }
-            }
-            if (!resolved) {
+            // The ordered candidate list handles cross-version Bazel inconsistencies (see resolver javadoc).
+            // ShowRepoExecutor tries each in turn and returns the first non-empty result; any candidate
+            // that crashes Bazel (7.x NPE) is treated as a miss and the loop advances.
+            Optional<String> output = showRepoExecutor.runFirstSuccessful(resolver.candidateRepoArgs(name));
+            if (output.isPresent()) {
+                result.put(moduleKey, output.get());
+            } else {
                 logger.debug("BZLMOD BCR: per-module show_repo produced no output for '{}'", moduleKey);
             }
         }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodBcrExtractor.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -61,14 +60,7 @@ public class BzlmodBcrExtractor {
 
     // Pattern for the target-scoped library query (same as the HTTP_ARCHIVE pipeline)
     private static final String LIBRARY_RULE_PATTERN = ".*library";
-    // Repo name prefixes that are Bazel toolchain / internal repos — excluded from BCR scope check.
-    // Mirrors the exclusion list in HttpFamilyProber and Pipelines.java.
-    private static final Set<String> EXCLUDED_REPO_PREFIXES = new HashSet<>(Arrays.asList(
-        "bazel_tools", "local_config_", "remotejdk", "platforms",
-        "rules_python", "rules_java", "rules_cc",
-        "maven", "unpinned_maven", "rules_jvm_external",
-        "rules_shell"  // Bazel 9 implicitly injects rules_shell into every Java target; it is a build toolchain module, not shipped software
-    ));
+    // Infrastructure / toolchain repo exclusion is centralized in BazelInfrastructureModules.
 
     private final BazelCommandExecutor bazelCmd;
     private final BazelVersion bazelVersion;
@@ -564,15 +556,10 @@ public class BzlmodBcrExtractor {
 
     /**
      * Returns true if the repo/module name should be excluded from BCR scope checks.
-     * Mirrors the exclusion list in HttpFamilyProber and Pipelines.java.
+     * Delegates to the shared {@link BazelInfrastructureModules} source of truth.
      */
     private boolean isExcludedModuleName(String name) {
-        for (String prefix : EXCLUDED_REPO_PREFIXES) {
-            if (name.startsWith(prefix)) {
-                return true;
-            }
-        }
-        return false;
+        return BazelInfrastructureModules.isInfrastructure(name);
     }
 
     /**

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodGraphJsonParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodGraphJsonParser.java
@@ -103,8 +103,7 @@ public class BzlmodGraphJsonParser {
      * @return Module name
      */
     public static String extractName(String moduleKey) {
-        int atIdx = moduleKey.indexOf(MODULE_KEY_SEPARATOR);
-        return atIdx > 0 ? moduleKey.substring(0, atIdx) : moduleKey;
+        return ModuleKey.parse(moduleKey).getName();
     }
 
     /**
@@ -115,8 +114,7 @@ public class BzlmodGraphJsonParser {
      * @return Module version, or null if not present
      */
     public static String extractVersion(String moduleKey) {
-        int atIdx = moduleKey.indexOf(MODULE_KEY_SEPARATOR);
-        return atIdx > 0 && atIdx < moduleKey.length() - 1 ? moduleKey.substring(atIdx + 1) : null;
+        return ModuleKey.parse(moduleKey).getVersion();
     }
 
     // -------------------------------------------------------------------------

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.bazel.v2;
 
 import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.BazelCommandExecutor;
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -69,21 +70,21 @@ import java.util.Optional;
 public class BzlmodRepoMappingResolver {
     private static final Logger logger = LoggerFactory.getLogger(BzlmodRepoMappingResolver.class);
 
-    // Label prefix constants
-    private static final String CANONICAL_PREFIX = "@@";
-    private static final String APPARENT_PREFIX  = "@";
+    // Label prefix constants (centralized in BazelCommandArguments)
+    private static final String CANONICAL_PREFIX = BazelCommandArguments.REPO_PREFIX_CANONICAL;
+    private static final String APPARENT_PREFIX  = BazelCommandArguments.REPO_PREFIX_SINGLE;
     // Canonical names for module extension sub-repos contain "++" (e.g., rules_jvm_external++maven+guava).
     // These never appear as module keys in bazel mod graph and must be excluded.
-    private static final String MODULE_EXTENSION_MARKER = "++";
+    private static final String MODULE_EXTENSION_MARKER = BazelCommandArguments.MODULE_EXTENSION_MARKER;
     // Separator between repo name and path in a fully-qualified label
-    private static final String LABEL_PATH_SEPARATOR = "//";
+    private static final String LABEL_PATH_SEPARATOR = BazelCommandArguments.LABEL_PATH_SEPARATOR;
     // Regex that strips any known canonical suffix when the mapping is unavailable
-    private static final String KNOWN_SUFFIXES_REGEX = "[+~]$";
+    private static final String KNOWN_SUFFIXES_REGEX = BazelCommandArguments.KNOWN_CANONICAL_SUFFIX_REGEX;
     // The two canonical suffix characters used by Bazel across versions:
     //   SUFFIX_TILDE (~) — introduced in Bazel 7.5+
     //   SUFFIX_PLUS  (+) — used in Bazel 7.x (pre-7.5) and some 8.x builds
-    private static final String SUFFIX_TILDE = "~";
-    private static final String SUFFIX_PLUS  = "+";
+    private static final String SUFFIX_TILDE = BazelCommandArguments.REPO_CANONICAL_SUFFIX_TILDE;
+    private static final String SUFFIX_PLUS  = BazelCommandArguments.REPO_CANONICAL_SUFFIX_PLUS;
 
     // -------------------------------------------------------------------------
     // Inner types

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
@@ -70,14 +70,9 @@ import java.util.Optional;
 public class BzlmodRepoMappingResolver {
     private static final Logger logger = LoggerFactory.getLogger(BzlmodRepoMappingResolver.class);
 
-    // Label prefix constants (centralized in BazelCommandArguments)
+    // Label prefix constant (centralized in BazelCommandArguments). Used when constructing
+    // canonical @@name show_repo arguments. Structural label *parsing* is delegated to BazelLabel.
     private static final String CANONICAL_PREFIX = BazelCommandArguments.REPO_PREFIX_CANONICAL;
-    private static final String APPARENT_PREFIX  = BazelCommandArguments.REPO_PREFIX_SINGLE;
-    // Canonical names for module extension sub-repos contain "++" (e.g., rules_jvm_external++maven+guava).
-    // These never appear as module keys in bazel mod graph and must be excluded.
-    private static final String MODULE_EXTENSION_MARKER = BazelCommandArguments.MODULE_EXTENSION_MARKER;
-    // Separator between repo name and path in a fully-qualified label
-    private static final String LABEL_PATH_SEPARATOR = BazelCommandArguments.LABEL_PATH_SEPARATOR;
     // Regex that strips any known canonical suffix when the mapping is unavailable
     private static final String KNOWN_SUFFIXES_REGEX = BazelCommandArguments.KNOWN_CANONICAL_SUFFIX_REGEX;
     // The two canonical suffix characters used by Bazel across versions:
@@ -206,43 +201,40 @@ public class BzlmodRepoMappingResolver {
      * </ul>
      */
     public Optional<String> resolveLabel(String label) {
-        if (label == null || label.isEmpty() || !label.startsWith(APPARENT_PREFIX)) {
+        BazelLabel parsed = BazelLabel.parse(label);
+        if (!parsed.isRepoLabel()) {
+            return Optional.empty();
+        }
+        // Module extension sub-repos (canonical names contain "++", e.g. rules_jvm_external++maven+guava)
+        // never appear as module keys in bazel mod graph and must be excluded.
+        if (parsed.isModuleExtensionSubRepo()) {
             return Optional.empty();
         }
 
-        // Strip the //path:target suffix — we only care about the repo name part
-        String repoName;
-        int pathIdx = label.indexOf(LABEL_PATH_SEPARATOR);
-        repoName = pathIdx >= 0 ? label.substring(0, pathIdx) : label;
+        // The repo name is the repository portion after the @/@@ prefix and before //path:target,
+        // with any version suffix (~/+) still attached — not yet the resolved BCR module name.
+        String rawRepoName = parsed.getRepoName();
 
         String moduleName;
-        if (repoName.startsWith(CANONICAL_PREFIX)) {
+        if (parsed.isCanonical()) {
             // ──────────────────────────────────────────────────────────────────
             // Canonical form: @@abseil-cpp~  or  @@abseil-cpp+
             // The suffix carries Bazel's version-specific mangling and must be stripped.
             // No mapping lookup needed — the name is already unambiguous.
             // ──────────────────────────────────────────────────────────────────
-            String raw = repoName.substring(CANONICAL_PREFIX.length()); // "abseil-cpp~"
-            if (raw.contains(MODULE_EXTENSION_MARKER)) {
-                return Optional.empty(); // e.g. rules_jvm_external++maven+guava
-            }
-            moduleName = stripKnownSuffix(raw);
+            moduleName = stripKnownSuffix(rawRepoName);
         } else {
             // ──────────────────────────────────────────────────────────────────
             // Apparent form: @com_google_protobuf
             // Look up in the forward map to resolve any repo_name alias.
             // If not found, the apparent name equals the module name (no override).
             // ──────────────────────────────────────────────────────────────────
-            String apparent = repoName.substring(APPARENT_PREFIX.length()); // "com_google_protobuf"
-            if (apparent.contains(MODULE_EXTENSION_MARKER)) {
-                return Optional.empty();
-            }
-            if (available && apparentToCanonical.containsKey(apparent)) {
-                String canonical = apparentToCanonical.get(apparent); // "protobuf~"
-                moduleName = stripKnownSuffix(canonical);             // "protobuf"
+            if (available && apparentToCanonical.containsKey(rawRepoName)) {
+                String canonical = apparentToCanonical.get(rawRepoName); // "protobuf~"
+                moduleName = stripKnownSuffix(canonical);                // "protobuf"
             } else {
                 // No alias in the mapping — apparent name IS the module name
-                moduleName = apparent;
+                moduleName = rawRepoName;
             }
         }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/BzlmodRepoMappingResolver.java
@@ -171,13 +171,11 @@ public class BzlmodRepoMappingResolver {
         try {
             output = bazelCmd.executeModCommandToString(cmd);
         } catch (Exception e) {
-            logger.warn("BZLMOD BCR: dump_repo_mapping command failed ({}); " +
-                "apparent-name aliases (repo_name overrides) will not be resolved", e.getMessage());
+            logger.warn("Repo alias resolution failed ({}); packages with custom names may not be resolved correctly", e.getMessage());
             return unavailable();
         }
         if (!output.isPresent() || output.get().trim().isEmpty()) {
-            logger.warn("BZLMOD BCR: dump_repo_mapping produced no output; " +
-                "apparent-name aliases will not be resolved");
+            logger.warn("Repo alias data was empty; packages with custom names may not be resolved correctly");
             return unavailable();
         }
         return parse(output.get());
@@ -462,7 +460,7 @@ public class BzlmodRepoMappingResolver {
         try {
             JsonElement element = JsonParser.parseString(json);
             if (!element.isJsonObject()) {
-                logger.warn("BZLMOD BCR: dump_repo_mapping output is not a JSON object; degrading gracefully");
+                logger.warn("Repo alias data has an unexpected format; degrading gracefully");
                 return unavailable();
             }
             JsonObject obj = element.getAsJsonObject();
@@ -477,7 +475,7 @@ public class BzlmodRepoMappingResolver {
                 }
             }
             if (apparentToCanonical.isEmpty()) {
-                logger.warn("BZLMOD BCR: dump_repo_mapping JSON had no usable entries; degrading gracefully");
+                logger.warn("Repo alias data contained no usable entries; degrading gracefully");
                 return unavailable();
             }
 
@@ -506,7 +504,7 @@ public class BzlmodRepoMappingResolver {
             return new BzlmodRepoMappingResolver(apparentToCanonical, moduleNameToCanonical, canonicalSuffix, true, hasSuffixEvidence);
 
         } catch (Exception e) {
-            logger.warn("BZLMOD BCR: failed to parse dump_repo_mapping output ({}); degrading gracefully", e.getMessage());
+            logger.warn("Failed to parse repo alias data ({}); degrading gracefully", e.getMessage());
             return unavailable();
         }
     }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/HttpFamilyProber.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/HttpFamilyProber.java
@@ -1,6 +1,7 @@
 package com.blackduck.integration.detectable.detectables.bazel.v2;
 
 import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.BazelCommandExecutor;
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
 import com.blackduck.integration.detectable.detectables.bazel.query.BazelQueryBuilder;
 import com.blackduck.integration.detectable.detectables.bazel.query.OutputFormat;
 import com.blackduck.integration.executable.ExecutableOutput;
@@ -44,30 +45,18 @@ public class HttpFamilyProber {
         "bazel_dep"
     );
 
-    // Excluded repository prefixes
-    private static final List<String> EXCLUDED_REPO_PREFIXES = Arrays.asList(
-        "bazel_tools",
-        "local_config_",
-        "remotejdk",
-        "platforms",
-        "rules_python",
-        "rules_java",
-        "rules_cc",
-        "maven",
-        "unpinned_maven",
-        "rules_jvm_external"
-    );
+    // Excluded repository prefixes are centralized in BazelInfrastructureModules.
 
     // TODO: Consider making this configurable if customers report performance issues on very large
     //       targets (500+ external repos). For now, hardcoded threshold with automatic HTTP pipeline
     //       enablement for large targets provides the best balance of performance and completeness.
     private static final int LARGE_TARGET_THRESHOLD = 150;
 
-    // Extracted string constants for repo prefix markers
-    private static final String REPO_PREFIX_SINGLE = "@";
-    private static final String REPO_PREFIX_CANONICAL = "@@";
+    // Repo prefix / path markers are centralized in BazelCommandArguments.
+    private static final String REPO_PREFIX_SINGLE = BazelCommandArguments.REPO_PREFIX_SINGLE;
+    private static final String REPO_PREFIX_CANONICAL = BazelCommandArguments.REPO_PREFIX_CANONICAL;
     // Repo path separator used in Bazel labels
-    private static final String REPO_PATH_SEPARATOR = "//";
+    private static final String REPO_PATH_SEPARATOR = BazelCommandArguments.LABEL_PATH_SEPARATOR;
 
 
     /**
@@ -376,7 +365,7 @@ public class HttpFamilyProber {
      * Returns true if the repo name is in the list of excluded (non-HTTP) repositories.
      */
     private boolean isExcludedRepo(String repo) {
-        return EXCLUDED_REPO_PREFIXES.stream().anyMatch(repo::startsWith);
+        return BazelInfrastructureModules.isInfrastructure(repo);
     }
 
     /**

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/HttpFamilyProber.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/HttpFamilyProber.java
@@ -53,8 +53,8 @@ public class HttpFamilyProber {
     private static final int LARGE_TARGET_THRESHOLD = 150;
 
     // Repo prefix / path markers are centralized in BazelCommandArguments.
+    // Structural label parsing is delegated to BazelLabel; these remain for building label strings.
     private static final String REPO_PREFIX_SINGLE = BazelCommandArguments.REPO_PREFIX_SINGLE;
-    private static final String REPO_PREFIX_CANONICAL = BazelCommandArguments.REPO_PREFIX_CANONICAL;
     // Repo path separator used in Bazel labels
     private static final String REPO_PATH_SEPARATOR = BazelCommandArguments.LABEL_PATH_SEPARATOR;
 
@@ -164,7 +164,7 @@ public class HttpFamilyProber {
             .withOutputJson()
             .build();
 
-        ExecutableOutput output = bazel.executeWithoutThrowing(modGraphJsonCmd);
+        ExecutableOutput output = bazel.executeToleratingExitCode(modGraphJsonCmd);
         if (output.getReturnCode() != 0) {
             // Don't bail immediately on non-zero exit: a broken module extension (e.g., bazel_jar_jar+
             // on Bazel 9) poisons the exit code even when the JSON graph was fully emitted to stdout.
@@ -245,9 +245,9 @@ public class HttpFamilyProber {
         String[] lines = depsOutput.split("\r?\n");
         Map<String, LinkedHashSet<String>> repoLabels = new HashMap<>();
         for (String line : lines) {
-            if (line.startsWith(REPO_PREFIX_SINGLE) && line.contains(REPO_PATH_SEPARATOR)) {
-                int start = line.startsWith(REPO_PREFIX_CANONICAL) ? 2 : 1; // Support canonical names starting with @@
-                String repo = line.substring(start, line.indexOf(REPO_PATH_SEPARATOR));
+            BazelLabel label = BazelLabel.parse(line);
+            if (label.isRepoLabel() && label.hasPath()) {
+                String repo = label.getRepoName(); // repo name with suffix, prefix and //path stripped
                 if (isExcludedRepo(repo)) {
                     continue;
                 }

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/ModuleKey.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/bazel/v2/ModuleKey.java
@@ -1,0 +1,86 @@
+package com.blackduck.integration.detectable.detectables.bazel.v2;
+
+import java.util.Objects;
+
+import com.blackduck.integration.detectable.detectables.bazel.query.BazelCommandArguments;
+
+/**
+ * Value type for a Bazel {@code mod graph} module key of the form {@code name@version}
+ * (e.g. {@code protobuf@31.0}).
+ *
+ * <p>Centralizes the {@code name@version} parsing that was previously duplicated as ad-hoc
+ * {@code indexOf('@')}/{@code substring(...)} logic. The parsing rules deliberately mirror the
+ * historical {@code BzlmodGraphJsonParser.extractName}/{@code extractVersion} behavior exactly:
+ * <ul>
+ *   <li>The name is the substring before the first {@code @}, or the whole key when there is no
+ *       {@code @} at an index greater than 0 (so a leading {@code @} is not treated as a separator).</li>
+ *   <li>The version is the substring after the first {@code @}, or {@code null} when there is no
+ *       {@code @}, the {@code @} is at index 0, or the {@code @} is the last character.</li>
+ * </ul>
+ */
+public final class ModuleKey {
+    private static final String SEPARATOR = BazelCommandArguments.MODULE_KEY_SEPARATOR;
+
+    private final String rawKey;
+    private final String name;
+    private final String version; // nullable, mirrors extractVersion() returning null
+
+    private ModuleKey(String rawKey, String name, String version) {
+        this.rawKey = rawKey;
+        this.name = name;
+        this.version = version;
+    }
+
+    /**
+     * Parses a raw module key ({@code name@version}) into a {@link ModuleKey}.
+     *
+     * @param moduleKey the raw key (must not be {@code null})
+     * @return the parsed key
+     */
+    public static ModuleKey parse(String moduleKey) {
+        int atIdx = moduleKey.indexOf(SEPARATOR);
+        String name = atIdx > 0 ? moduleKey.substring(0, atIdx) : moduleKey;
+        String version = (atIdx > 0 && atIdx < moduleKey.length() - 1) ? moduleKey.substring(atIdx + 1) : null;
+        return new ModuleKey(moduleKey, name, version);
+    }
+
+    /** @return the module name (e.g. {@code protobuf} from {@code protobuf@31.0}). */
+    public String getName() {
+        return name;
+    }
+
+    /** @return the version, or {@code null} if the key has no {@code @version} part. */
+    public String getVersion() {
+        return version;
+    }
+
+    /** @return the original, unmodified key string. */
+    public String getRawKey() {
+        return rawKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModuleKey that = (ModuleKey) o;
+        return Objects.equals(name, that.name) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, version);
+    }
+
+    @Override
+    public String toString() {
+        return "ModuleKey{name='" + name + "', version='" + version + "'}";
+    }
+}
+
+
+

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/functional/bazel/pipeline/step/IntermediateStepParseShowRepoToUrlCandidatesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/functional/bazel/pipeline/step/IntermediateStepParseShowRepoToUrlCandidatesTest.java
@@ -1,0 +1,164 @@
+package com.blackduck.integration.detectable.detectables.bazel.functional.bazel.pipeline.step;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.detectable.detectable.exception.DetectableException;
+import com.blackduck.integration.detectable.detectables.bazel.pipeline.step.IntermediateStepParseShowRepoToUrlCandidates;
+
+/**
+ * Tests for {@link IntermediateStepParseShowRepoToUrlCandidates}.
+ *
+ * <p>Covers: explicit {@code url=}, {@code urls=[...]}, {@code remote=} (git_repository),
+ * and {@code go_repository} importpath synthesis — including the per-block guard fix that
+ * ensures go_repository synthesis is attempted even when a preceding block contributed URLs.
+ */
+public class IntermediateStepParseShowRepoToUrlCandidatesTest {
+
+    private IntermediateStepParseShowRepoToUrlCandidates step;
+
+    @BeforeEach
+    public void setUp() {
+        step = new IntermediateStepParseShowRepoToUrlCandidates();
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic attribute extraction
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void process_singleUrlAttribute_extractsUrl() throws DetectableException {
+        String block = "http_archive(\n"
+            + "    url = \"https://github.com/madler/zlib/archive/v1.3.tar.gz\",\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        assertEquals(1, result.size());
+        assertEquals("https://github.com/madler/zlib/archive/v1.3.tar.gz", result.get(0));
+    }
+
+    @Test
+    public void process_urlsListAttribute_extractsAllUrls() throws DetectableException {
+        String block = "http_archive(\n"
+            + "    urls = [\n"
+            + "        \"https://github.com/protocolbuffers/protobuf/archive/v31.0.tar.gz\",\n"
+            + "        \"https://mirror.example.com/protobuf-31.0.tar.gz\",\n"
+            + "    ],\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        assertEquals(2, result.size());
+        assertTrue(result.contains("https://github.com/protocolbuffers/protobuf/archive/v31.0.tar.gz"));
+        assertTrue(result.contains("https://mirror.example.com/protobuf-31.0.tar.gz"));
+    }
+
+    @Test
+    public void process_remoteAttribute_extractsGitRepositoryUrl() throws DetectableException {
+        String block = "git_repository(\n"
+            + "    remote = \"https://github.com/bazelbuild/rules_go.git\",\n"
+            + "    tag = \"v0.39.1\",\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        assertEquals(1, result.size());
+        assertEquals("https://github.com/bazelbuild/rules_go.git", result.get(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // go_repository synthesis
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void process_goRepositoryWithGithubImportpath_synthesizesHttpsUrl() throws DetectableException {
+        String block = "# Rule class: go_repository\n"
+            + "go_repository(\n"
+            + "    importpath = \"github.com/google/uuid\",\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        assertEquals(1, result.size());
+        assertEquals("https://github.com/google/uuid", result.get(0));
+    }
+
+    @Test
+    public void process_goRepositoryWithNonGithubImportpath_producesNoUrl() throws DetectableException {
+        String block = "# Rule class: go_repository\n"
+            + "go_repository(\n"
+            + "    importpath = \"golang.org/x/net\",\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        assertTrue(result.isEmpty(), "Non-GitHub importpath must not produce a synthesized URL");
+    }
+
+    // -------------------------------------------------------------------------
+    // Bug fix: per-block synthesis guard
+    //
+    // Before the fix, addSynthesizedGoUrlIfNoExplicit checked results.isEmpty() against
+    // the accumulated list — so if block 1 contributed a URL, go_repository synthesis for
+    // block 2 was silently skipped.  After the fix, the guard is per-block.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void process_goRepositoryBlockAfterHttpArchiveBlock_synthesisNotSkipped() throws DetectableException {
+        // Block 1: a normal http_archive with an explicit URL
+        String block1 = "## @@somelib~:\n"
+            + "http_archive(\n"
+            + "    urls = [\"https://github.com/example/somelib/archive/v1.0.tar.gz\"],\n"
+            + ")";
+
+        // Block 2: a go_repository with a GitHub importpath — synthesis must still be attempted
+        String block2 = "## @@golib~:\n"
+            + "# Rule class: go_repository\n"
+            + "go_repository(\n"
+            + "    importpath = \"github.com/example/golib\",\n"
+            + ")";
+
+        List<String> result = step.process(Arrays.asList(block1, block2));
+
+        assertEquals(2, result.size(),
+            "Block 1 must contribute its explicit URL and block 2 must contribute the synthesized URL; "
+                + "the per-block guard must not suppress block 2 because block 1 contributed a URL");
+        assertEquals("https://github.com/example/somelib/archive/v1.0.tar.gz", result.get(0));
+        assertEquals("https://github.com/example/golib", result.get(1));
+    }
+
+    @Test
+    public void process_goRepositoryBlockWithExplicitUrl_synthesisSkippedForThatBlock() throws DetectableException {
+        // go_repository that already has an explicit url= (unusual but valid) — synthesis must be suppressed
+        String block = "# Rule class: go_repository\n"
+            + "go_repository(\n"
+            + "    importpath = \"github.com/example/golib\",\n"
+            + "    url = \"https://github.com/example/golib/archive/v2.0.tar.gz\",\n"
+            + ")";
+        List<String> result = step.process(Collections.singletonList(block));
+        // Only the explicit URL should appear; no synthesized URL on top
+        assertEquals(1, result.size());
+        assertEquals("https://github.com/example/golib/archive/v2.0.tar.gz", result.get(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void process_nullInput_returnsEmpty() throws DetectableException {
+        assertTrue(step.process(null).isEmpty());
+    }
+
+    @Test
+    public void process_emptyInput_returnsEmpty() throws DetectableException {
+        assertTrue(step.process(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void process_blockWithNoUrlAttributes_returnsEmpty() throws DetectableException {
+        String block = "local_path_repository(\n"
+            + "    name = \"local-dep\",\n"
+            + "    path = \"/workspace/local-dep\",\n"
+            + ")";
+        assertTrue(step.process(Collections.singletonList(block)).isEmpty());
+    }
+}
+

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelCommandExecutorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelCommandExecutorTest.java
@@ -28,8 +28,9 @@ public class BazelCommandExecutorTest {
     @Test
     public void executeToString_whenExecutableFails_throwsExecutableFailedException() throws Exception {
         DetectableExecutableRunner executableRunner = Mockito.mock(DetectableExecutableRunner.class);
-        ExecutableFailedException failedException = Mockito.mock(ExecutableFailedException.class);
-        when(executableRunner.executeSuccessfully(any())).thenThrow(failedException);
+        // executeToString now routes through executeToleratingExitCode (execute), treating any
+        // non-zero exit as a hard failure → ExecutableFailedException.
+        when(executableRunner.execute(any())).thenReturn(new ExecutableOutput(1, "", "ERROR: build failed"));
 
         BazelCommandExecutor executor = makeExecutor(executableRunner);
 

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelLabelTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelLabelTest.java
@@ -1,0 +1,89 @@
+package com.blackduck.integration.detectable.detectables.bazel.v2.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.detectable.detectables.bazel.v2.BazelLabel;
+
+class BazelLabelTest {
+
+    @Test
+    void canonicalLabelWithSuffixAndPath() {
+        BazelLabel label = BazelLabel.parse("@@abseil-cpp~//absl:strings");
+        assertTrue(label.isRepoLabel());
+        assertTrue(label.isCanonical());
+        assertTrue(label.hasPath());
+        assertEquals("abseil-cpp~", label.getRepoName());
+        assertFalse(label.isModuleExtensionSubRepo());
+    }
+
+    @Test
+    void apparentLabelWithPath() {
+        BazelLabel label = BazelLabel.parse("@com_google_protobuf//google/protobuf:lib");
+        assertTrue(label.isRepoLabel());
+        assertFalse(label.isCanonical());
+        assertTrue(label.hasPath());
+        assertEquals("com_google_protobuf", label.getRepoName());
+    }
+
+    @Test
+    void canonicalLabelWithoutPath() {
+        BazelLabel label = BazelLabel.parse("@@abseil-cpp~");
+        assertTrue(label.isRepoLabel());
+        assertTrue(label.isCanonical());
+        assertFalse(label.hasPath());
+        assertEquals("abseil-cpp~", label.getRepoName());
+    }
+
+    @Test
+    void moduleExtensionSubRepoDetected() {
+        BazelLabel label = BazelLabel.parse("@@rules_jvm_external++maven+guava//:guava");
+        assertTrue(label.isCanonical());
+        assertTrue(label.isModuleExtensionSubRepo());
+        assertEquals("rules_jvm_external++maven+guava", label.getRepoName());
+    }
+
+    @Test
+    void plusSuffixPreserved() {
+        BazelLabel label = BazelLabel.parse("@@protobuf+//:protobuf");
+        assertEquals("protobuf+", label.getRepoName());
+    }
+
+    @Test
+    void localTargetIsNotRepoLabel() {
+        BazelLabel label = BazelLabel.parse("//src/main:app");
+        assertFalse(label.isRepoLabel());
+        assertEquals("", label.getRepoName());
+        assertTrue(label.hasPath());
+    }
+
+    @Test
+    void nullTolerated() {
+        BazelLabel label = BazelLabel.parse(null);
+        assertFalse(label.isRepoLabel());
+        assertEquals("", label.getRepoName());
+        assertEquals("", label.getRaw());
+    }
+
+    @Test
+    void emptyTolerated() {
+        BazelLabel label = BazelLabel.parse("");
+        assertFalse(label.isRepoLabel());
+        assertEquals("", label.getRepoName());
+    }
+
+    @Test
+    void apparentPrefixWithImmediatePathYieldsEmptyRepoName() {
+        // mirrors historical resolveLabel: "@//foo:bar" -> apparent repo name ""
+        BazelLabel label = BazelLabel.parse("@//foo:bar");
+        assertTrue(label.isRepoLabel());
+        assertFalse(label.isCanonical());
+        assertTrue(label.hasPath());
+        assertEquals("", label.getRepoName());
+    }
+}
+
+

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelVersionCheckerTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BazelVersionCheckerTest.java
@@ -18,7 +18,7 @@ public class BazelVersionCheckerTest {
     @Test
     public void detectVersion_successfulCommand_returnsVersion() {
         BazelCommandExecutor executor = mock(BazelCommandExecutor.class);
-        when(executor.executeWithoutThrowing(anyList()))
+        when(executor.executeToleratingExitCode(anyList()))
                 .thenReturn(new ExecutableOutput(0, "bazel 7.4.1", ""));
 
         BazelVersionChecker checker = new BazelVersionChecker(executor);
@@ -32,7 +32,7 @@ public class BazelVersionCheckerTest {
     @Test
     public void detectVersion_nonZeroExitCode_returnsEmpty() {
         BazelCommandExecutor executor = mock(BazelCommandExecutor.class);
-        when(executor.executeWithoutThrowing(anyList()))
+        when(executor.executeToleratingExitCode(anyList()))
                 .thenReturn(new ExecutableOutput(1, "", "command not found"));
 
         BazelVersionChecker checker = new BazelVersionChecker(executor);
@@ -42,7 +42,7 @@ public class BazelVersionCheckerTest {
     @Test
     public void detectVersion_unparsableOutput_returnsEmpty() {
         BazelCommandExecutor executor = mock(BazelCommandExecutor.class);
-        when(executor.executeWithoutThrowing(anyList()))
+        when(executor.executeToleratingExitCode(anyList()))
                 .thenReturn(new ExecutableOutput(0, "not a version string", ""));
 
         BazelVersionChecker checker = new BazelVersionChecker(executor);
@@ -52,7 +52,7 @@ public class BazelVersionCheckerTest {
     @Test
     public void detectVersion_commandThrows_returnsEmpty() {
         BazelCommandExecutor executor = mock(BazelCommandExecutor.class);
-        when(executor.executeWithoutThrowing(anyList()))
+        when(executor.executeToleratingExitCode(anyList()))
                 .thenThrow(new RuntimeException("bazel not found"));
 
         BazelVersionChecker checker = new BazelVersionChecker(executor);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BzlmodBcrExtractorTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/BzlmodBcrExtractorTest.java
@@ -263,6 +263,32 @@ public class BzlmodBcrExtractorTest {
                 + "    urls = [\"https://github.com/google/glog/archive/v0.6.0.tar.gz\"],\n"
                 + ")\n";
         }
+
+        /**
+         * One direct dep (zlib@1.3) whose show_repo block uses a single {@code url =} attribute
+         * (not a {@code urls = [...]} list). Used to verify the single-url extraction path in
+         * {@link com.blackduck.integration.detectable.detectables.bazel.pipeline.step.IntermediateStepParseShowRepoToUrlCandidates}.
+         */
+        static final class SingleUrlAttribute {
+            static final String MOD_GRAPH =
+                "{\n"
+                + "  \"key\": \"<root>\",\n"
+                + "  \"dependencies\": [\n"
+                + "    { \"key\": \"zlib@1.3\", \"dependencies\": [] }\n"
+                + "  ]\n"
+                + "}";
+
+            static final String REPO_MAPPING = "{ \"zlib\": \"zlib~\" }";
+
+            static final String TARGET_QUERY = "@@zlib~//zlib:zlib\n";
+
+            static final String SHOW_REPO_BATCH =
+                "## @@zlib~:\n"
+                + "http_archive(\n"
+                + "    name = \"zlib~\",\n"
+                + "    url = \"https://github.com/madler/zlib/archive/v1.3.tar.gz\",\n"
+                + ")\n";
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -446,6 +472,30 @@ public class BzlmodBcrExtractorTest {
         Dependency glog = rootDeps.iterator().next();
         assertEquals("google/glog", glog.getExternalId().getName());
         assertEquals("v0.6.0", glog.getExternalId().getVersion());
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests — single url= attribute (not urls=[...] list)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void extractGraph_singleUrlAttribute_depResolvedCorrectly() {
+        StubBazelCommandExecutor stub = new StubBazelCommandExecutor();
+        stub.addModResponse(Fixtures.SingleUrlAttribute.MOD_GRAPH);
+        stub.addModResponse(Fixtures.SingleUrlAttribute.REPO_MAPPING);
+        stub.addQueryResponse(Fixtures.SingleUrlAttribute.TARGET_QUERY);
+        stub.addModResponse(Fixtures.SingleUrlAttribute.SHOW_REPO_BATCH);
+
+        DependencyGraph graph = new BzlmodBcrExtractor(stub, VERSION_7_1, TEST_TARGET).extractGraph();
+
+        Set<Dependency> rootDeps = graph.getRootDependencies();
+        assertEquals(1, rootDeps.size(), "zlib should be the sole root dependency");
+
+        Dependency zlib = rootDeps.iterator().next();
+        assertEquals("madler/zlib", zlib.getExternalId().getName(),
+            "org/repo must be parsed from the single url= attribute");
+        assertEquals("v1.3", zlib.getExternalId().getVersion(),
+            "version must be parsed from the archive path segment");
     }
 
     // -------------------------------------------------------------------------

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/ModuleKeyTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/bazel/v2/unit/ModuleKeyTest.java
@@ -1,0 +1,59 @@
+package com.blackduck.integration.detectable.detectables.bazel.v2.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.blackduck.integration.detectable.detectables.bazel.v2.ModuleKey;
+
+class ModuleKeyTest {
+
+    @Test
+    void parsesNameAndVersion() {
+        ModuleKey key = ModuleKey.parse("protobuf@31.0");
+        assertEquals("protobuf", key.getName());
+        assertEquals("31.0", key.getVersion());
+        assertEquals("protobuf@31.0", key.getRawKey());
+    }
+
+    @Test
+    void versionMayContainDots() {
+        assertEquals("8.6.4", ModuleKey.parse("rules_java@8.6.4").getVersion());
+    }
+
+    @Test
+    void noSeparatorReturnsWholeAsNameAndNullVersion() {
+        ModuleKey key = ModuleKey.parse("bazel_tools");
+        assertEquals("bazel_tools", key.getName());
+        assertNull(key.getVersion());
+    }
+
+    @Test
+    void leadingAtIsNotTreatedAsSeparator() {
+        // mirrors extractName: '@' at index 0 is not a separator, whole string is the name
+        ModuleKey key = ModuleKey.parse("@foo");
+        assertEquals("@foo", key.getName());
+        assertNull(key.getVersion());
+    }
+
+    @Test
+    void trailingAtYieldsNullVersion() {
+        ModuleKey key = ModuleKey.parse("foo@");
+        assertEquals("foo", key.getName());
+        assertNull(key.getVersion());
+    }
+
+    @Test
+    void firstAtIsTheSeparator() {
+        ModuleKey key = ModuleKey.parse("foo@1@2");
+        assertEquals("foo", key.getName());
+        assertEquals("1@2", key.getVersion());
+    }
+
+    @Test
+    void equalityByNameAndVersion() {
+        assertEquals(ModuleKey.parse("foo@1.0"), ModuleKey.parse("foo@1.0"));
+    }
+}
+

--- a/src/test/java/com/blackduck/integration/detect/battery/detector/BazelBattery.java
+++ b/src/test/java/com/blackduck/integration/detect/battery/detector/BazelBattery.java
@@ -42,8 +42,9 @@ class BazelBattery {
     private static final String BAZEL_V2_BZLMOD_PROBE_HASKELL_RESOURCE = "probe-haskell-cabal.xout";
     private static final String BAZEL_V2_BZLMOD_PROBE_HTTP_RESOURCE = "probe-http-libraries.xout";
     private static final String BAZEL_V2_BZLMOD_PROBE_CLASSIFY_GFLAGS_RESOURCE = "probe-classify-gflags.xout";
-    private static final String BAZEL_V2_BZLMOD_HTTP_INITIAL_QUERY_RESOURCE = "http-initial-query.xout";
-    private static final String BAZEL_V2_BZLMOD_HTTP_SHOW_REPO_GFLAGS_RESOURCE = "http-show-repo-gflags.xout";
+    // NOTE: the HTTP pipeline's initial library query and its gflags show_repo are identical to the
+    // HTTP probe query and the classify-gflags show_repo respectively, so both are served from
+    // BazelCommandExecutor's per-extraction cache (no separate fixtures needed).
     private static final String BAZEL_V2_BZLMOD_HTTP_SHOW_REPO_GLOG_RESOURCE = "http-show-repo-glog.xout";
 
     @Test
@@ -197,12 +198,15 @@ class BazelBattery {
             BAZEL_V2_BZLMOD_PROBE_MAVEN_INSTALL_RESOURCE,  // Probe for maven_install -> empty
             BAZEL_V2_BZLMOD_PROBE_MAVEN_JAR_RESOURCE,      // Probe for maven_jar -> empty
             BAZEL_V2_BZLMOD_PROBE_HASKELL_RESOURCE,        // Probe for haskell_cabal_library -> empty
-            BAZEL_V2_BZLMOD_PROBE_HTTP_RESOURCE,           // Probe for HTTP archives -> finds gflags & glog
-            BAZEL_V2_BZLMOD_PROBE_CLASSIFY_GFLAGS_RESOURCE, // mod show_repo to classify gflags as HTTP family
-            // HTTP Pipeline Execution Phase (3 queries to extract dependencies)
-            BAZEL_V2_BZLMOD_HTTP_INITIAL_QUERY_RESOURCE,   // Initial library query
-            BAZEL_V2_BZLMOD_HTTP_SHOW_REPO_GFLAGS_RESOURCE, // bazel mod show_repo com_github_gflags_gflags
-            BAZEL_V2_BZLMOD_HTTP_SHOW_REPO_GLOG_RESOURCE    // bazel mod show_repo glog
+            BAZEL_V2_BZLMOD_PROBE_HTTP_RESOURCE,           // Probe for HTTP archives -> finds gflags & glog (query kind(.*library, deps(target)))
+            BAZEL_V2_BZLMOD_PROBE_CLASSIFY_GFLAGS_RESOURCE, // mod show_repo @com_github_gflags_gflags -> classifies gflags as HTTP family
+            // HTTP Pipeline Execution Phase. Two commands are now served from BazelCommandExecutor's
+            // per-extraction cache and make NO Bazel call (so no fixture is consumed for them):
+            //   (a) the pipeline's initial library query — identical to the HTTP probe query above.
+            //   (b) the gflags show_repo — identical to the classify-gflags command above.
+            // Only glog's show_repo is a genuinely new command (glog was never probed — probing stops
+            // at the first HTTP repo, gflags).
+            BAZEL_V2_BZLMOD_HTTP_SHOW_REPO_GLOG_RESOURCE    // bazel mod show_repo @glog
         );
         test.sourceDirectoryNamed("bazel-v2-graph-probing-http-bzlmod");
         test.sourceFileNamed("MODULE.bazel");  // BZLMOD uses MODULE.bazel instead of WORKSPACE


### PR DESCRIPTION
### **Description**

This PR consolidates several Bazel tool quality improvements and removes duplicated logic. **No scanner behaviour changes are intended**, except for the two deliberate fixes noted below.

### **Key Changes**

**Centralised infrastructure exclusions**
Bazel toolchain and build-rule repositories that should never appear in the BOM (for example, bazel_tools, rules_java, rules_jvm_external) now come from a single shared definition. This removes drift across exclusion paths and fixes inconsistent handling of rules_shell.

**Shared show_repo execution layer**
Common logic for batched bazel mod show_repo execution, output splitting, and retry handling has been consolidated into a shared component used by both the BCR extractor and HTTP pipeline.

**Typed parsing for labels and module keys**
Bazel labels and module graph keys are now represented by dedicated value types rather than repeated string parsing logic, improving readability and maintainability.

**Command result deduplication**
Read-only Bazel command results are now cached for the lifetime of a single extraction, eliminating duplicate invocations when multiple components request the same query.

### Behavioural Fixes

**rules_shell exclusion fix**
rules_shell is now consistently excluded across all BOM generation paths. On Bazel 9, it is injected as a toolchain dependency and should never appear as a shipped component.

**go_repository URL synthesis fix**
Fixed an issue where synthesised GitHub URLs for go_repository entries could be dropped when processing multi-repo show_repo responses containing earlier repositories with explicit URLs.