### PR TITLE
npm transitive alias support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 group = 'com.blackduck.integration'
 
-version = '12.1.0-SIGQA5-SNAPSHOT'
+version = '12.1.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.solution'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies {
 
     implementation 'com.blackducksoftware.bdio:bdio-protobuf:3.2.12'
     implementation "com.blackduck.integration:blackduck-common:${blackDuckCommonVersion}"
-    implementation 'com.blackduck.integration:blackduck-upload-common:4.1.6'
+    implementation 'com.blackduck.integration:blackduck-upload-common:4.1.8-SNAPSHOT'
     implementation 'com.blackducksoftware:method-analyzer-core:1.0.7'
     implementation "${locatorGroup}:${locatorModule}:2.4.5"
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/NpmCliExtractor.java
@@ -5,7 +5,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
@@ -15,6 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.blackduck.integration.detectable.ExecutableTarget;
 import com.blackduck.integration.detectable.ExecutableUtils;
 import com.blackduck.integration.detectable.detectable.executable.DetectableExecutableRunner;
@@ -22,7 +26,6 @@ import com.blackduck.integration.detectable.detectables.npm.cli.parse.NpmCliPars
 import com.blackduck.integration.detectable.detectables.npm.lockfile.result.NpmPackagerResult;
 import com.blackduck.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
 import com.blackduck.integration.detectable.detectables.npm.packagejson.CombinedPackageJsonExtractor;
-import com.blackduck.integration.detectable.detectables.npm.packagejson.model.PackageJson;
 import com.blackduck.integration.detectable.extraction.Extraction;
 import com.blackduck.integration.detectable.util.ToolVersionLogger;
 import com.blackduck.integration.executable.ExecutableOutput;
@@ -86,13 +89,65 @@ public class NpmCliExtractor {
         } else if (StringUtils.isNotBlank(standardOutput)) {
             logger.debug("Parsing npm ls file.");
             logger.debug(standardOutput);
-            NpmPackagerResult result = npmCliParser.generateCodeLocation(standardOutput, combinedPackageJson, workspaceFilter);
+            Map<String, String> nodeModulesAliases = buildNodeModulesAliasMap(directory);
+            NpmPackagerResult result = npmCliParser.generateCodeLocation(standardOutput, combinedPackageJson, workspaceFilter, nodeModulesAliases);
             String projectName = result.getProjectName() != null ? result.getProjectName() : combinedPackageJson.getName();
             String projectVersion = result.getProjectVersion() != null ? result.getProjectVersion() : combinedPackageJson.getVersion();
             return new Extraction.Builder().success(result.getCodeLocation()).projectName(projectName).projectVersion(projectVersion).build();
         } else {
             logger.error("Nothing returned from npm ls -json command");
             return new Extraction.Builder().failure("Npm returned error after running npm ls.").build();
+        }
+    }
+
+    private Map<String, String> buildNodeModulesAliasMap(File projectDirectory) {
+        Map<String, String> aliases = new HashMap<>();
+        File nodeModules = new File(projectDirectory, "node_modules");
+        if (!nodeModules.isDirectory()) {
+            return aliases;
+        }
+        File[] entries = nodeModules.listFiles();
+        if (entries == null) {
+            return aliases;
+        }
+        for (File entry : entries) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            if (entry.getName().startsWith("@")) {
+                // Scope directory (e.g. node_modules/@babel) — each subdirectory is a scoped package.
+                // An alias whose key is scoped (e.g. "@acme/utils": "npm:lodash@4") is installed here.
+                File[] scopedEntries = entry.listFiles();
+                if (scopedEntries != null) {
+                    for (File scopedEntry : scopedEntries) {
+                        if (scopedEntry.isDirectory()) {
+                            readAliasEntry(scopedEntry, entry.getName() + "/" + scopedEntry.getName(), aliases);
+                        }
+                    }
+                }
+            } else {
+                readAliasEntry(entry, entry.getName(), aliases);
+            }
+        }
+        return aliases;
+    }
+
+    private void readAliasEntry(File directory, String dirName, Map<String, String> aliases) {
+        File pkgJson = new File(directory, "package.json");
+        if (!pkgJson.isFile()) {
+            return;
+        }
+        try {
+            String content = FileUtils.readFileToString(pkgJson, StandardCharsets.UTF_8);
+            JsonObject obj = JsonParser.parseString(content).getAsJsonObject();
+            if (obj.has("name")) {
+                String actualName = obj.get("name").getAsString();
+                if (!dirName.equals(actualName)) {
+                    aliases.put(dirName, actualName);
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Could not read package.json for node_modules/{}: {}", dirName, e.getMessage());
         }
     }
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -1,6 +1,6 @@
 package com.blackduck.integration.detectable.detectables.npm.cli.parse;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -46,26 +46,41 @@ public class NpmCliParser {
     }
 
     public NpmPackagerResult generateCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson) {
-        return generateCodeLocation(npmLsOutput, combinedPackageJson, null);
+        return generateCodeLocation(npmLsOutput, combinedPackageJson, (ExcludedIncludedWildcardFilter) null);
     }
 
     public NpmPackagerResult generateCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson,
             ExcludedIncludedWildcardFilter workspaceFilter) {
+        return generateCodeLocation(npmLsOutput, combinedPackageJson, workspaceFilter, Collections.emptyMap());
+    }
+
+    public NpmPackagerResult generateCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson,
+            Map<String, String> supplementalAliases) {
+        return generateCodeLocation(npmLsOutput, combinedPackageJson, null, supplementalAliases);
+    }
+
+    public NpmPackagerResult generateCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson,
+            ExcludedIncludedWildcardFilter workspaceFilter, Map<String, String> supplementalAliases) {
         if (StringUtils.isBlank(npmLsOutput)) {
             logger.error("Ran into an issue creating and writing to file");
             return null;
         }
 
         logger.debug("Generating results from npm ls -json");
-        return convertNpmJsonFileToCodeLocation(npmLsOutput, combinedPackageJson, workspaceFilter);
+        return convertNpmJsonFileToCodeLocation(npmLsOutput, combinedPackageJson, workspaceFilter, supplementalAliases);
     }
 
     public NpmPackagerResult convertNpmJsonFileToCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson) {
-        return convertNpmJsonFileToCodeLocation(npmLsOutput, combinedPackageJson, null);
+        return convertNpmJsonFileToCodeLocation(npmLsOutput, combinedPackageJson, null, Collections.emptyMap());
     }
 
     public NpmPackagerResult convertNpmJsonFileToCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson,
             ExcludedIncludedWildcardFilter workspaceFilter) {
+        return convertNpmJsonFileToCodeLocation(npmLsOutput, combinedPackageJson, workspaceFilter, Collections.emptyMap());
+    }
+
+    public NpmPackagerResult convertNpmJsonFileToCodeLocation(String npmLsOutput, CombinedPackageJson combinedPackageJson,
+            ExcludedIncludedWildcardFilter workspaceFilter, Map<String, String> supplementalAliases) {
         JsonObject npmJson = JsonParser.parseString(npmLsOutput).getAsJsonObject();
         DependencyGraph graph = new BasicDependencyGraph();
 
@@ -74,8 +89,8 @@ public class NpmCliParser {
         String projectName = projectNameElement != null ? projectNameElement.getAsString() : null;
         String projectVersion = projectVersionElement != null ? projectVersionElement.getAsString() : null;
 
-        // Build alias mapping once from package.json
         Map<String, String> aliasMapping = buildAliasMapping(combinedPackageJson);
+        aliasMapping.putAll(supplementalAliases);
 
         populateChildren(graph, null, npmJson.getAsJsonObject(JSON_DEPENDENCIES), true,
             combinedPackageJson, aliasMapping, workspaceFilter);
@@ -87,14 +102,6 @@ public class NpmCliParser {
         return new NpmPackagerResult(projectName, projectVersion, codeLocation);
     }
 
-    /**
-     * Builds a mapping of alias names to actual package names from CombinedPackageJson.
-     * Scans all dependency maps (dependencies, devDependencies, peerDependencies, optionalDependencies)
-     * looking for entries with "npm:" prefix.
-     *
-     * @param combinedPackageJson The package.json data
-     * @return Map of alias name -> actual package name
-     */
     private Map<String, String> buildAliasMapping(CombinedPackageJson combinedPackageJson) {
         return NpmAliasParser.buildAliasMapping(
             combinedPackageJson.getDependencies(),

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParser.java
@@ -89,6 +89,8 @@ public class NpmCliParser {
         String projectName = projectNameElement != null ? projectNameElement.getAsString() : null;
         String projectVersion = projectVersionElement != null ? projectVersionElement.getAsString() : null;
 
+        // Build alias mapping from package.json, then merge the supplemental map built by NpmCliExtractor
+        // from scanning node_modules. The supplemental map covers transitive aliases not in package.json.
         Map<String, String> aliasMapping = buildAliasMapping(combinedPackageJson);
         aliasMapping.putAll(supplementalAliases);
 

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/NpmDependencyConverter.java
@@ -19,7 +19,6 @@ import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmDe
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmProject;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmRequires;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLock;
-import com.blackduck.integration.detectable.detectables.npm.NpmAliasParser;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLockDependency;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLockPackage;
 import com.blackduck.integration.detectable.detectables.npm.packagejson.CombinedPackageJson;
@@ -80,11 +79,13 @@ public class NpmDependencyConverter {
             String packageKey = packageEntry.getKey();
             PackageLockPackage packageLockDependency = packageEntry.getValue();
 
-            // For npm aliases, the 'name' field contains the actual package name, while the key contains the alias.
-            // For regular packages, the 'name' field is null, so we use the key.
-            String packageName = packageLockDependency.name != null ? packageLockDependency.name : packageKey;
+            // For alias packages the key is the alias (e.g. "react-is-18") and the "name" field is the
+            // actual npm package (e.g. "react-is").  We use the key as the lookup name so that other
+            // packages' "requires" entries (which reference the alias) can find this dependency, but we
+            // build the ExternalId from the actual name so the BOM identifies the real component.
+            String actualName = packageLockDependency.name != null ? packageLockDependency.name : packageKey;
 
-            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
+            NpmDependency dependency = createNpmDependency(packageKey, actualName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);
 
@@ -108,7 +109,7 @@ public class NpmDependencyConverter {
             String packageName = packageEntry.getKey();
             PackageLockDependency packageLockDependency = packageEntry.getValue();
 
-            NpmDependency dependency = createNpmDependency(packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
+            NpmDependency dependency = createNpmDependency(packageName, packageName, packageLockDependency.version, packageLockDependency.dev, packageLockDependency.peer, packageLockDependency.optional);
             dependency.setParent(parent);
             children.add(dependency);
 
@@ -121,12 +122,12 @@ public class NpmDependencyConverter {
         return children;
     }
 
-    private NpmDependency createNpmDependency(String name, String version, Boolean isDev, Boolean isPeer, Boolean isOptional) {
+    private NpmDependency createNpmDependency(String lookupName, String actualName, String version, Boolean isDev, Boolean isPeer, Boolean isOptional) {
         boolean dev = isDev != null && isDev;
         boolean peer = isPeer != null && isPeer;
         boolean optional = isOptional != null && isOptional;
-        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, name, version);
-        return new NpmDependency(name, version, externalId, dev, peer, optional);
+        ExternalId externalId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, actualName, version);
+        return new NpmDependency(lookupName, version, externalId, dev, peer, optional);
     }
 
     public List<NpmRequires> convertNameVersionMapToRequires(MultiValuedMap<String, String> requires) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -1,7 +1,6 @@
 package com.blackduck.integration.detectable.detectables.npm.lockfile.parse;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,7 +30,7 @@ public class NpmLockfileGraphTransformer {
             : EnumListFilter.excludeNone();
     }
 
-    public DependencyGraph transform(PackageLock packageLock, NpmProject project, List<NameVersion> externalDependencies, List<String> workspaces, Map<String, String> aliasMapping) {
+    public DependencyGraph transform(PackageLock packageLock, NpmProject project, List<NameVersion> externalDependencies, List<String> workspaces) {
         DependencyGraph dependencyGraph = new BasicDependencyGraph();
 
         logger.debug("Processing project.");
@@ -39,11 +38,8 @@ public class NpmLockfileGraphTransformer {
             logger.debug(String.format("Found %d packages in the lockfile.",
                     packageLock.packages != null ? packageLock.packages.size() : packageLock.dependencies.size()));
 
-            //First we will recreate the graph from the resolved npm dependencies
-            createGraphFromResolvedDependencies(project, externalDependencies, workspaces, dependencyGraph, aliasMapping);
-
-            //Then we will add relationships between the project (root) and the graph
-            addRootDependencies(project, dependencyGraph, externalDependencies, workspaces, aliasMapping);
+            createGraphFromResolvedDependencies(project, externalDependencies, workspaces, dependencyGraph);
+            addRootDependencies(project, dependencyGraph, externalDependencies, workspaces);
 
             logger.debug(String.format("Found %d root dependencies.", dependencyGraph.getRootDependencies().size()));
         } else {
@@ -53,13 +49,13 @@ public class NpmLockfileGraphTransformer {
         return dependencyGraph;
     }
 
-    private void createGraphFromResolvedDependencies(NpmProject project, List<NameVersion> externalDependencies, List<String> workspaces, DependencyGraph dependencyGraph, Map<String, String> aliasMapping) {
+    private void createGraphFromResolvedDependencies(NpmProject project, List<NameVersion> externalDependencies, List<String> workspaces, DependencyGraph dependencyGraph) {
         for (NpmDependency resolved : project.getResolvedDependencies()) {
-            transformTreeToGraph(resolved, project, dependencyGraph, externalDependencies, workspaces, aliasMapping);
+            transformTreeToGraph(resolved, project, dependencyGraph, externalDependencies, workspaces);
         }
     }
 
-    private void addRootDependencies(NpmProject project, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, List<String> workspaces, Map<String, String> aliasMapping) {
+    private void addRootDependencies(NpmProject project, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, List<String> workspaces) {
         boolean atLeastOneRequired = !project.getDeclaredDependencies().isEmpty()
             || !project.getDeclaredDevDependencies().isEmpty()
             || !project.getDeclaredPeerDependencies().isEmpty();
@@ -83,15 +79,15 @@ public class NpmLockfileGraphTransformer {
         // zero root dependencies when the root declares nothing and all workspaces are filtered.
         // The "add all" fallback is preserved only for the true no-package.json case.
         if (atLeastOneRequired || workspaces != null) {
-            addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDependencies(), dependencyGraph, externalDependencies, aliasMapping);
+            addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDependencies(), dependencyGraph, externalDependencies);
             if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.DEV)) {
-                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDevDependencies(), dependencyGraph, externalDependencies, aliasMapping);
+                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredDevDependencies(), dependencyGraph, externalDependencies);
             }
             if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.PEER)) {
-                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredPeerDependencies(), dependencyGraph, externalDependencies, aliasMapping);
+                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredPeerDependencies(), dependencyGraph, externalDependencies);
             }
             if (npmDependencyTypeFilter.shouldInclude(NpmDependencyType.OPTIONAL)) {
-                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredOptionalDependencies(), dependencyGraph, externalDependencies, aliasMapping);
+                addRootDependencies(project.getResolvedDependencies(), project.getDeclaredOptionalDependencies(), dependencyGraph, externalDependencies);
             }
         } else {
             // No package.json provided — fall back to treating all resolved lock-file entries as root deps.
@@ -106,13 +102,10 @@ public class NpmLockfileGraphTransformer {
         List<NpmDependency> resolvedDependencies,
         List<NpmRequires> requires,
         DependencyGraph dependencyGraph,
-        List<NameVersion> externalDependencies,
-        Map<String, String> aliasMapping
+        List<NameVersion> externalDependencies
     ) {
         for (NpmRequires dependency : requires) {
-            // Resolve alias name to actual package name if it's an alias
-            String packageName = aliasMapping.getOrDefault(dependency.getName(), dependency.getName());
-            Dependency resolved = lookupProjectOrExternal(packageName, resolvedDependencies, externalDependencies);
+            Dependency resolved = lookupProjectOrExternal(dependency.getName(), resolvedDependencies, externalDependencies);
             if (resolved != null) {
                 dependencyGraph.addChildToRoot(resolved);
             } else {
@@ -121,24 +114,19 @@ public class NpmLockfileGraphTransformer {
         }
     }
 
-    private void transformTreeToGraph(NpmDependency npmDependency, NpmProject npmProject, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, List<String> workspaces, Map<String, String> aliasMapping) {
+    private void transformTreeToGraph(NpmDependency npmDependency, NpmProject npmProject, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, List<String> workspaces) {
         if (!shouldIncludeDependency(npmDependency)) {
             return;
         }
 
-        // add workspaces as direct dependencies
         if (workspaces != null && !StringUtils.isBlank(npmDependency.getName()) &&
                 workspaces.stream().anyMatch(x -> x.equals(npmDependency.getName()))) {
             dependencyGraph.addDirectDependency(npmDependency);
-
-            // add workspace requires
-            addWorkspaceRequires(npmDependency, npmProject, dependencyGraph, externalDependencies, aliasMapping);
+            addWorkspaceRequires(npmDependency, npmProject, dependencyGraph, externalDependencies);
         } else {
             npmDependency.getRequires().forEach(required -> {
                 logger.trace(String.format("Required package: %s of version: %s", required.getName(), required.getFuzzyVersion()));
-                // Resolve alias name to actual package name if it's an alias
-                String packageName = aliasMapping.getOrDefault(required.getName(), required.getName());
-                NpmDependency resolved = lookupDependency(packageName, npmDependency, npmProject, externalDependencies);
+                NpmDependency resolved = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
                 if (resolved == null) {
                     logger.debug("No resolved dependency found for required package: {}", required.getName());
                 } else {
@@ -150,19 +138,16 @@ public class NpmLockfileGraphTransformer {
             });
         }
 
-        npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, externalDependencies, workspaces, aliasMapping));
+        npmDependency.getDependencies().forEach(child -> transformTreeToGraph(child, npmProject, dependencyGraph, externalDependencies, workspaces));
     }
 
     /**
-     * This method adds any requires under npmDependency to the root of the project. This should only be called for npmDependency objects that are found
-     * at the workspace level. This makes all requires under that dependency direct dependencies in BlackDuck, which is what we want as they are specified
-     * directly in the workspace's package.json.
+     * Adds all requires under a workspace dependency directly to the root. Workspace dependencies'
+     * own deps are treated as direct project dependencies in Black Duck.
      */
-    private void addWorkspaceRequires(NpmDependency npmDependency, NpmProject npmProject, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies, Map<String, String> aliasMapping) {
+    private void addWorkspaceRequires(NpmDependency npmDependency, NpmProject npmProject, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies) {
         for (NpmRequires required : npmDependency.getRequires()) {
-            // Resolve alias name to actual package name if it's an alias
-            String packageName = aliasMapping.getOrDefault(required.getName(), required.getName());
-            NpmDependency workspaceDependency = lookupDependency(packageName, npmDependency, npmProject, externalDependencies);
+            NpmDependency workspaceDependency = lookupDependency(required.getName(), npmDependency, npmProject, externalDependencies);
 
             if (workspaceDependency != null) {
                 if ((workspaceDependency.isDevDependency() && npmDependencyTypeFilter.shouldExclude(NpmDependencyType.DEV))

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfileGraphTransformer.java
@@ -38,7 +38,10 @@ public class NpmLockfileGraphTransformer {
             logger.debug(String.format("Found %d packages in the lockfile.",
                     packageLock.packages != null ? packageLock.packages.size() : packageLock.dependencies.size()));
 
+            // First we will recreate the graph from the resolved npm dependencies
             createGraphFromResolvedDependencies(project, externalDependencies, workspaces, dependencyGraph);
+
+            // Then we will add relationships between the project (root) and the graph
             addRootDependencies(project, dependencyGraph, externalDependencies, workspaces);
 
             logger.debug(String.format("Found %d root dependencies.", dependencyGraph.getRootDependencies().size()));
@@ -119,9 +122,11 @@ public class NpmLockfileGraphTransformer {
             return;
         }
 
+        // add workspaces as direct dependencies
         if (workspaces != null && !StringUtils.isBlank(npmDependency.getName()) &&
                 workspaces.stream().anyMatch(x -> x.equals(npmDependency.getName()))) {
             dependencyGraph.addDirectDependency(npmDependency);
+            // add workspace requires
             addWorkspaceRequires(npmDependency, npmProject, dependencyGraph, externalDependencies);
         } else {
             npmDependency.getRequires().forEach(required -> {
@@ -142,8 +147,9 @@ public class NpmLockfileGraphTransformer {
     }
 
     /**
-     * Adds all requires under a workspace dependency directly to the root. Workspace dependencies'
-     * own deps are treated as direct project dependencies in Black Duck.
+     * This method adds any requires under npmDependency to the root of the project. This should only be called for npmDependency objects that are found
+     * at the workspace level. This makes all requires under that dependency direct dependencies in BlackDuck, which is what we want as they are specified
+     * directly in the workspace's package.json.
      */
     private void addWorkspaceRequires(NpmDependency npmDependency, NpmProject npmProject, DependencyGraph dependencyGraph, List<NameVersion> externalDependencies) {
         for (NpmRequires required : npmDependency.getRequires()) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/npm/lockfile/parse/NpmLockfilePackager.java
@@ -3,9 +3,7 @@ package com.blackduck.integration.detectable.detectables.npm.lockfile.parse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -16,7 +14,6 @@ import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectable.codelocation.CodeLocation;
-import com.blackduck.integration.detectable.detectables.npm.NpmAliasParser;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmProject;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLock;
@@ -68,18 +65,8 @@ public class NpmLockfilePackager {
 
         NpmProject project = dependencyConverter.convertLockFile(packageLock, combinedPackageJson);
 
-        // Build alias mapping from package.json to resolve aliased package names
-        Map<String, String> aliasMapping = combinedPackageJson != null
-            ? NpmAliasParser.buildAliasMapping(
-                combinedPackageJson.getDependencies(),
-                combinedPackageJson.getDevDependencies(),
-                combinedPackageJson.getPeerDependencies(),
-                combinedPackageJson.getOptionalDependencies()
-            )
-            : new HashMap<>();
-
         DependencyGraph dependencyGraph = graphTransformer.transform(packageLock, project, externalDependencies,
-                getFilteredWorkspaces(combinedPackageJson), aliasMapping);
+                getFilteredWorkspaces(combinedPackageJson));
         ExternalId projectId = projectIdTransformer.transform(combinedPackageJson, packageLock);
         CodeLocation codeLocation = new CodeLocation(dependencyGraph, projectId);
         return new NpmPackagerResult(projectId.getName(), projectId.getVersion(), codeLocation);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/cli/parse/NpmCliParserTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -187,6 +189,45 @@ class NpmCliParserTest {
     }
 
     @Test
+    void transitiveAliasIsResolvedToActualPackageNameViaSupplementalAliasMap() {
+        // Root package.json has no alias entries — react-is-18 is a transitive alias declared by
+        // pretty-format, not the root project. The supplemental map comes from scanning node_modules.
+        CombinedPackageJson combinedPackageJson = new CombinedPackageJson();
+        combinedPackageJson.getDependencies().put("pretty-format", "^30.0.0");
+
+        String npmLsOutput = "{"
+            + "\"name\":\"test-project\","
+            + "\"version\":\"1.0.0\","
+            + "\"dependencies\":{"
+            +   "\"pretty-format\":{"
+            +     "\"version\":\"30.0.0\","
+            +     "\"dependencies\":{"
+            +       "\"react-is-18\":{\"version\":\"18.3.1\"},"
+            +       "\"react-is-19\":{\"version\":\"19.2.7\"}"
+            +     "}"
+            +   "}"
+            + "}}";
+
+        // Built by scanning node_modules/react-is-18/package.json etc. in NpmCliExtractor
+        Map<String, String> nodeModulesAliasMap = new HashMap<>();
+        nodeModulesAliasMap.put("react-is-18", "react-is");
+        nodeModulesAliasMap.put("react-is-19", "react-is");
+
+        EnumListFilter<NpmDependencyType> filter = EnumListFilter.excludeNone();
+        NpmCliParser parser = new NpmCliParser(externalIdFactory, filter);
+
+        NpmPackagerResult result = parser.generateCodeLocation(npmLsOutput, combinedPackageJson, nodeModulesAliasMap);
+
+        DependencyGraph graph = result.getCodeLocation().getDependencyGraph();
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
+
+        graphAssert.hasDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is", "18.3.1"));
+        graphAssert.hasDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is", "19.2.7"));
+        graphAssert.hasNoDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is-18", "18.3.1"));
+        graphAssert.hasNoDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is-19", "19.2.7"));
+    }
+
+    @Test
     public void excludedWorkspaceIsNotTreatedAsWorkspace() {
         // npm ls -json output: root project has "my-ui" workspace and "express" regular dep.
         // my-ui has lodash as its own dep.
@@ -230,5 +271,40 @@ class NpmCliParserTest {
             externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "lodash", "4.17.21"));
         graphAssert.hasNoDependency(
             externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "my-ui", "1.0.0"));
+    }
+
+    @Test
+    void scopedAliasKeyIsResolvedToActualScopedPackageNameViaSupplementalAliasMap() {
+        // Alias key is a scoped name: "@acme/types": "npm:@babel/types@^7.26.0"
+        // node_modules/@acme/types/package.json has "name": "@babel/types"
+        // buildNodeModulesAliasMap must descend into the @acme scope directory to find this entry.
+        CombinedPackageJson combinedPackageJson = new CombinedPackageJson();
+        combinedPackageJson.getDependencies().put("some-lib", "^1.0.0");
+
+        String npmLsOutput = "{"
+            + "\"name\":\"test-project\","
+            + "\"version\":\"1.0.0\","
+            + "\"dependencies\":{"
+            +   "\"some-lib\":{"
+            +     "\"version\":\"1.0.0\","
+            +     "\"dependencies\":{"
+            +       "\"@acme/types\":{\"version\":\"7.26.0\"}"
+            +     "}"
+            +   "}"
+            + "}}";
+
+        Map<String, String> nodeModulesAliasMap = new HashMap<>();
+        nodeModulesAliasMap.put("@acme/types", "@babel/types");
+
+        EnumListFilter<NpmDependencyType> filter = EnumListFilter.excludeNone();
+        NpmCliParser parser = new NpmCliParser(externalIdFactory, filter);
+
+        NpmPackagerResult result = parser.generateCodeLocation(npmLsOutput, combinedPackageJson, nodeModulesAliasMap);
+
+        DependencyGraph graph = result.getCodeLocation().getDependencyGraph();
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
+
+        graphAssert.hasDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "@babel/types", "7.26.0"));
+        graphAssert.hasNoDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "@acme/types", "7.26.0"));
     }
 }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmDependencyConverterTest.java
@@ -1,11 +1,18 @@
 package com.blackduck.integration.detectable.detectables.npm.lockfile.unit;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.NpmDependencyConverter;
+import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmDependency;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLock;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.PackageLockPackage;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.parse.NpmLockfilePackager;
@@ -75,6 +82,27 @@ public class NpmDependencyConverterTest {
         Assertions.assertTrue(testPackage.dependencies.containsKey("optional1"));
     }
     
+    @Test
+    void aliasPackagePreservesKeyAsLookupNameAndReportsActualNameInExternalId() {
+        // node_modules/react-is-18 -> { "name": "react-is", "version": "18.3.1" }
+        // After removePathInfoFromPackageName the key becomes "react-is-18"
+        PackageLockPackage aliasPackage = new PackageLockPackage();
+        aliasPackage.name = "react-is";
+        aliasPackage.version = "18.3.1";
+        Map<String, PackageLockPackage> packages = new HashMap<>();
+        packages.put("react-is-18", aliasPackage);
+
+        List<NpmDependency> dependencies = converter.convertLockPackagesToNpmDependencies(null, packages);
+
+        Assertions.assertEquals(1, dependencies.size());
+        NpmDependency dep = dependencies.get(0);
+        // Lookup name must be the alias key so other packages' "requires" can find it
+        Assertions.assertEquals("react-is-18", dep.getName());
+        // ExternalId must use the actual npm package name so the BOM identifies the real component
+        ExternalId expected = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is", "18.3.1");
+        Assertions.assertEquals(expected, dep.getExternalId());
+    }
+
     private void validatePackageLinkage(String lockFileText) {
         lockFileText = packager.removePathInfoFromPackageName(lockFileText);   
         PackageLock packageLock = gson.fromJson(lockFileText, PackageLock.class);  

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmLockfileGraphTransformerTest.java
@@ -2,9 +2,7 @@ package com.blackduck.integration.detectable.detectables.npm.lockfile.unit;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.Gson;
 import com.blackduck.integration.bdio.graph.DependencyGraph;
 import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
 import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmDependency;
 import com.blackduck.integration.detectable.detectables.npm.lockfile.model.NpmProject;
@@ -103,7 +102,7 @@ public class NpmLockfileGraphTransformerTest {
         NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(null);
         List<String> workspaces = new ArrayList<>();
         workspaces.add("packages/a");
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), workspaces, Collections.emptyMap());
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), workspaces);
         
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "abbrev", "^2.0.0"));
@@ -159,7 +158,7 @@ public class NpmLockfileGraphTransformerTest {
         NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(filter);
         PackageLock packageLock = new PackageLock();
         packageLock.packages = Collections.emptyMap();
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList());
         
         // Verify that the regular child dependency is included but optional child dependency is excluded
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
@@ -172,42 +171,36 @@ public class NpmLockfileGraphTransformerTest {
     
     @Test
     void testNpmAliasesResolvedCorrectly() {
-        // Test that npm aliases are properly resolved using the 'name' field from package-lock.json
-        // When package.json has: "coloring": "npm:picocolors@^1.0.0"
-        // The package-lock.json has: "node_modules/coloring": { "name": "picocolors", ... }
+        // package.json has: "coloring": "npm:picocolors@^1.0.0"
+        // package-lock.json has: "node_modules/coloring": { "name": "picocolors", "version": "1.1.1" }
+        // After the fix, NpmDependencyConverter stores the dependency under the alias key "coloring"
+        // but with an ExternalId that identifies picocolors@1.1.1.
 
-        // Create resolved dependencies with the ACTUAL package name (picocolors)
-        NpmDependency picocolorsDependency = new NpmDependency("picocolors", "1.1.1", false, false, false);
+        ExternalId picocolorsId = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "picocolors", "1.1.1");
+        // name="coloring" (alias key, for lookup), externalId=picocolors@1.1.1 (actual component)
+        NpmDependency coloringDependency = new NpmDependency("coloring", "1.1.1", picocolorsId, false, false, false);
 
         List<NpmDependency> resolvedDependencies = new ArrayList<>();
-        resolvedDependencies.add(picocolorsDependency);
+        resolvedDependencies.add(coloringDependency);
 
-        // Create declared dependencies with the ALIAS name (coloring)
         List<NpmRequires> declaredDependencies = new ArrayList<>();
         declaredDependencies.add(new NpmRequires("coloring", "npm:picocolors@^1.0.0"));
 
-        // Create alias mapping (coloring -> picocolors)
-        Map<String, String> aliasMapping = new HashMap<>();
-        aliasMapping.put("coloring", "picocolors");
-
-        // Create npm project
         NpmProject npmProject = new NpmProject(
             "test-project",
             "1.0.0",
-            Collections.emptyList(), // devDependencies
-            Collections.emptyList(), // peerDependencies
-            declaredDependencies,    // dependencies
-            Collections.emptyList(), // optionalDependencies
+            Collections.emptyList(),
+            Collections.emptyList(),
+            declaredDependencies,
+            Collections.emptyList(),
             resolvedDependencies
         );
 
-        // Transform the graph with alias mapping
         NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(EnumListFilter.excludeNone());
         PackageLock packageLock = new PackageLock();
         packageLock.packages = Collections.emptyMap();
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList(), aliasMapping);
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList());
 
-        // Verify that picocolors (the actual package) is in the graph, not coloring (the alias)
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "picocolors", "1.1.1"));
     }
@@ -261,7 +254,7 @@ public class NpmLockfileGraphTransformerTest {
         NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(filter);
         PackageLock packageLock = new PackageLock();
         packageLock.packages = Collections.emptyMap();
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), Collections.emptyList());
         
         // Verify that both regular and optional child dependencies are included
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmTransitiveAliasLockfileTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmTransitiveAliasLockfileTest.java
@@ -1,0 +1,71 @@
+package com.blackduck.integration.detectable.detectables.npm.lockfile.unit;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.blackduck.integration.bdio.graph.DependencyGraph;
+import com.blackduck.integration.bdio.model.Forge;
+import com.blackduck.integration.bdio.model.externalid.ExternalId;
+import com.blackduck.integration.bdio.model.externalid.ExternalIdFactory;
+import com.blackduck.integration.detectable.detectable.util.EnumListFilter;
+import com.blackduck.integration.detectable.detectables.npm.NpmDependencyType;
+import com.blackduck.integration.detectable.detectables.npm.lockfile.parse.NpmLockFileProjectIdTransformer;
+import com.blackduck.integration.detectable.detectables.npm.lockfile.parse.NpmLockfileGraphTransformer;
+import com.blackduck.integration.detectable.detectables.npm.lockfile.parse.NpmLockfilePackager;
+import com.blackduck.integration.detectable.detectables.npm.lockfile.result.NpmPackagerResult;
+import com.blackduck.integration.detectable.util.graph.GraphAssert;
+
+class NpmTransitiveAliasLockfileTest {
+
+    private Gson gson;
+    private ExternalIdFactory externalIdFactory;
+    private NpmLockfilePackager packager;
+
+    @BeforeEach
+    void setup() {
+        gson = new Gson();
+        externalIdFactory = new ExternalIdFactory();
+        NpmLockFileProjectIdTransformer projectIdTransformer = new NpmLockFileProjectIdTransformer(gson, externalIdFactory);
+        NpmLockfileGraphTransformer graphTransformer = new NpmLockfileGraphTransformer(EnumListFilter.excludeNone());
+        packager = new NpmLockfilePackager(gson, externalIdFactory, projectIdTransformer, graphTransformer);
+    }
+
+    @Test
+    void transitiveAliasPackagesAppearInBOMWithActualPackageName() throws IOException {
+        // pretty-format declares aliases for two versions of react-is; neither alias appears in the
+        // root package.json, so they are purely transitive.
+        String packageJsonText = "{\"name\":\"test-project\",\"version\":\"1.0.0\","
+            + "\"dependencies\":{\"pretty-format\":\"^30.0.0\"}}";
+
+        String lockFileText = "{"
+            + "\"name\":\"test-project\",\"version\":\"1.0.0\",\"lockfileVersion\":3,"
+            + "\"packages\":{"
+            + "\"\":{\"dependencies\":{\"pretty-format\":\"^30.0.0\"}},"
+            + "\"node_modules/pretty-format\":{\"version\":\"30.0.0\","
+            +   "\"dependencies\":{"
+            +     "\"react-is-18\":\"npm:react-is@^18.3.1\","
+            +     "\"react-is-19\":\"npm:react-is@^19.2.5\"}},"
+            + "\"node_modules/react-is-18\":{\"name\":\"react-is\",\"version\":\"18.3.1\"},"
+            + "\"node_modules/react-is-19\":{\"name\":\"react-is\",\"version\":\"19.2.7\"}"
+            + "}}";
+
+        NpmPackagerResult result = packager.parseAndTransform(null, packageJsonText, lockFileText);
+
+        DependencyGraph graph = result.getCodeLocation().getDependencyGraph();
+        GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
+
+        ExternalId reactIs18 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is", "18.3.1");
+        ExternalId reactIs19 = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is", "19.2.7");
+        ExternalId prettyFormat = externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "pretty-format", "30.0.0");
+        graphAssert.hasDependency(reactIs18);
+        graphAssert.hasDependency(reactIs19);
+        graphAssert.hasParentChildRelationship(prettyFormat, reactIs18);
+        graphAssert.hasParentChildRelationship(prettyFormat, reactIs19);
+
+        graphAssert.hasNoDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is-18", "18.3.1"));
+        graphAssert.hasNoDependency(externalIdFactory.createNameVersionExternalId(Forge.NPMJS, "react-is-19", "19.2.7"));
+    }
+}

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/npm/lockfile/unit/NpmWithoutRequiresExcludesTest.java
@@ -42,14 +42,14 @@ public class NpmWithoutRequiresExcludesTest {
         // Test with packages for v2/v3 lockfile
         packageLock.packages = new HashMap<>();
         
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null, Collections.emptyMap());
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
 
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(0);
         
         // Test with dependencies for v1 lockfile
         packageLock.dependencies = new HashMap<>();
