### PR TITLE
 Document Java 25 support for Detect 12.1.0

### DIFF
--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* Support for Java 25 has been added.
+* Support for OpenJDK 25 has been added.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/currentreleasenotes.md
+++ b/documentation/src/main/markdown/currentreleasenotes.md
@@ -22,7 +22,7 @@
 
 ### New features
 
-* 
+* Support for Java 25 has been added.
 
 ### Changed features
 

--- a/documentation/src/main/markdown/gettingstarted/requirements.md
+++ b/documentation/src/main/markdown/gettingstarted/requirements.md
@@ -3,7 +3,7 @@
 ## General requirements
      
 * Minimum 8GB RAM.   
-* Java: OpenJDK 64-bit version 11, 13, 14, 15, 16, 17, or 21. 
+* Java: OpenJDK 64-bit version 11, 13, 14, 15, 16, 17, 21, or 25.
 * Minimum curl version 7.34.0, recommended 8.4.0 or later.   
 * Bash.   
 * If using [powershell_script_name]: PowerShell versions 4.0 or higher.   


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5251

**Description**

This pull request documents official support for Java 25 (LTS) in Detect 12.1.0. 

Detect 12.1.0 was tested with Oracle JDK 25.0.4 across all four basic scan types (signature, package manager, container, and binary). All scans passed without Detect level failures, following the same validation approach used for Java 21 in IDETECT-4367.