### PR TITLE
Add support for transitive dependencies for detect.uv.dependency.groups.only property

### DIFF
--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -114,13 +114,13 @@ public class UVLockParser {
     // isProjectEntry is true only for the root project's own [[package]] entry and for
     // workspace member entries (identified via [manifest].members, collected up-front by
     // collectWorkspaceMembers before this loop runs). It is false for every other (regular,
-    // third-party/transitive) package such as "httpx" or "requests" pulled in as a dependency.
+    // third-party/transitive) package pulled in as a dependency.
     private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups, boolean isProjectEntry) {
 
         // [dependencies] — for the root project / workspace members this is [project.dependencies]
         // (the main project's regular deps), which is skipped when onlyGroups is set, mirroring CLI
         // behaviour where --only-group does not include regular dependencies.
-        // For every OTHER package (e.g. "httpx" pulled in via a selected dev group), [dependencies]
+        // For every OTHER package (e.g. a package pulled in via a selected dev group), [dependencies]
         // is that package's OWN runtime requirements and must always be parsed — otherwise the
         // transitive closure of a selected group's dependencies would be silently dropped.
         if ((!isProjectEntry || onlyGroups.isEmpty()) && dependencyTable.contains(DEPENDENCIES_KEY)) {

--- a/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
+++ b/detectable/src/main/java/com/blackduck/integration/detectable/detectables/uv/transform/UVLockParser.java
@@ -97,12 +97,13 @@ public class UVLockParser {
                 // we parse project name and workspace members first and add them to a list, while recursively looping over dependencies, we loop over all workspaceMembers list
                 // which will in turn mean that their dependencies are direct since uv.lock always has one entry for the root project
                 // Here if rootName from pyproject.toml or workspace member is encountered then we store it
-                if(rootName.equals(dependencyName) || workSpaceMembers.contains(dependencyName)) {
+                boolean isProjectEntry = rootName.equals(dependencyName) || workSpaceMembers.contains(dependencyName);
+                if(isProjectEntry) {
                     workSpaceMembers.add(dependencyName);
                 }
 
                 //parse transitive dependencies section of current dependency
-                parseDependenciesSection(dependencyTable, dependencyName, onlyGroups, excludedGroups);
+                parseDependenciesSection(dependencyTable, dependencyName, onlyGroups, excludedGroups, isProjectEntry);
             }
         }
 
@@ -110,11 +111,19 @@ public class UVLockParser {
 
     }
 
-    private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups) {
+    // isProjectEntry is true only for the root project's own [[package]] entry and for
+    // workspace member entries (identified via [manifest].members, collected up-front by
+    // collectWorkspaceMembers before this loop runs). It is false for every other (regular,
+    // third-party/transitive) package such as "httpx" or "requests" pulled in as a dependency.
+    private void parseDependenciesSection(TomlTable dependencyTable, String dependencyName, Set<String> onlyGroups, Set<String> excludedGroups, boolean isProjectEntry) {
 
-        // [dependencies] (regular project deps) — skipped when onlyGroups is set,
-        // mirroring CLI behaviour where --only-group does not include regular dependencies.
-        if (onlyGroups.isEmpty() && dependencyTable.contains(DEPENDENCIES_KEY)) {
+        // [dependencies] — for the root project / workspace members this is [project.dependencies]
+        // (the main project's regular deps), which is skipped when onlyGroups is set, mirroring CLI
+        // behaviour where --only-group does not include regular dependencies.
+        // For every OTHER package (e.g. "httpx" pulled in via a selected dev group), [dependencies]
+        // is that package's OWN runtime requirements and must always be parsed — otherwise the
+        // transitive closure of a selected group's dependencies would be silently dropped.
+        if ((!isProjectEntry || onlyGroups.isEmpty()) && dependencyTable.contains(DEPENDENCIES_KEY)) {
             parseTransitiveDependencies(dependencyTable.getArray(DEPENDENCIES_KEY), dependencyName);
         }
 
@@ -124,9 +133,10 @@ public class UVLockParser {
             parseFilteredGroupDependencies(dependencyTable.getTable(DEV_DEPENDENCIES_KEY), dependencyName, onlyGroups, excludedGroups);
         }
 
-        // [optional-dependencies] — skipped when onlyGroups is set,
-        // mirroring CLI behaviour where --only-group does not include optional extras.
-        if (onlyGroups.isEmpty() && dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
+        // [optional-dependencies] — same rationale as [dependencies] above: skipped only for the
+        // root project / workspace members (their own [project.optional-dependencies] extras),
+        // always parsed for any other package so extras needed to resolve that dependency remain.
+        if ((!isProjectEntry || onlyGroups.isEmpty()) && dependencyTable.contains(OPTIONAL_DEPENDENCIES_KEY)) {
             parseFilteredGroupDependencies(dependencyTable.getTable(OPTIONAL_DEPENDENCIES_KEY), dependencyName, onlyGroups, excludedGroups);
         }
     }

--- a/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
+++ b/detectable/src/test/java/com/blackduck/integration/detectable/detectables/uv/unit/UVLockParserTest.java
@@ -671,6 +671,109 @@ class UVLockParserTest {
         assertTrue(codeLocations.isEmpty(), "All only-groups are also excluded: parser should return empty list (extractor handles empty BOM creation)");
     }
 
+    // Regression test for: with detect.uv.dependency.groups.only=dev set, a selected group's
+    // direct dependency (e.g. "httpx") had its own `dependencies = [...]` block skipped, so its
+    // transitive dependencies (anyio, certifi, httpcore, idna, sniffio) were dropped from the BOM.
+    // Mirrors the real-world uv.lock example reported for httpx 0.27.0, plus an extra level of
+    // nesting (httpcore -> certifi, h11) to confirm the fix isn't limited to a single level.
+    @Test
+    void onlyDependencyGroupsIncludesTransitiveDependenciesOfSelectedGroupMembers() {
+        String lockContent = String.join("\n",
+            "version = 1",
+            "",
+            "[[package]]",
+            "name = \"my-project\"",
+            "version = \"1.0.0\"",
+            "dependencies = [",
+            "    { name = \"requests\" },",
+            "]",
+            "",
+            "[package.dev-dependencies]",
+            "dev = [",
+            "    { name = \"httpx\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"requests\"",
+            "version = \"2.31.0\"",
+            "",
+            "[[package]]",
+            "name = \"httpx\"",
+            "version = \"0.27.0\"",
+            "dependencies = [",
+            "    { name = \"anyio\" },",
+            "    { name = \"certifi\" },",
+            "    { name = \"httpcore\" },",
+            "    { name = \"idna\" },",
+            "    { name = \"sniffio\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"anyio\"",
+            "version = \"4.3.0\"",
+            "dependencies = [",
+            "    { name = \"idna\" },",
+            "    { name = \"sniffio\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"certifi\"",
+            "version = \"2024.2.2\"",
+            "",
+            "[[package]]",
+            "name = \"httpcore\"",
+            "version = \"1.0.2\"",
+            "dependencies = [",
+            "    { name = \"certifi\" },",
+            "    { name = \"h11\" },",
+            "]",
+            "",
+            "[[package]]",
+            "name = \"idna\"",
+            "version = \"3.6\"",
+            "",
+            "[[package]]",
+            "name = \"sniffio\"",
+            "version = \"1.3.1\"",
+            "",
+            "[[package]]",
+            "name = \"h11\"",
+            "version = \"0.14.0\""
+        );
+
+        UVLockParser parser = new UVLockParser(externalIdFactory);
+        UVDetectorOptions options = new UVDetectorOptions(
+            Collections.emptyList(),
+            Arrays.asList("dev"),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        List<CodeLocation> codeLocations = parser.parseLockFile(lockContent, "my-project", options);
+
+        assertEquals(1, codeLocations.size(), "Expected one code location");
+        DependencyGraph graph = codeLocations.get(0).getDependencyGraph();
+
+        assertEquals(1, graph.getRootDependencies().size(), "Expected only 'httpx' as root dependency; 'requests' must remain excluded since onlyGroups=dev");
+        assertTrue(hasDependency(graph.getRootDependencies(), "httpx", "0.27.0"), "Expected 'httpx' from the selected 'dev' group to be a root dependency");
+        assertTrue(graph.getRootDependencies().stream().noneMatch(d -> d.getName().equals("requests")), "Expected regular [dependencies] ('requests') to remain excluded when onlyGroups is set");
+
+        Dependency httpxDep = findDependency(graph.getRootDependencies(), "httpx");
+        Set<Dependency> httpxChildren = graph.getChildrenForParent(httpxDep);
+        assertEquals(5, httpxChildren.size(), "Expected httpx's own dependencies = [...] block to be parsed even though onlyGroups is set");
+        assertTrue(hasDependency(httpxChildren, "anyio", "4.3.0"), "Expected 'anyio' as a transitive dependency of httpx");
+        assertTrue(hasDependency(httpxChildren, "certifi", "2024.2.2"), "Expected 'certifi' as a transitive dependency of httpx");
+        assertTrue(hasDependency(httpxChildren, "httpcore", "1.0.2"), "Expected 'httpcore' as a transitive dependency of httpx");
+        assertTrue(hasDependency(httpxChildren, "idna", "3.6"), "Expected 'idna' as a transitive dependency of httpx");
+        assertTrue(hasDependency(httpxChildren, "sniffio", "1.3.1"), "Expected 'sniffio' as a transitive dependency of httpx");
+
+        Dependency httpcoreDep = findDependency(httpxChildren, "httpcore");
+        Set<Dependency> httpcoreChildren = graph.getChildrenForParent(httpcoreDep);
+        assertEquals(2, httpcoreChildren.size(), "Expected httpcore's own dependencies (certifi, h11) to also be parsed, confirming the fix isn't limited to a single level of transitivity");
+        assertTrue(hasDependency(httpcoreChildren, "certifi", "2024.2.2"), "Expected 'certifi' as a transitive dependency of httpcore");
+        assertTrue(hasDependency(httpcoreChildren, "h11", "0.14.0"), "Expected 'h11' as a transitive dependency of httpcore");
+    }
+
     private boolean hasDependency(Set<Dependency> dependencies, String name, String version) {
         return dependencies.stream()
             .anyMatch(dep -> dep.getName().equals(name) && dep.getVersion().equals(version));


### PR DESCRIPTION
# Description

## What This Fixes

When a customer sets `detect.uv.dependency.groups.only` (for example, `dev`) for a UV project scanned via `uv.lock`, Detect correctly picked only the packages in that group as direct dependencies. However, it was silently dropping those packages' own dependencies.

These dependencies are still part of the actual installation and should therefore be included in the dependency graph and BOM.

## What Changed

The `only-groups` filter was being applied too broadly. It was incorrectly skipping the **regular dependencies** section for every package in the lockfile, rather than only for the project's own top-level dependencies.

This fix narrows the filter's scope so that it applies only to **project/workspace-level dependencies**, which is the intended behaviour. All other packages now have their dependency lists parsed normally, ensuring that complete transitive dependency chains are preserved.

## Test Coverage

Added a new unit test in `UVLockParserTest` that reproduces the real-world scenario reported by the customer: a dependency in a selected group with multiple levels of transitive dependencies.

The test verifies that:

- The project's regular dependencies remain excluded (existing behaviour, unchanged).
- The selected group's package is included.
- All transitive dependencies of that package are included.
- Nested dependencies (second-level and beyond) are correctly resolved and preserved.