-        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null, Collections.emptyMap());
+        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
 
         graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(0);
@@ -78,21 +78,21 @@ public class NpmWithoutRequiresExcludesTest {
         // Test with packages for v2/v3 lockfile
         packageLock.packages = new HashMap<>();
         
-        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null, Collections.emptyMap());
+        DependencyGraph graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
 
         GraphAssert graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(0);
         
         // Test with dependencies for v1 lockfile
         packageLock.dependencies = new HashMap<>();
-        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null, Collections.emptyMap());
+        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
 
         graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(0);
         
         // Clear filtering and check we get a dependency
         graphTransformer = new NpmLockfileGraphTransformer(EnumListFilter.fromExcluded());
-        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null, Collections.emptyMap());
+        graph = graphTransformer.transform(packageLock, npmProject, Collections.emptyList(), null);
         
         graphAssert = new GraphAssert(Forge.NPMJS, graph);
         graphAssert.hasRootSize(1);


### PR DESCRIPTION
There were two things going on here. 1) Aliases to the same package were not properly handled in the map and 2) aliases were only handled at the root project level. If components used aliases in their own package.json files, Detect would not appropriately discover that.

Problem 1 — Lockfile detector: aliases to the same package conflated into one BOM entry

When a project declares multiple aliases to the same underlying package (e.g. "react-is-18": "npm:react-is@18.3.1" and "react-is-19": "npm:react-is@19.2.7"), the lockfile detector reported only one of them in the BOM.

Root cause: NpmDependencyConverter was storing actual package name (react-is) rather than their alias key. Both entries then had NpmDependency.name = "react-is", so when the graph transformer looked
up each declared dependency by name the code returned the same object for both, conflating two distinct versions into a single BOM entry.

Fix: NpmDependencyConverter.convertLockPackagesToNpmDependencies now stores the lockfile map key (the alias, e.g.
react-is-18) as NpmDependency.name. Each alias resolves to a unique NpmDependency so both versions reach
the BOM. As a consequence, the alias-mapping in GraphTransformer became redundant and was removed. Lookups now work directly against the alias key.

Problem 2 — Both detectors: transitive aliases invisible in the BOM

When an intermediate dependency declares alias dependencies in its own subtree, neither
detector reported them.

Fix: Covered by the same change above. Because alias keys are now the native lookup name in every NpmDependency, transitive aliases are found the same way as normal dependencies.

CLI detector root cause: npm ls --json outputs only the alias key and version (e.g. "react-is-18": {"version": "18.3.1"}). The alias map was built exclusively from the root package.json, so transitive aliases were invisible to it.

Fix: NpmCliExtractor.extract() now scans node_modules and crates a map of alias to real packages. npm itself writes node_modules folder so we have to go there to get the information missing from the CLI command. This supplemental map is then merged with the package.json derived map before processing, covering both root and transitive aliases.